### PR TITLE
Editorial: document potential error in selectRange

### DIFF
--- a/pluralrules/diff.emu
+++ b/pluralrules/diff.emu
@@ -299,7 +299,7 @@
         1. Perform ? RequireInternalSlot(_pr_, [[InitializedPluralRules]]).
         1. Let _x_ be ? ToNumber(_start_).
         1. Let _y_ be ? ToNumber(_end_).
-        1. Return ! ResolvePluralRange(_pr_, _x_, _y_).
+        1. Return ? ResolvePluralRange(_pr_, _x_, _y_).
       </emu-alg>
     </emu-clause>
     </ins>

--- a/pluralrules/proposed.emu
+++ b/pluralrules/proposed.emu
@@ -296,7 +296,7 @@
         1. Perform ? RequireInternalSlot(_pr_, [[InitializedPluralRules]]).
         1. Let _x_ be ? ToNumber(_start_).
         1. Let _y_ be ? ToNumber(_end_).
-        1. Return ! ResolvePluralRange(_pr_, _x_, _y_).
+        1. Return ? ResolvePluralRange(_pr_, _x_, _y_).
       </emu-alg>
     </emu-clause>
 


### PR DESCRIPTION
Prior to this commit, the algorithm for
`Intl.PluralRules.prototype.selectRange` asserted that its invocation of
the ResolvePluralRange abstract operation would not return an abrupt
completion. This was inaccurate because ResolvePluralRange returns a
throw completion when the two input numbers do not describe a valid
range and because because the relationship between the specification
variables `x` and `y` is not verified prior to invocation.

Communicate the potential for failure by replacing the `!` shorthand
with `?`.