### PR TITLE
Correct interpretation of mathematical value

### DIFF
--- a/numberformat/diff.emu
+++ b/numberformat/diff.emu
@@ -1018,7 +1018,9 @@
           1. Else,
             1. Let _str_ be ! Number::toString(_x_).
         1. If the grammar cannot interpret _str_ as an expansion of |StringNumericLiteral|, return *NaN*.
-        1. Let _mv_ be the MV, a mathematical value, of ? ToNumber(_str_), as described in <emu-xref href="#sec-runtime-semantics-mv-s"></emu-xref>.
+        1. Let _text_ be ! StringToCodePoints(_str_).
+        1. Let _literal_ be ParseText(_text_, |StringNumericLiteral|).
+        1. Let _mv_ be the MV of _literal_.
         1. If _mv_ is 0 and the first non white space code point in _str_ is `-`, return *-0*.
         1. If _mv_ is 10<sup>10000</sup> and _str_ contains `Infinity`, return *+&infin;*.
         1. If _mv_ is -10<sup>10000</sup> and _str_ contains `Infinity`, return *-&infin;*.


### PR DESCRIPTION
Step 6 in ToIntlMathematicalValue reads:

>     1. Let _mv_ be the MV, a mathematical value, of ? ToNumber(_str_), as described in <emu-xref href="#sec-runtime-semantics-mv-s"></emu-xref>.

If I understand correctly, this is the critical operation to address [gh-334](https://github.com/tc39/ecma402/issues/334), but if so, I don't understand how it achieves this.

The reference to "mathematical value" confuses me because neither of ToNumber nor [sec-runtime-semantics-mv-s](https://tc39.es/ecma262/#sec-runtime-semantics-mv-s) (i.e. StringNumericValue) produce a mathematical value. It may be that this is intended to describe a conversion, but it seems like converting from a Number value to a mathematical value will not address the motivating use case because the undesirable rounding has already taken place.

This might be addressed by the phrase `as described in <emu-xref href="#sec-runtime-semantics-mv-s"></emu-xref>` since I admittedly don't understand that, either. It appears to be applied to the result of ToNumber, but as an syntax-directed operation, I don't know how that works. On the one hand, [the StringToNumber abstract operation](https://tc39.es/ecma262/#sec-stringtonumber) seems like a more conventional way to use the SDO, but the description of that operation asserts, "It returns a Number."

I'm not convinced that this patch is correct or even necessary, but I figured it might at least help folks understand my confusion.