### PR TITLE
Meta: Update output directory with recent changes

### DIFF
--- a/out/annexes/diff.html
+++ b/out/annexes/diff.html
@@ -1,6 +1,88 @@
 <!doctype html>
-<head><meta charset="utf-8"><script type="application/json" id="menu-search-biblio">[{"type":"clause","id":"annex-implementation-dependent-behaviour","aoid":null,"title":"Implementation Dependent Behaviour","titleHTML":"Implementation Dependent Behaviour","number":"A","namespace":"<no location>","location":"","referencingIds":[],"key":"Implementation Dependent Behaviour"},{"type":"clause","id":"annex-incompatibilities","aoid":null,"title":"Additions and Changes That Introduce Incompatibilities with Prior Editions","titleHTML":"Additions and Changes That Introduce Incompatibilities with Prior Editions","number":"B","namespace":"<no location>","location":"","referencingIds":[],"key":"Additions and Changes That Introduce Incompatibilities with Prior Editions"}]</script><script>"use strict";
+<head><meta charset="utf-8"><script>'use strict';
+let sdoBox = {
+  init() {
+    this.$alternativeId = null;
+    this.$outer = document.createElement('div');
+    this.$outer.classList.add('toolbox-container');
+    this.$container = document.createElement('div');
+    this.$container.classList.add('toolbox');
+    this.$displayLink = document.createElement('a');
+    this.$displayLink.setAttribute('href', '#');
+    this.$displayLink.textContent = 'Syntax-Directed Operations';
+    this.$displayLink.addEventListener('click', e => {
+      e.preventDefault();
+      e.stopPropagation();
+      referencePane.showSDOs(sdoMap[this.$alternativeId] || {}, this.$alternativeId);
+    });
+    this.$container.appendChild(this.$displayLink);
+    this.$outer.appendChild(this.$container);
+    document.body.appendChild(this.$outer);
+  },
 
+  activate(el) {
+    clearTimeout(this.deactiveTimeout);
+    Toolbox.deactivate();
+    this.$alternativeId = el.id;
+    let numSdos = Object.keys(sdoMap[this.$alternativeId] || {}).length;
+    this.$displayLink.textContent = 'Syntax-Directed Operations (' + numSdos + ')';
+    this.$outer.classList.add('active');
+    let top = el.offsetTop - this.$outer.offsetHeight;
+    let left = el.offsetLeft + 50 - 10; // 50px = padding-left(=75px) + text-indent(=-25px)
+    this.$outer.setAttribute('style', 'left: ' + left + 'px; top: ' + top + 'px');
+    if (top < document.body.scrollTop) {
+      this.$container.scrollIntoView();
+    }
+  },
+
+  deactivate() {
+    clearTimeout(this.deactiveTimeout);
+    this.$outer.classList.remove('active');
+  },
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+  if (typeof sdoMap == 'undefined') {
+    console.error('could not find sdo map');
+    return;
+  }
+  sdoBox.init();
+
+  let insideTooltip = false;
+  sdoBox.$outer.addEventListener('pointerenter', () => {
+    insideTooltip = true;
+  });
+  sdoBox.$outer.addEventListener('pointerleave', () => {
+    insideTooltip = false;
+    sdoBox.deactivate();
+  });
+
+  sdoBox.deactiveTimeout = null;
+  [].forEach.call(document.querySelectorAll('emu-grammar[type=definition] emu-rhs'), node => {
+    node.addEventListener('pointerenter', function () {
+      sdoBox.activate(this);
+    });
+
+    node.addEventListener('pointerleave', () => {
+      sdoBox.deactiveTimeout = setTimeout(() => {
+        if (!insideTooltip) {
+          sdoBox.deactivate();
+        }
+      }, 500);
+    });
+  });
+
+  document.addEventListener(
+    'keydown',
+    debounce(e => {
+      if (e.code === 'Escape') {
+        sdoBox.deactivate();
+      }
+    })
+  );
+});
+
+'use strict';
 function Search(menu) {
   this.menu = menu;
   this.$search = document.getElementById('menu-search');
@@ -11,8 +93,14 @@ function Search(menu) {
 
   document.addEventListener('keydown', this.documentKeydown.bind(this));
 
-  this.$searchBox.addEventListener('keydown', debounce(this.searchBoxKeydown.bind(this), { stopPropagation: true }));
-  this.$searchBox.addEventListener('keyup', debounce(this.searchBoxKeyup.bind(this), { stopPropagation: true }));
+  this.$searchBox.addEventListener(
+    'keydown',
+    debounce(this.searchBoxKeydown.bind(this), { stopPropagation: true })
+  );
+  this.$searchBox.addEventListener(
+    'keyup',
+    debounce(this.searchBoxKeyup.bind(this), { stopPropagation: true })
+  );
 
   // Perform an initial search if the box is not empty.
   if (this.$searchBox.value) {
@@ -21,26 +109,34 @@ function Search(menu) {
 }
 
 Search.prototype.loadBiblio = function () {
-  var $biblio = document.getElementById('menu-search-biblio');
-  if (!$biblio) {
-    this.biblio = [];
+  if (typeof biblio === 'undefined') {
+    console.error('could not find biblio');
+    this.biblio = { refToClause: {}, entries: [] };
   } else {
-    this.biblio = JSON.parse($biblio.textContent);
-    this.biblio.clauses = this.biblio.filter(function (e) { return e.type === 'clause' });
-    this.biblio.byId = this.biblio.reduce(function (map, entry) {
+    this.biblio = biblio;
+    this.biblio.clauses = this.biblio.entries.filter(e => e.type === 'clause');
+    this.biblio.byId = this.biblio.entries.reduce((map, entry) => {
       map[entry.id] = entry;
       return map;
     }, {});
+    let refParentClause = Object.create(null);
+    this.biblio.refParentClause = refParentClause;
+    let refsByClause = this.biblio.refsByClause;
+    Object.keys(refsByClause).forEach(clause => {
+      refsByClause[clause].forEach(ref => {
+        refParentClause[ref] = clause;
+      });
+    });
   }
-}
+};
 
 Search.prototype.documentKeydown = function (e) {
-  if (e.keyCode === 191) {
+  if (e.key === '/') {
     e.preventDefault();
     e.stopPropagation();
     this.triggerSearch();
   }
-}
+};
 
 Search.prototype.searchBoxKeydown = function (e) {
   e.stopPropagation();
@@ -51,7 +147,7 @@ Search.prototype.searchBoxKeydown = function (e) {
     e.preventDefault();
     this.selectResult();
   }
-}
+};
 
 Search.prototype.searchBoxKeyup = function (e) {
   if (e.keyCode === 13 || e.keyCode === 9) {
@@ -59,10 +155,9 @@ Search.prototype.searchBoxKeyup = function (e) {
   }
 
   this.search(e.target.value);
-}
+};
 
-
-Search.prototype.triggerSearch = function (e) {
+Search.prototype.triggerSearch = function () {
   if (this.menu.isVisible()) {
     this._closeAfterSearch = false;
   } else {
@@ -72,14 +167,14 @@ Search.prototype.triggerSearch = function (e) {
 
   this.$searchBox.focus();
   this.$searchBox.select();
-}
+};
 // bit 12 - Set if the result starts with searchString
 // bits 8-11: 8 - number of chunks multiplied by 2 if cases match, otherwise 1.
 // bits 1-7: 127 - length of the entry
 // General scheme: prefer case sensitive matches with fewer chunks, and otherwise
 // prefer shorter matches.
-function relevance(result, searchString) {
-  var relevance = 0;
+function relevance(result) {
+  let relevance = 0;
 
   relevance = Math.max(0, 8 - result.match.chunks) << 7;
 
@@ -88,10 +183,10 @@ function relevance(result, searchString) {
   }
 
   if (result.match.prefix) {
-    relevance += 2048
+    relevance += 2048;
   }
 
-  relevance += Math.max(0, 255 - result.entry.key.length);
+  relevance += Math.max(0, 255 - result.key.length);
 
   return relevance;
 }
@@ -110,36 +205,34 @@ Search.prototype.search = function (searchString) {
     return;
   }
 
-  var results;
+  let results;
 
-  if (/^[\d\.]*$/.test(searchString)) {
-    results = this.biblio.clauses.filter(function (clause) {
-      return clause.number.substring(0, searchString.length) === searchString;
-    }).map(function (clause) {
-      return { entry: clause };
-    });
+  if (/^[\d.]*$/.test(searchString)) {
+    results = this.biblio.clauses
+      .filter(clause => clause.number.substring(0, searchString.length) === searchString)
+      .map(clause => ({ key: getKey(clause), entry: clause }));
   } else {
     results = [];
 
-    for (var i = 0; i < this.biblio.length; i++) {
-      var entry = this.biblio[i];
-      if (!entry.key) {
+    for (let i = 0; i < this.biblio.entries.length; i++) {
+      let entry = this.biblio.entries[i];
+      let key = getKey(entry);
+      if (!key) {
         // biblio entries without a key aren't searchable
         continue;
       }
 
-      var match = fuzzysearch(searchString, entry.key);
+      let match = fuzzysearch(searchString, key);
       if (match) {
-        results.push({ entry: entry, match: match });
+        results.push({ key, entry, match });
       }
     }
 
-    results.forEach(function (result) {
+    results.forEach(result => {
       result.relevance = relevance(result, searchString);
     });
 
-    results = results.sort(function (a, b) { return b.relevance - a.relevance });
-
+    results = results.sort((a, b) => b.relevance - a.relevance);
   }
 
   if (results.length > 50) {
@@ -147,17 +240,17 @@ Search.prototype.search = function (searchString) {
   }
 
   this.displayResults(results);
-}
+};
 Search.prototype.hideSearch = function () {
   this.$search.classList.remove('active');
-}
+};
 
 Search.prototype.showSearch = function () {
   this.$search.classList.add('active');
-}
+};
 
 Search.prototype.selectResult = function () {
-  var $first = this.$searchResults.querySelector('li:first-child a');
+  let $first = this.$searchResults.querySelector('li:first-child a');
 
   if ($first) {
     document.location = $first.getAttribute('href');
@@ -171,53 +264,79 @@ Search.prototype.selectResult = function () {
   if (this._closeAfterSearch) {
     this.menu.hide();
   }
-}
+};
 
 Search.prototype.displayResults = function (results) {
   if (results.length > 0) {
     this.$searchResults.classList.remove('no-results');
 
-    var html = '<ul>';
+    let html = '<ul>';
 
-    results.forEach(function (result) {
-      var entry = result.entry;
-      var id = entry.id;
-      var cssClass = '';
-      var text = '';
+    results.forEach(result => {
+      let key = result.key;
+      let entry = result.entry;
+      let id = entry.id;
+      let cssClass = '';
+      let text = '';
 
       if (entry.type === 'clause') {
-        var number = entry.number ? entry.number + ' ' : '';
-        text = number + entry.key;
+        let number = entry.number ? entry.number + ' ' : '';
+        text = number + key;
         cssClass = 'clause';
         id = entry.id;
       } else if (entry.type === 'production') {
-        text = entry.key;
+        text = key;
         cssClass = 'prod';
         id = entry.id;
       } else if (entry.type === 'op') {
-        text = entry.key;
+        text = key;
         cssClass = 'op';
         id = entry.id || entry.refId;
       } else if (entry.type === 'term') {
-        text = entry.key;
+        text = key;
         cssClass = 'term';
         id = entry.id || entry.refId;
       }
 
       if (text) {
-        html += '<li class=menu-search-result-' + cssClass + '><a href="#' + id + '">' + text + '</a></li>';
+        // prettier-ignore
+        html += `<li class=menu-search-result-${cssClass}><a href="${makeLinkToId(id)}">${text}</a></li>`;
       }
     });
 
-    html += '</ul>'
+    html += '</ul>';
 
     this.$searchResults.innerHTML = html;
   } else {
     this.$searchResults.innerHTML = '';
     this.$searchResults.classList.add('no-results');
   }
-}
+};
 
+function getKey(item) {
+  if (item.key) {
+    return item.key;
+  }
+  switch (item.type) {
+    case 'clause':
+      return item.title || item.titleHTML;
+    case 'production':
+      return item.name;
+    case 'op':
+      return item.aoid;
+    case 'term':
+      return item.term;
+    case 'table':
+    case 'figure':
+    case 'example':
+    case 'note':
+      return item.caption;
+    case 'step':
+      return item.id;
+    default:
+      throw new Error("Can't get key for " + item.type);
+  }
+}
 
 function Menu() {
   this.$toggle = document.getElementById('menu-toggle');
@@ -229,7 +348,7 @@ function Menu() {
   this.$specContainer = document.getElementById('spec-container');
   this.search = new Search(this);
 
-  this._pinnedIds = {}; 
+  this._pinnedIds = {};
   this.loadPinEntries();
 
   // toggle menu
@@ -239,23 +358,23 @@ function Menu() {
   document.addEventListener('keydown', this.documentKeydown.bind(this));
 
   // toc expansion
-  var tocItems = this.$menu.querySelectorAll('#menu-toc li');
-  for (var i = 0; i < tocItems.length; i++) {
-    var $item = tocItems[i];
-    $item.addEventListener('click', function($item, event) {
+  let tocItems = this.$menu.querySelectorAll('#menu-toc li');
+  for (let i = 0; i < tocItems.length; i++) {
+    let $item = tocItems[i];
+    $item.addEventListener('click', event => {
       $item.classList.toggle('active');
       event.stopPropagation();
-    }.bind(null, $item));
+    });
   }
 
   // close toc on toc item selection
-  var tocLinks = this.$menu.querySelectorAll('#menu-toc li > a');
-  for (var i = 0; i < tocLinks.length; i++) {
-    var $link = tocLinks[i];
-    $link.addEventListener('click', function(event) {
+  let tocLinks = this.$menu.querySelectorAll('#menu-toc li > a');
+  for (let i = 0; i < tocLinks.length; i++) {
+    let $link = tocLinks[i];
+    $link.addEventListener('click', event => {
       this.toggle();
       event.stopPropagation();
-    }.bind(this));
+    });
   }
 
   // update active clause on scroll
@@ -263,14 +382,13 @@ function Menu() {
   this.updateActiveClause();
 
   // prevent menu scrolling from scrolling the body
-  this.$toc.addEventListener('wheel', function (e) {
-    var target = e.currentTarget;
-    var offTop = e.deltaY < 0 && target.scrollTop === 0;
+  this.$toc.addEventListener('wheel', e => {
+    let target = e.currentTarget;
+    let offTop = e.deltaY < 0 && target.scrollTop === 0;
     if (offTop) {
       e.preventDefault();
     }
-    var offBottom = e.deltaY > 0
-                    && target.offsetHeight + target.scrollTop >= target.scrollHeight;
+    let offBottom = e.deltaY > 0 && target.offsetHeight + target.scrollTop >= target.scrollHeight;
 
     if (offBottom) {
       e.preventDefault();
@@ -285,62 +403,66 @@ Menu.prototype.documentKeydown = function (e) {
   } else if (e.keyCode > 48 && e.keyCode < 58) {
     this.selectPin(e.keyCode - 49);
   }
-}
+};
 
 Menu.prototype.updateActiveClause = function () {
-  this.setActiveClause(findActiveClause(this.$specContainer))
-}
+  this.setActiveClause(findActiveClause(this.$specContainer));
+};
 
 Menu.prototype.setActiveClause = function (clause) {
   this.$activeClause = clause;
   this.revealInToc(this.$activeClause);
-}
+};
 
 Menu.prototype.revealInToc = function (path) {
-  var current = this.$toc.querySelectorAll('li.revealed');
-  for (var i = 0; i < current.length; i++) {
+  let current = this.$toc.querySelectorAll('li.revealed');
+  for (let i = 0; i < current.length; i++) {
     current[i].classList.remove('revealed');
     current[i].classList.remove('revealed-leaf');
   }
 
-  var current = this.$toc;
-  var index = 0;
-  while (index < path.length) {
-    var children = current.children;
-    for (var i = 0; i < children.length; i++) {
-      if ('#' + path[index].id === children[i].children[1].getAttribute('href') ) {
+  current = this.$toc;
+  let index = 0;
+  outer: while (index < path.length) {
+    let children = current.children;
+    for (let i = 0; i < children.length; i++) {
+      if ('#' + path[index].id === children[i].children[1].hash) {
         children[i].classList.add('revealed');
         if (index === path.length - 1) {
           children[i].classList.add('revealed-leaf');
-          var rect = children[i].getBoundingClientRect();
+          let rect = children[i].getBoundingClientRect();
           // this.$toc.getBoundingClientRect().top;
-          var tocRect = this.$toc.getBoundingClientRect();
+          let tocRect = this.$toc.getBoundingClientRect();
           if (rect.top + 10 > tocRect.bottom) {
-            this.$toc.scrollTop = this.$toc.scrollTop + (rect.top - tocRect.bottom) + (rect.bottom - rect.top);
+            this.$toc.scrollTop =
+              this.$toc.scrollTop + (rect.top - tocRect.bottom) + (rect.bottom - rect.top);
           } else if (rect.top < tocRect.top) {
             this.$toc.scrollTop = this.$toc.scrollTop - (tocRect.top - rect.top);
           }
         }
         current = children[i].querySelector('ol');
         index++;
-        break;
+        continue outer;
       }
     }
-
+    console.log('could not find location in table of contents', path);
+    break;
   }
-}
+};
 
 function findActiveClause(root, path) {
-  var clauses = new ClauseWalker(root);
-  var $clause;
-  var path = path || [];
+  let clauses = getChildClauses(root);
+  path = path || [];
 
-  while ($clause = clauses.nextNode()) {
-    var rect = $clause.getBoundingClientRect();
-    var $header = $clause.querySelector("h1");
-    var marginTop = parseInt(getComputedStyle($header)["margin-top"]);
+  for (let $clause of clauses) {
+    let rect = $clause.getBoundingClientRect();
+    let $header = $clause.querySelector('h1');
+    let marginTop = Math.max(
+      parseInt(getComputedStyle($clause)['margin-top']),
+      parseInt(getComputedStyle($header)['margin-top'])
+    );
 
-    if ((rect.top - marginTop) <= 0 && rect.bottom > 0) {
+    if (rect.top - marginTop <= 1 && rect.bottom > 0) {
       return findActiveClause($clause, path.concat($clause)) || path;
     }
   }
@@ -348,57 +470,49 @@ function findActiveClause(root, path) {
   return path;
 }
 
-function ClauseWalker(root) {
-  var previous;
-  var treeWalker = document.createTreeWalker(
-    root,
-    NodeFilter.SHOW_ELEMENT,
-    {
-      acceptNode: function (node) {
-        if (previous === node.parentNode) {
-          return NodeFilter.FILTER_REJECT;
-        } else {
-          previous = node;
-        }
-        if (node.nodeName === 'EMU-CLAUSE' || node.nodeName === 'EMU-INTRO' || node.nodeName === 'EMU-ANNEX') {
-          return NodeFilter.FILTER_ACCEPT;
-        } else {
-          return NodeFilter.FILTER_SKIP;
-        }
-      }
-    },
-    false
-    );
+function* getChildClauses(root) {
+  for (let el of root.children) {
+    switch (el.nodeName) {
+      // descend into <emu-import>
+      case 'EMU-IMPORT':
+        yield* getChildClauses(el);
+        break;
 
-  return treeWalker;
+      // accept <emu-clause>, <emu-intro>, and <emu-annex>
+      case 'EMU-CLAUSE':
+      case 'EMU-INTRO':
+      case 'EMU-ANNEX':
+        yield el;
+    }
+  }
 }
 
 Menu.prototype.toggle = function () {
   this.$menu.classList.toggle('active');
-}
+};
 
 Menu.prototype.show = function () {
   this.$menu.classList.add('active');
-}
+};
 
 Menu.prototype.hide = function () {
   this.$menu.classList.remove('active');
-}
+};
 
-Menu.prototype.isVisible = function() {
+Menu.prototype.isVisible = function () {
   return this.$menu.classList.contains('active');
-}
+};
 
 Menu.prototype.showPins = function () {
   this.$pins.classList.add('active');
-}
+};
 
 Menu.prototype.hidePins = function () {
   this.$pins.classList.remove('active');
-}
+};
 
 Menu.prototype.addPinEntry = function (id) {
-  var entry = this.search.biblio.byId[id];
+  let entry = this.search.biblio.byId[id];
   if (!entry) {
     // id was deleted after pin (or something) so remove it
     delete this._pinnedIds[id];
@@ -407,15 +521,16 @@ Menu.prototype.addPinEntry = function (id) {
   }
 
   if (entry.type === 'clause') {
-    var prefix;
+    let prefix;
     if (entry.number) {
       prefix = entry.number + ' ';
     } else {
       prefix = '';
     }
-    this.$pinList.innerHTML += '<li><a href="#' + entry.id + '">' + prefix + entry.titleHTML + '</a></li>';
+    // prettier-ignore
+    this.$pinList.innerHTML += `<li><a href="${makeLinkToId(entry.id)}">${prefix}${entry.titleHTML}</a></li>`;
   } else {
-    this.$pinList.innerHTML += '<li><a href="#' + entry.id + '">' + entry.key + '</a></li>';
+    this.$pinList.innerHTML += `<li><a href="${makeLinkToId(entry.id)}">${getKey(entry)}</a></li>`;
   }
 
   if (Object.keys(this._pinnedIds).length === 0) {
@@ -423,10 +538,10 @@ Menu.prototype.addPinEntry = function (id) {
   }
   this._pinnedIds[id] = true;
   this.persistPinEntries();
-}
+};
 
 Menu.prototype.removePinEntry = function (id) {
-  var item = this.$pinList.querySelector('a[href="#' + id + '"]').parentNode;
+  let item = this.$pinList.querySelector(`a[href="${makeLinkToId(id)}"]`).parentNode;
   this.$pinList.removeChild(item);
   delete this._pinnedIds[id];
   if (Object.keys(this._pinnedIds).length === 0) {
@@ -434,7 +549,7 @@ Menu.prototype.removePinEntry = function (id) {
   }
 
   this.persistPinEntries();
-}
+};
 
 Menu.prototype.persistPinEntries = function () {
   try {
@@ -444,7 +559,7 @@ Menu.prototype.persistPinEntries = function () {
   }
 
   localStorage.pinEntries = JSON.stringify(Object.keys(this._pinnedIds));
-}
+};
 
 Menu.prototype.loadPinEntries = function () {
   try {
@@ -453,13 +568,13 @@ Menu.prototype.loadPinEntries = function () {
     return;
   }
 
-  var pinsString = window.localStorage.pinEntries;
+  let pinsString = window.localStorage.pinEntries;
   if (!pinsString) return;
-  var pins = JSON.parse(pinsString);
-  for(var i = 0; i < pins.length; i++) {
+  let pins = JSON.parse(pinsString);
+  for (let i = 0; i < pins.length; i++) {
     this.addPinEntry(pins[i]);
   }
-}
+};
 
 Menu.prototype.togglePinEntry = function (id) {
   if (!id) {
@@ -471,62 +586,49 @@ Menu.prototype.togglePinEntry = function (id) {
   } else {
     this.addPinEntry(id);
   }
-}
+};
 
 Menu.prototype.selectPin = function (num) {
   document.location = this.$pinList.children[num].children[0].href;
-}
+};
 
-var menu;
-function init() {
-  menu = new Menu();
-  var $container = document.getElementById('spec-container');
-  $container.addEventListener('mouseover', debounce(function (e) {
-    Toolbox.activateIfMouseOver(e);
-  }));
-  document.addEventListener('keydown', debounce(function (e) {
-    if (e.code === "Escape" && Toolbox.active) {
-      Toolbox.deactivate();
-    }
-  }));
-}
+let menu;
 
 document.addEventListener('DOMContentLoaded', init);
 
 function debounce(fn, opts) {
   opts = opts || {};
-  var timeout;
-  return function(e) {
+  let timeout;
+  return function (e) {
     if (opts.stopPropagation) {
       e.stopPropagation();
     }
-    var args = arguments;
+    let args = arguments;
     if (timeout) {
       clearTimeout(timeout);
     }
-    timeout = setTimeout(function() {
+    timeout = setTimeout(() => {
       timeout = null;
       fn.apply(this, args);
-    }.bind(this), 150);
-  }
+    }, 150);
+  };
 }
 
-var CLAUSE_NODES = ['EMU-CLAUSE', 'EMU-INTRO', 'EMU-ANNEX'];
-function findLocalReferences ($elem) {
-  var name = $elem.innerHTML;
-  var references = [];
-
-  var parentClause = $elem.parentNode;
+let CLAUSE_NODES = ['EMU-CLAUSE', 'EMU-INTRO', 'EMU-ANNEX'];
+function findContainer($elem) {
+  let parentClause = $elem.parentNode;
   while (parentClause && CLAUSE_NODES.indexOf(parentClause.nodeName) === -1) {
     parentClause = parentClause.parentNode;
   }
+  return parentClause;
+}
 
-  if(!parentClause) return;
+function findLocalReferences(parentClause, name) {
+  let vars = parentClause.querySelectorAll('var');
+  let references = [];
 
-  var vars = parentClause.querySelectorAll('var');
-
-  for (var i = 0; i < vars.length; i++) {
-    var $var = vars[i];
+  for (let i = 0; i < vars.length; i++) {
+    let $var = vars[i];
 
     if ($var.innerHTML === name) {
       references.push($var);
@@ -536,21 +638,38 @@ function findLocalReferences ($elem) {
   return references;
 }
 
+let REFERENCED_CLASSES = Array.from({ length: 7 }, (x, i) => `referenced${i}`);
+function chooseHighlightIndex(parentClause) {
+  let counts = REFERENCED_CLASSES.map($class => parentClause.getElementsByClassName($class).length);
+  // Find the earliest index with the lowest count.
+  let minCount = Infinity;
+  let index = null;
+  for (let i = 0; i < counts.length; i++) {
+    if (counts[i] < minCount) {
+      minCount = counts[i];
+      index = i;
+    }
+  }
+  return index;
+}
+
 function toggleFindLocalReferences($elem) {
-  var references = findLocalReferences($elem);
+  let parentClause = findContainer($elem);
+  let references = findLocalReferences(parentClause, $elem.innerHTML);
   if ($elem.classList.contains('referenced')) {
-    references.forEach(function ($reference) {
-      $reference.classList.remove('referenced');
+    references.forEach($reference => {
+      $reference.classList.remove('referenced', ...REFERENCED_CLASSES);
     });
   } else {
-    references.forEach(function ($reference) {
-      $reference.classList.add('referenced');
+    let index = chooseHighlightIndex(parentClause);
+    references.forEach($reference => {
+      $reference.classList.add('referenced', `referenced${index}`);
     });
   }
 }
 
-function installFindLocalReferences () {
-  document.addEventListener('click', function (e) {
+function installFindLocalReferences() {
+  document.addEventListener('click', e => {
     if (e.target.nodeName === 'VAR') {
       toggleFindLocalReferences(e.target);
     }
@@ -558,9 +677,6 @@ function installFindLocalReferences () {
 }
 
 document.addEventListener('DOMContentLoaded', installFindLocalReferences);
-
-
-
 
 // The following license applies to the fuzzysearch function
 // The MIT License (MIT)
@@ -582,11 +698,11 @@ document.addEventListener('DOMContentLoaded', installFindLocalReferences);
 // COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-function fuzzysearch (searchString, haystack, caseInsensitive) {
-  var tlen = haystack.length;
-  var qlen = searchString.length;
-  var chunks = 1;
-  var finding = false;
+function fuzzysearch(searchString, haystack, caseInsensitive) {
+  let tlen = haystack.length;
+  let qlen = searchString.length;
+  let chunks = 1;
+  let finding = false;
 
   if (qlen > tlen) {
     return false;
@@ -602,10 +718,11 @@ function fuzzysearch (searchString, haystack, caseInsensitive) {
     }
   }
 
-  outer: for (var i = 0, j = 0; i < qlen; i++) {
-    var nch = searchString[i];
+  let j = 0;
+  outer: for (let i = 0; i < qlen; i++) {
+    let nch = searchString[i];
     while (j < tlen) {
-      var targetChar = haystack[j++];
+      let targetChar = haystack[j++];
       if (targetChar === nch) {
         finding = true;
         continue outer;
@@ -616,113 +733,24 @@ function fuzzysearch (searchString, haystack, caseInsensitive) {
       }
     }
 
-    if (caseInsensitive) { return false; }
+    if (caseInsensitive) {
+      return false;
+    }
 
     return fuzzysearch(searchString.toLowerCase(), haystack.toLowerCase(), true);
   }
 
-  return { caseMatch: !caseInsensitive, chunks: chunks, prefix: j <= qlen };
+  return { caseMatch: !caseInsensitive, chunks, prefix: j <= qlen };
 }
 
-var Toolbox = {
-  init: function () {
-    this.$container = document.createElement('div');
-    this.$container.classList.add('toolbox');
-    this.$permalink = document.createElement('a');
-    this.$permalink.textContent = 'Permalink';
-    this.$pinLink = document.createElement('a');
-    this.$pinLink.textContent = 'Pin';
-    this.$pinLink.setAttribute('href', '#');
-    this.$pinLink.addEventListener('click', function (e) {
-      e.preventDefault();
-      e.stopPropagation();
-      menu.togglePinEntry(this.entry.id);
-    }.bind(this));
-
-    this.$refsLink = document.createElement('a');
-    this.$refsLink.setAttribute('href', '#');
-    this.$refsLink.addEventListener('click', function (e) {
-      e.preventDefault();
-      e.stopPropagation();
-      referencePane.showReferencesFor(this.entry);
-    }.bind(this));
-    this.$container.appendChild(this.$permalink);
-    this.$container.appendChild(this.$pinLink);
-    this.$container.appendChild(this.$refsLink);
-    document.body.appendChild(this.$container);
-  },
-
-  activate: function (el, entry, target) {
-    if (el === this._activeEl) return;
-    this.active = true;
-    this.entry = entry;
-    this.$container.classList.add('active');
-    this.top = el.offsetTop - this.$container.offsetHeight - 10;
-    this.left = el.offsetLeft;
-    this.$container.setAttribute('style', 'left: ' + this.left + 'px; top: ' + this.top + 'px');
-    this.updatePermalink();
-    this.updateReferences();
-    this._activeEl = el;
-    if (this.top < document.body.scrollTop && el === target) {
-      // don't scroll unless it's a small thing (< 200px)
-      this.$container.scrollIntoView();
-    }
-  },
-
-  updatePermalink: function () {
-    this.$permalink.setAttribute('href', '#' + this.entry.id);
-  },
-
-  updateReferences: function () {
-    this.$refsLink.textContent = 'References (' + this.entry.referencingIds.length + ')';
-  },
-
-  activateIfMouseOver: function (e) {
-    var ref = this.findReferenceUnder(e.target);
-    if (ref && (!this.active || e.pageY > this._activeEl.offsetTop)) {
-      var entry = menu.search.biblio.byId[ref.id];
-      this.activate(ref.element, entry, e.target);
-    } else if (this.active && ((e.pageY < this.top) || e.pageY > (this._activeEl.offsetTop + this._activeEl.offsetHeight))) {
-      this.deactivate();
-    }
-  },
-
-  findReferenceUnder: function (el) {
-    while (el) {
-      var parent = el.parentNode;
-      if (el.nodeName === 'H1' && parent.nodeName.match(/EMU-CLAUSE|EMU-ANNEX|EMU-INTRO/) && parent.id) {
-        return { element: el, id: parent.id };
-      } else if (el.nodeName.match(/EMU-(?!CLAUSE|XREF|ANNEX|INTRO)|DFN/) &&
-                el.id && el.id[0] !== '_') {
-        if (el.nodeName === 'EMU-FIGURE' || el.nodeName === 'EMU-TABLE' || el.nodeName === 'EMU-EXAMPLE') {
-          // return the figcaption element
-          return { element: el.children[0].children[0], id: el.id };
-        } else if (el.nodeName === 'EMU-PRODUCTION') {
-          // return the LHS non-terminal element
-          return { element: el.children[0], id: el.id };
-        } else {
-          return { element: el, id: el.id };
-        }
-      }
-      el = parent;
-    }
-  },
-
-  deactivate: function () {
-    this.$container.classList.remove('active');
-    this._activeEl = null;
-    this.activeElBounds = null;
-    this.active = false;
-  }
-}
-
-var referencePane = {
-  init: function() {
+let referencePane = {
+  init() {
     this.$container = document.createElement('div');
     this.$container.setAttribute('id', 'references-pane-container');
 
-    var $spacer = document.createElement('div');
+    let $spacer = document.createElement('div');
     $spacer.setAttribute('id', 'references-pane-spacer');
+    $spacer.classList.add('menu-spacer');
 
     this.$pane = document.createElement('div');
     this.$pane.setAttribute('id', 'references-pane');
@@ -732,18 +760,19 @@ var referencePane = {
 
     this.$header = document.createElement('div');
     this.$header.classList.add('menu-pane-header');
-    this.$header.textContent = 'References to ';
+    this.$headerText = document.createElement('span');
+    this.$header.appendChild(this.$headerText);
     this.$headerRefId = document.createElement('a');
     this.$header.appendChild(this.$headerRefId);
     this.$closeButton = document.createElement('span');
     this.$closeButton.setAttribute('id', 'references-pane-close');
-    this.$closeButton.addEventListener('click', function (e) {
+    this.$closeButton.addEventListener('click', () => {
       this.deactivate();
-    }.bind(this));
+    });
     this.$header.appendChild(this.$closeButton);
 
     this.$pane.appendChild(this.$header);
-    var tableContainer = document.createElement('div');
+    let tableContainer = document.createElement('div');
     tableContainer.setAttribute('id', 'references-pane-table-container');
 
     this.$table = document.createElement('table');
@@ -757,70 +786,238 @@ var referencePane = {
     menu.$specContainer.appendChild(this.$container);
   },
 
-  activate: function () {
+  activate() {
     this.$container.classList.add('active');
   },
 
-  deactivate: function () {
+  deactivate() {
     this.$container.classList.remove('active');
+    this.state = null;
   },
 
   showReferencesFor(entry) {
     this.activate();
-    var newBody = document.createElement('tbody');
-    var previousId;
-    var previousCell;
-    var dupCount = 0;
+    this.state = { type: 'ref', id: entry.id };
+    this.$headerText.textContent = 'References to ';
+    let newBody = document.createElement('tbody');
+    let previousId;
+    let previousCell;
+    let dupCount = 0;
     this.$headerRefId.textContent = '#' + entry.id;
-    this.$headerRefId.setAttribute('href', '#' + entry.id);
-    entry.referencingIds.map(function (id) {
-      var target = document.getElementById(id);
-      var cid = findParentClauseId(target);
-      var clause = menu.search.biblio.byId[cid];
-      return { id: id, clause: clause }
-    }).sort(function (a, b) {
-      return sortByClauseNumber(a.clause, b.clause);
-    }).forEach(function (record, i) {
-      if (previousId === record.clause.id) {
-        previousCell.innerHTML += ' (<a href="#' + record.id + '">' + (dupCount + 2) + '</a>)';
-        dupCount++;
-      } else {
-        var row = newBody.insertRow();
-        var cell = row.insertCell();
-        cell.innerHTML = record.clause.number;
-        cell = row.insertCell();
-        cell.innerHTML = '<a href="#' + record.id + '">' + record.clause.titleHTML + '</a>';
-        previousCell = cell;
-        previousId = record.clause.id;
-        dupCount = 0;
-      }
-    }, this);
+    this.$headerRefId.setAttribute('href', makeLinkToId(entry.id));
+    this.$headerRefId.style.display = 'inline';
+    (entry.referencingIds || [])
+      .map(id => {
+        let cid = menu.search.biblio.refParentClause[id];
+        let clause = menu.search.biblio.byId[cid];
+        if (clause == null) {
+          throw new Error('could not find clause for id ' + cid);
+        }
+        return { id, clause };
+      })
+      .sort((a, b) => sortByClauseNumber(a.clause, b.clause))
+      .forEach(record => {
+        if (previousId === record.clause.id) {
+          previousCell.innerHTML += ` (<a href="${makeLinkToId(record.id)}">${dupCount + 2}</a>)`;
+          dupCount++;
+        } else {
+          let row = newBody.insertRow();
+          let cell = row.insertCell();
+          cell.innerHTML = record.clause.number;
+          cell = row.insertCell();
+          cell.innerHTML = `<a href="${makeLinkToId(record.id)}">${record.clause.titleHTML}</a>`;
+          previousCell = cell;
+          previousId = record.clause.id;
+          dupCount = 0;
+        }
+      }, this);
     this.$table.removeChild(this.$tableBody);
     this.$tableBody = newBody;
     this.$table.appendChild(this.$tableBody);
-  }
-}
-function findParentClauseId(node) {
-  while (node && node.nodeName !== 'EMU-CLAUSE' && node.nodeName !== 'EMU-INTRO' && node.nodeName !== 'EMU-ANNEX') {
-    node = node.parentNode;
-  }
-  if (!node) return null;
-  return node.getAttribute('id');
-}
+  },
 
-function sortByClauseNumber(c1, c2) {
-  var c1c = c1.number.split('.');
-  var c2c = c2.number.split('.');
+  showSDOs(sdos, alternativeId) {
+    let rhs = document.getElementById(alternativeId);
+    let parentName = rhs.parentNode.getAttribute('name');
+    let colons = rhs.parentNode.querySelector('emu-geq');
+    rhs = rhs.cloneNode(true);
+    rhs.querySelectorAll('emu-params,emu-constraints').forEach(e => {
+      e.remove();
+    });
+    rhs.querySelectorAll('[id]').forEach(e => {
+      e.removeAttribute('id');
+    });
+    rhs.querySelectorAll('a').forEach(e => {
+      e.parentNode.replaceChild(document.createTextNode(e.textContent), e);
+    });
 
-  for (var i = 0; i < c1c.length; i++) {
+    // prettier-ignore
+    this.$headerText.innerHTML = `Syntax-Directed Operations for<br><a href="${makeLinkToId(alternativeId)}" class="menu-pane-header-production"><emu-nt>${parentName}</emu-nt> ${colons.outerHTML} </a>`;
+    this.$headerText.querySelector('a').append(rhs);
+    this.showSDOsBody(sdos, alternativeId);
+  },
+
+  showSDOsBody(sdos, alternativeId) {
+    this.activate();
+    this.state = { type: 'sdo', id: alternativeId, html: this.$headerText.innerHTML };
+    this.$headerRefId.style.display = 'none';
+    let newBody = document.createElement('tbody');
+    Object.keys(sdos).forEach(sdoName => {
+      let pair = sdos[sdoName];
+      let clause = pair.clause;
+      let ids = pair.ids;
+      let first = ids[0];
+      let row = newBody.insertRow();
+      let cell = row.insertCell();
+      cell.innerHTML = clause;
+      cell = row.insertCell();
+      let html = '<a href="' + makeLinkToId(first) + '">' + sdoName + '</a>';
+      for (let i = 1; i < ids.length; ++i) {
+        html += ' (<a href="' + makeLinkToId(ids[i]) + '">' + (i + 1) + '</a>)';
+      }
+      cell.innerHTML = html;
+    });
+    this.$table.removeChild(this.$tableBody);
+    this.$tableBody = newBody;
+    this.$table.appendChild(this.$tableBody);
+  },
+};
+
+let Toolbox = {
+  init() {
+    this.$outer = document.createElement('div');
+    this.$outer.classList.add('toolbox-container');
+    this.$container = document.createElement('div');
+    this.$container.classList.add('toolbox');
+    this.$outer.appendChild(this.$container);
+    this.$permalink = document.createElement('a');
+    this.$permalink.textContent = 'Permalink';
+    this.$pinLink = document.createElement('a');
+    this.$pinLink.textContent = 'Pin';
+    this.$pinLink.setAttribute('href', '#');
+    this.$pinLink.addEventListener('click', e => {
+      e.preventDefault();
+      e.stopPropagation();
+      menu.togglePinEntry(this.entry.id);
+      this.$pinLink.textContent = menu._pinnedIds[this.entry.id] ? 'Unpin' : 'Pin';
+    });
+
+    this.$refsLink = document.createElement('a');
+    this.$refsLink.setAttribute('href', '#');
+    this.$refsLink.addEventListener('click', e => {
+      e.preventDefault();
+      e.stopPropagation();
+      referencePane.showReferencesFor(this.entry);
+    });
+    this.$container.appendChild(this.$permalink);
+    this.$container.appendChild(this.$pinLink);
+    this.$container.appendChild(this.$refsLink);
+    document.body.appendChild(this.$outer);
+  },
+
+  activate(el, entry, target) {
+    if (el === this._activeEl) return;
+    sdoBox.deactivate();
+    this.active = true;
+    this.entry = entry;
+    this.$pinLink.textContent = menu._pinnedIds[entry.id] ? 'Unpin' : 'Pin';
+    this.$outer.classList.add('active');
+    this.top = el.offsetTop - this.$outer.offsetHeight;
+    this.left = el.offsetLeft - 10;
+    this.$outer.setAttribute('style', 'left: ' + this.left + 'px; top: ' + this.top + 'px');
+    this.updatePermalink();
+    this.updateReferences();
+    this._activeEl = el;
+    if (this.top < document.body.scrollTop && el === target) {
+      // don't scroll unless it's a small thing (< 200px)
+      this.$outer.scrollIntoView();
+    }
+  },
+
+  updatePermalink() {
+    this.$permalink.setAttribute('href', makeLinkToId(this.entry.id));
+  },
+
+  updateReferences() {
+    this.$refsLink.textContent = `References (${(this.entry.referencingIds || []).length})`;
+  },
+
+  activateIfMouseOver(e) {
+    let ref = this.findReferenceUnder(e.target);
+    if (ref && (!this.active || e.pageY > this._activeEl.offsetTop)) {
+      let entry = menu.search.biblio.byId[ref.id];
+      this.activate(ref.element, entry, e.target);
+    } else if (
+      this.active &&
+      (e.pageY < this.top || e.pageY > this._activeEl.offsetTop + this._activeEl.offsetHeight)
+    ) {
+      this.deactivate();
+    }
+  },
+
+  findReferenceUnder(el) {
+    while (el) {
+      let parent = el.parentNode;
+      if (el.nodeName === 'EMU-RHS' || el.nodeName === 'EMU-PRODUCTION') {
+        return null;
+      }
+      if (
+        el.nodeName === 'H1' &&
+        parent.nodeName.match(/EMU-CLAUSE|EMU-ANNEX|EMU-INTRO/) &&
+        parent.id
+      ) {
+        return { element: el, id: parent.id };
+      } else if (el.nodeName === 'EMU-NT') {
+        if (
+          parent.nodeName === 'EMU-PRODUCTION' &&
+          parent.id &&
+          parent.id[0] !== '_' &&
+          parent.firstElementChild === el
+        ) {
+          // return the LHS non-terminal element
+          return { element: el, id: parent.id };
+        }
+        return null;
+      } else if (
+        el.nodeName.match(/EMU-(?!CLAUSE|XREF|ANNEX|INTRO)|DFN/) &&
+        el.id &&
+        el.id[0] !== '_'
+      ) {
+        if (
+          el.nodeName === 'EMU-FIGURE' ||
+          el.nodeName === 'EMU-TABLE' ||
+          el.nodeName === 'EMU-EXAMPLE'
+        ) {
+          // return the figcaption element
+          return { element: el.children[0].children[0], id: el.id };
+        } else {
+          return { element: el, id: el.id };
+        }
+      }
+      el = parent;
+    }
+  },
+
+  deactivate() {
+    this.$outer.classList.remove('active');
+    this._activeEl = null;
+    this.active = false;
+  },
+};
+
+function sortByClauseNumber(clause1, clause2) {
+  let c1c = clause1.number.split('.');
+  let c2c = clause2.number.split('.');
+
+  for (let i = 0; i < c1c.length; i++) {
     if (i >= c2c.length) {
       return 1;
     }
 
-    var c1 = c1c[i];
-    var c2 = c2c[i];
-    var c1cn = Number(c1);
-    var c2cn = Number(c2);
+    let c1 = c1c[i];
+    let c2 = c2c[i];
+    let c1cn = Number(c1);
+    let c2cn = Number(c2);
 
     if (Number.isNaN(c1cn) && Number.isNaN(c2cn)) {
       if (c1 > c2) {
@@ -832,7 +1029,7 @@ function sortByClauseNumber(c1, c2) {
       return -1;
     } else if (Number.isNaN(c1cn) && !Number.isNaN(c2cn)) {
       return 1;
-    } else if(c1cn > c2cn) {
+    } else if (c1cn > c2cn) {
       return 1;
     } else if (c1cn < c2cn) {
       return -1;
@@ -845,59 +1042,314 @@ function sortByClauseNumber(c1, c2) {
   return -1;
 }
 
-document.addEventListener('DOMContentLoaded', function () {
+function makeLinkToId(id) {
+  let hash = '#' + id;
+  if (typeof idToSection === 'undefined' || !idToSection[id]) {
+    return hash;
+  }
+  let targetSec = idToSection[id];
+  return (targetSec === 'index' ? './' : targetSec + '.html') + hash;
+}
+
+function doShortcut(e) {
+  if (!(e.target instanceof HTMLElement)) {
+    return;
+  }
+  let target = e.target;
+  let name = target.nodeName.toLowerCase();
+  if (name === 'textarea' || name === 'input' || name === 'select' || target.isContentEditable) {
+    return;
+  }
+  if (e.altKey || e.ctrlKey || e.metaKey) {
+    return;
+  }
+  if (e.key === 'm' && usesMultipage) {
+    let pathParts = location.pathname.split('/');
+    let hash = location.hash;
+    if (pathParts[pathParts.length - 2] === 'multipage') {
+      if (hash === '') {
+        let sectionName = pathParts[pathParts.length - 1];
+        if (sectionName.endsWith('.html')) {
+          sectionName = sectionName.slice(0, -5);
+        }
+        if (idToSection['sec-' + sectionName] !== undefined) {
+          hash = '#sec-' + sectionName;
+        }
+      }
+      location = pathParts.slice(0, -2).join('/') + '/' + hash;
+    } else {
+      location = 'multipage/' + hash;
+    }
+  } else if (e.key === 'u') {
+    document.documentElement.classList.toggle('show-ao-annotations');
+  } else if (e.key === '?') {
+    document.getElementById('shortcuts-help').classList.toggle('active');
+  }
+}
+
+function init() {
+  menu = new Menu();
+  let $container = document.getElementById('spec-container');
+  $container.addEventListener(
+    'mouseover',
+    debounce(e => {
+      Toolbox.activateIfMouseOver(e);
+    })
+  );
+  document.addEventListener(
+    'keydown',
+    debounce(e => {
+      if (e.code === 'Escape') {
+        if (Toolbox.active) {
+          Toolbox.deactivate();
+        }
+        document.getElementById('shortcuts-help').classList.remove('active');
+      }
+    })
+  );
+}
+
+document.addEventListener('keypress', doShortcut);
+
+document.addEventListener('DOMContentLoaded', () => {
   Toolbox.init();
   referencePane.init();
-})
-var CLAUSE_NODES = ['EMU-CLAUSE', 'EMU-INTRO', 'EMU-ANNEX'];
-function findLocalReferences ($elem) {
-  var name = $elem.innerHTML;
-  var references = [];
+});
 
-  var parentClause = $elem.parentNode;
-  while (parentClause && CLAUSE_NODES.indexOf(parentClause.nodeName) === -1) {
-    parentClause = parentClause.parentNode;
+// preserve state during navigation
+
+function getTocPath(li) {
+  let path = [];
+  let pointer = li;
+  while (true) {
+    let parent = pointer.parentElement;
+    if (parent == null) {
+      return null;
+    }
+    let index = [].indexOf.call(parent.children, pointer);
+    if (index == -1) {
+      return null;
+    }
+    path.unshift(index);
+    pointer = parent.parentElement;
+    if (pointer == null) {
+      return null;
+    }
+    if (pointer.id === 'menu-toc') {
+      break;
+    }
+    if (pointer.tagName !== 'LI') {
+      return null;
+    }
   }
+  return path;
+}
 
-  if(!parentClause) return;
+function activateTocPath(path) {
+  try {
+    let pointer = document.getElementById('menu-toc');
+    for (let index of path) {
+      pointer = pointer.querySelector('ol').children[index];
+    }
+    pointer.classList.add('active');
+  } catch (e) {
+    // pass
+  }
+}
 
-  var vars = parentClause.querySelectorAll('var');
+function getActiveTocPaths() {
+  return [...menu.$menu.querySelectorAll('.active')].map(getTocPath).filter(p => p != null);
+}
 
-  for (var i = 0; i < vars.length; i++) {
-    var $var = vars[i];
-
-    if ($var.innerHTML === name) {
-      references.push($var);
+function loadStateFromSessionStorage() {
+  if (!window.sessionStorage || typeof menu === 'undefined' || window.navigating) {
+    return;
+  }
+  if (sessionStorage.referencePaneState != null) {
+    let state = JSON.parse(sessionStorage.referencePaneState);
+    if (state != null) {
+      if (state.type === 'ref') {
+        let entry = menu.search.biblio.byId[state.id];
+        if (entry != null) {
+          referencePane.showReferencesFor(entry);
+        }
+      } else if (state.type === 'sdo') {
+        let sdos = sdoMap[state.id];
+        if (sdos != null) {
+          referencePane.$headerText.innerHTML = state.html;
+          referencePane.showSDOsBody(sdos, state.id);
+        }
+      }
+      delete sessionStorage.referencePaneState;
     }
   }
 
-  return references;
-}
+  if (sessionStorage.activeTocPaths != null) {
+    document
+      .getElementById('menu-toc')
+      .querySelectorAll('.active')
+      .forEach(e => {
+        e.classList.remove('active');
+      });
+    let active = JSON.parse(sessionStorage.activeTocPaths);
+    active.forEach(activateTocPath);
+    delete sessionStorage.activeTocPaths;
+  }
 
-function toggleFindLocalReferences($elem) {
-  var references = findLocalReferences($elem);
-  if ($elem.classList.contains('referenced')) {
-    references.forEach(function ($reference) {
-      $reference.classList.remove('referenced');
-    });
-  } else {
-    references.forEach(function ($reference) {
-      $reference.classList.add('referenced');
-    });
+  if (sessionStorage.searchValue != null) {
+    let value = JSON.parse(sessionStorage.searchValue);
+    menu.search.$searchBox.value = value;
+    menu.search.search(value);
+    delete sessionStorage.searchValue;
+  }
+
+  if (sessionStorage.tocScroll != null) {
+    let tocScroll = JSON.parse(sessionStorage.tocScroll);
+    menu.$toc.scrollTop = tocScroll;
+    delete sessionStorage.tocScroll;
   }
 }
 
-function installFindLocalReferences () {
-  document.addEventListener('click', function (e) {
-    if (e.target.nodeName === 'VAR') {
-      toggleFindLocalReferences(e.target);
+document.addEventListener('DOMContentLoaded', loadStateFromSessionStorage);
+
+window.addEventListener('pageshow', loadStateFromSessionStorage);
+
+window.addEventListener('beforeunload', () => {
+  if (!window.sessionStorage || typeof menu === 'undefined') {
+    return;
+  }
+  sessionStorage.referencePaneState = JSON.stringify(referencePane.state || null);
+  sessionStorage.activeTocPaths = JSON.stringify(getActiveTocPaths());
+  sessionStorage.searchValue = JSON.stringify(menu.search.$searchBox.value);
+  sessionStorage.tocScroll = JSON.stringify(menu.$toc.scrollTop);
+});
+
+'use strict';
+
+// Manually prefix algorithm step list items with hidden counter representations
+// corresponding with their markers so they get selected and copied with content.
+// We read list-style-type to avoid divergence with the style sheet, but
+// for efficiency assume that all lists at the same nesting depth use the same
+// style (except for those associated with replacement steps).
+// We also precompute some initial items for each supported style type.
+// https://w3c.github.io/csswg-drafts/css-counter-styles/
+
+const lowerLetters = Array.from({ length: 26 }, (_, i) =>
+  String.fromCharCode('a'.charCodeAt(0) + i)
+);
+// Implement the lower-alpha 'alphabetic' algorithm,
+// adjusting for indexing from 0 rather than 1.
+// https://w3c.github.io/csswg-drafts/css-counter-styles/#simple-alphabetic
+// https://w3c.github.io/csswg-drafts/css-counter-styles/#alphabetic-system
+const lowerAlphaTextForIndex = i => {
+  let S = '';
+  for (const N = lowerLetters.length; i >= 0; i--) {
+    S = lowerLetters[i % N] + S;
+    i = Math.floor(i / N);
+  }
+  return S;
+};
+
+const weightedLowerRomanSymbols = Object.entries({
+  m: 1000,
+  cm: 900,
+  d: 500,
+  cd: 400,
+  c: 100,
+  xc: 90,
+  l: 50,
+  xl: 40,
+  x: 10,
+  ix: 9,
+  v: 5,
+  iv: 4,
+  i: 1,
+});
+// Implement the lower-roman 'additive' algorithm,
+// adjusting for indexing from 0 rather than 1.
+// https://w3c.github.io/csswg-drafts/css-counter-styles/#simple-numeric
+// https://w3c.github.io/csswg-drafts/css-counter-styles/#additive-system
+const lowerRomanTextForIndex = i => {
+  let value = i + 1;
+  let S = '';
+  for (const [symbol, weight] of weightedLowerRomanSymbols) {
+    if (!value) break;
+    if (weight > value) continue;
+    const reps = Math.floor(value / weight);
+    S += symbol.repeat(reps);
+    value -= weight * reps;
+  }
+  return S;
+};
+
+// Memoize pure index-to-text functions with an exposed cache for fast retrieval.
+const makeCounter = (pureGetTextForIndex, precomputeCount = 30) => {
+  const cache = Array.from({ length: precomputeCount }, (_, i) => pureGetTextForIndex(i));
+  const getTextForIndex = i => {
+    if (i >= cache.length) cache[i] = pureGetTextForIndex(i);
+    return cache[i];
+  };
+  return { getTextForIndex, cache };
+};
+
+const counterByStyle = {
+  __proto__: null,
+  decimal: makeCounter(i => String(i + 1)),
+  'lower-alpha': makeCounter(lowerAlphaTextForIndex),
+  'upper-alpha': makeCounter(i => lowerAlphaTextForIndex(i).toUpperCase()),
+  'lower-roman': makeCounter(lowerRomanTextForIndex),
+  'upper-roman': makeCounter(i => lowerRomanTextForIndex(i).toUpperCase()),
+};
+const fallbackCounter = makeCounter(() => '?');
+const counterByDepth = [];
+
+function addStepNumberText(
+  ol,
+  depth = 0,
+  special = [...ol.classList].some(c => c.startsWith('nested-'))
+) {
+  let counter = !special && counterByDepth[depth];
+  if (!counter) {
+    const counterStyle = getComputedStyle(ol)['list-style-type'];
+    counter = counterByStyle[counterStyle];
+    if (!counter) {
+      console.warn('unsupported list-style-type', {
+        ol,
+        counterStyle,
+        id: ol.closest('[id]')?.getAttribute('id'),
+      });
+      counterByStyle[counterStyle] = fallbackCounter;
+      counter = fallbackCounter;
     }
+    if (!special) {
+      counterByDepth[depth] = counter;
+    }
+  }
+  const { cache, getTextForIndex } = counter;
+  let i = (Number(ol.getAttribute('start')) || 1) - 1;
+  for (const li of ol.children) {
+    const marker = document.createElement('span');
+    marker.textContent = `${i < cache.length ? cache[i] : getTextForIndex(i)}. `;
+    marker.setAttribute('aria-hidden', 'true');
+    li.prepend(marker);
+    for (const sublist of li.querySelectorAll(':scope > ol')) {
+      addStepNumberText(sublist, depth + 1, special);
+    }
+    i++;
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('emu-alg > ol').forEach(ol => {
+    addStepNumberText(ol);
   });
-}
+});
 
-document.addEventListener('DOMContentLoaded', installFindLocalReferences);
-</script><style>body {
+let sdoMap = JSON.parse(`{}`);
+let biblio = JSON.parse(`{"refsByClause":{},"entries":[{"type":"clause","id":"annex-implementation-dependent-behaviour","titleHTML":"Implementation Dependent Behaviour","number":"A"},{"type":"clause","id":"annex-incompatibilities","titleHTML":"Additions and Changes That Introduce Incompatibilities with Prior Editions","number":"B"}]}`);
+;let usesMultipage = false</script><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.0.1/styles/base16/solarized-light.min.css"><style>body {
   display: flex;
+  word-wrap: break-word;
   font-size: 18px;
   line-height: 1.5;
   font-family: Cambria, Palatino Linotype, Palatino, Liberation Serif, serif;
@@ -912,6 +1364,7 @@ document.addEventListener('DOMContentLoaded', installFindLocalReferences);
   flex-basis: 66%;
   box-sizing: border-box;
   overflow: hidden;
+  padding-bottom: 1em;
 }
 
 body.oldtoc {
@@ -919,8 +1372,8 @@ body.oldtoc {
 }
 
 a {
-    text-decoration: none;
-    color: #206ca7;
+  text-decoration: none;
+  color: #206ca7;
 }
 
 a:visited {
@@ -928,15 +1381,51 @@ a:visited {
 }
 
 a:hover {
-    text-decoration: underline;
-    color: #239dee;
+  text-decoration: underline;
+  color: #239dee;
 }
 
+a.e-user-code,
+span.e-user-code {
+  white-space: nowrap;
+}
+
+a.e-user-code::before,
+span.e-user-code::before {
+  display: none;
+  color: brown;
+  background-color: white;
+  border: 2pt solid brown;
+  padding: 0.3ex;
+  margin: 0 0.25em 0 0;
+  line-height: 1;
+  vertical-align: text-top;
+  text-transform: uppercase;
+  font-family: 'Comic Code', sans-serif;
+  font-weight: 900;
+  font-size: x-small;
+}
+
+a.e-user-code:hover::before,
+span.e-user-code:hover::before {
+  background-color: brown;
+  color: white;
+}
+
+html.show-ao-annotations a.e-user-code::before,
+html.show-ao-annotations span.e-user-code::before {
+  display: inline-block;
+}
+
+a.e-user-code::before,
+span.e-user-code::before {
+  content: 'UC';
+}
 
 code {
-    font-weight: bold;
-    font-family: Consolas, Monaco, monospace;
-    white-space: pre;
+  font-weight: bold;
+  font-family: Consolas, Monaco, monospace;
+  white-space: pre;
 }
 
 pre code {
@@ -950,13 +1439,13 @@ pre code.hljs {
 }
 
 ol.toc {
-    list-style: none;
-    padding-left: 0;
+  list-style: none;
+  padding-left: 0;
 }
 
 ol.toc ol.toc {
-    padding-left: 2ex;
-    list-style: none;
+  padding-left: 2ex;
+  list-style: none;
 }
 
 var {
@@ -965,8 +1454,40 @@ var {
   cursor: pointer;
 }
 
-var.referenced {
+var.referenced0 {
+  color: inherit;
   background-color: #ffff33;
+  box-shadow: 0 0 0 2px #ffff33;
+}
+var.referenced1 {
+  color: inherit;
+  background-color: #ff87a2;
+  box-shadow: 0 0 0 2px #ff87a2;
+}
+var.referenced2 {
+  color: inherit;
+  background-color: #96e885;
+  box-shadow: 0 0 0 2px #96e885;
+}
+var.referenced3 {
+  color: inherit;
+  background-color: #3eeed2;
+  box-shadow: 0 0 0 2px #3eeed2;
+}
+var.referenced4 {
+  color: inherit;
+  background-color: #eacfb6;
+  box-shadow: 0 0 0 2px #eacfb6;
+}
+var.referenced5 {
+  color: inherit;
+  background-color: #82ddff;
+  box-shadow: 0 0 0 2px #82ddff;
+}
+var.referenced6 {
+  color: inherit;
+  background-color: #ffbcf2;
+  box-shadow: 0 0 0 2px #ffbcf2;
 }
 
 emu-const {
@@ -1015,6 +1536,10 @@ emu-alg ol.nested-lots ol {
   list-style-type: lower-roman;
 }
 
+emu-alg [aria-hidden=true] {
+  font-size: 0;
+}
+
 emu-eqn {
   display: block;
   margin-left: 4em;
@@ -1030,29 +1555,32 @@ emu-eqn div:first-child {
 }
 
 emu-note {
-    margin: 1em 0;
-    color: #666;
-    border-left: 5px solid #ccc;
-    display: flex;
-    flex-direction: row;
+  margin: 1em 0;
+  display: flex;
+  flex-direction: row;
+  color: inherit;
+  border-left: 5px solid #52e052;
+  background: #e9fbe9;
+  padding: 10px 10px 10px 0;
 }
 
 emu-note > span.note {
-    flex-basis: 100px;
-    min-width: 100px;
-    flex-grow: 0;
-    flex-shrink: 1;
-    text-transform: uppercase;
-    padding-left: 5px;
+  flex-basis: 100px;
+  min-width: 100px;
+  flex-grow: 0;
+  flex-shrink: 1;
+  text-transform: uppercase;
+  padding-left: 5px;
 }
 
-emu-note[type=editor] {
+emu-note[type='editor'] {
   border-left-color: #faa;
 }
 
 emu-note > div.note-contents {
   flex-grow: 1;
   flex-shrink: 1;
+  overflow: auto;
 }
 
 emu-note > div.note-contents > p:first-of-type {
@@ -1063,9 +1591,9 @@ emu-note > div.note-contents > p:last-of-type {
   margin-bottom: 0;
 }
 
-emu-table td code {
+emu-table:not(.code) td code {
   white-space: normal;
-} 
+}
 
 emu-figure {
   display: block;
@@ -1090,99 +1618,120 @@ emu-table figure {
 }
 
 emu-production {
-    display: block;
+  display: block;
 }
 
-emu-grammar[type="example"] emu-production,
-emu-grammar[type="definition"] emu-production {
-    margin-top: 1em;
-    margin-bottom: 1em;
-    margin-left: 5ex;
+emu-grammar[type='example'] emu-production,
+emu-grammar[type='definition'] emu-production {
+  margin-top: 1em;
+  margin-bottom: 1em;
+  margin-left: 5ex;
 }
 
-emu-grammar.inline, emu-production.inline,
-emu-grammar.inline emu-production emu-rhs, emu-production.inline emu-rhs,
-emu-grammar[collapsed] emu-production emu-rhs, emu-production[collapsed] emu-rhs {
-    display: inline;
-    padding-left: 1ex;
-    margin-left: 0;
+emu-grammar.inline,
+emu-production.inline,
+emu-grammar.inline emu-production emu-rhs,
+emu-production.inline emu-rhs,
+emu-grammar[collapsed] emu-production emu-rhs {
+  display: inline;
+  padding-left: 1ex;
+  margin-left: 0;
 }
 
-emu-grammar[collapsed] emu-production, emu-production[collapsed] {
-    margin: 0;
+emu-production[collapsed] emu-rhs {
+  display: inline;
+  padding-left: 0.5ex;
+  margin-left: 0;
+}
+
+emu-grammar[collapsed] emu-production,
+emu-production[collapsed] {
+  margin: 0;
 }
 
 emu-constraints {
-    font-size: .75em;
-    margin-right: 1ex;
+  font-size: 0.75em;
+  margin-right: 0.5ex;
 }
 
 emu-gann {
-    margin-right: 1ex;
+  margin-right: 0.5ex;
 }
 
 emu-gann emu-t:last-child,
 emu-gann emu-gprose:last-child,
 emu-gann emu-nt:last-child {
-    margin-right: 0;
+  margin-right: 0;
 }
 
 emu-geq {
-    margin-left: 1ex;
-    font-weight: bold;
+  margin-left: 0.5ex;
+  font-weight: bold;
 }
 
 emu-oneof {
-    font-weight: bold;
-    margin-left: 1ex;
+  font-weight: bold;
+  margin-left: 0.5ex;
 }
 
 emu-nt {
-    display: inline-block;
-    font-style: italic;
-    white-space: nowrap;
-    text-indent: 0;
+  display: inline-block;
+  font-style: italic;
+  white-space: nowrap;
+  text-indent: 0;
 }
 
-emu-nt a, emu-nt a:visited {
+emu-nt a,
+emu-nt a:visited {
   color: #333;
 }
 
 emu-rhs emu-nt {
-    margin-right: 1ex;
+  margin-right: 0.5ex;
 }
 
 emu-t {
-    display: inline-block;
-    font-family: monospace;
-    font-weight: bold;
-    white-space: nowrap;
-    text-indent: 0;
+  display: inline-block;
+  font-family: monospace;
+  font-weight: bold;
+  white-space: nowrap;
+  text-indent: 0;
 }
 
 emu-production emu-t {
-    margin-right: 1ex;
+  margin-right: 0.5ex;
 }
 
 emu-rhs {
-    display: block;
-    padding-left: 75px;
-    text-indent: -25px;
+  display: block;
+  padding-left: 75px;
+  text-indent: -25px;
+}
+
+emu-production:not([collapsed]) emu-rhs {
+  border: 0.2ex dashed transparent;
+}
+
+emu-production:not([collapsed]) emu-rhs:hover {
+  border-color: #888;
+  background-color: #f0f0f0;
 }
 
 emu-mods {
-    font-size: .85em;
-    vertical-align: sub;
-    font-style: normal;
-    font-weight: normal;
+  font-size: 0.85em;
+  vertical-align: sub;
+  font-style: normal;
+  font-weight: normal;
 }
 
-emu-params, emu-opt {
+emu-params,
+emu-opt {
   margin-right: 1ex;
   font-family: monospace;
 }
 
-emu-params, emu-constraints {
+emu-params,
+emu-constraints {
   color: #2aa198;
 }
 
@@ -1191,12 +1740,12 @@ emu-opt {
 }
 
 emu-gprose {
-    font-size: 0.9em;
-    font-family: Helvetica, Arial, sans-serif;
+  font-size: 0.9em;
+  font-family: Helvetica, Arial, sans-serif;
 }
 
 emu-production emu-gprose {
-    margin-right: 1ex;
+  margin-right: 1ex;
 }
 
 h1.shortname {
@@ -1208,20 +1757,19 @@ h1.shortname {
 h1.version {
   color: #f60;
   font-size: 1.5em;
-  margin: 0;
 }
 
 h1.title {
-  margin-top: 0;
   color: #f60;
 }
 
-h1.first {
-  margin-top: 0;
-}
-
-h1, h2, h3, h4, h5, h6 {
-    position: relative;
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  position: relative;
 }
 
 h1 .secnum {
@@ -1233,142 +1781,267 @@ h1 span.title {
   order: 2;
 }
 
+h1 {
+  font-size: 2.67em;
+  margin-bottom: 0;
+  line-height: 1em;
+}
+h2 {
+  font-size: 2em;
+}
+h3 {
+  font-size: 1.56em;
+}
+h4 {
+  font-size: 1.25em;
+}
+h5 {
+  font-size: 1.11em;
+}
+h6 {
+  font-size: 1em;
+}
 
-h1 { font-size: 2.67em; margin-top: 2em; margin-bottom: 0; line-height: 1em;}
-h2 { font-size: 2em; }
-h3 { font-size: 1.56em; }
-h4 { font-size: 1.25em; }
-h5 { font-size: 1.11em; }
-h6 { font-size: 1em; }
+pre code.hljs {
+  background: transparent;
+}
 
-h1:hover span.utils {
+emu-clause[id],
+emu-annex[id],
+emu-intro[id] {
+  scroll-margin-top: 2ex;
+}
+
+emu-intro h1,
+emu-clause h1,
+emu-annex h1 {
+  font-size: 2em;
+}
+emu-intro h2,
+emu-clause h2,
+emu-annex h2 {
+  font-size: 1.56em;
+}
+emu-intro h3,
+emu-clause h3,
+emu-annex h3 {
+  font-size: 1.25em;
+}
+emu-intro h4,
+emu-clause h4,
+emu-annex h4 {
+  font-size: 1.11em;
+}
+emu-intro h5,
+emu-clause h5,
+emu-annex h5 {
+  font-size: 1em;
+}
+emu-intro h6,
+emu-clause h6,
+emu-annex h6 {
+  font-size: 0.9em;
+}
+emu-intro emu-intro h1,
+emu-clause emu-clause h1,
+emu-annex emu-annex h1 {
+  font-size: 1.56em;
+}
+emu-intro emu-intro h2,
+emu-clause emu-clause h2,
+emu-annex emu-annex h2 {
+  font-size: 1.25em;
+}
+emu-intro emu-intro h3,
+emu-clause emu-clause h3,
+emu-annex emu-annex h3 {
+  font-size: 1.11em;
+}
+emu-intro emu-intro h4,
+emu-clause emu-clause h4,
+emu-annex emu-annex h4 {
+  font-size: 1em;
+}
+emu-intro emu-intro h5,
+emu-clause emu-clause h5,
+emu-annex emu-annex h5 {
+  font-size: 0.9em;
+}
+emu-intro emu-intro emu-intro h1,
+emu-clause emu-clause emu-clause h1,
+emu-annex emu-annex emu-annex h1 {
+  font-size: 1.25em;
+}
+emu-intro emu-intro emu-intro h2,
+emu-clause emu-clause emu-clause h2,
+emu-annex emu-annex emu-annex h2 {
+  font-size: 1.11em;
+}
+emu-intro emu-intro emu-intro h3,
+emu-clause emu-clause emu-clause h3,
+emu-annex emu-annex emu-annex h3 {
+  font-size: 1em;
+}
+emu-intro emu-intro emu-intro h4,
+emu-clause emu-clause emu-clause h4,
+emu-annex emu-annex emu-annex h4 {
+  font-size: 0.9em;
+}
+emu-intro emu-intro emu-intro emu-intro h1,
+emu-clause emu-clause emu-clause emu-clause h1,
+emu-annex emu-annex emu-annex emu-annex h1 {
+  font-size: 1.11em;
+}
+emu-intro emu-intro emu-intro emu-intro h2,
+emu-clause emu-clause emu-clause emu-clause h2,
+emu-annex emu-annex emu-annex emu-annex h2 {
+  font-size: 1em;
+}
+emu-intro emu-intro emu-intro emu-intro h3,
+emu-clause emu-clause emu-clause emu-clause h3,
+emu-annex emu-annex emu-annex emu-annex h3 {
+  font-size: 0.9em;
+}
+emu-intro emu-intro emu-intro emu-intro emu-intro h1,
+emu-clause emu-clause emu-clause emu-clause emu-clause h1,
+emu-annex emu-annex emu-annex emu-annex emu-annex h1 {
+  font-size: 1em;
+}
+emu-intro emu-intro emu-intro emu-intro emu-intro h2,
+emu-clause emu-clause emu-clause emu-clause emu-clause h2,
+emu-annex emu-annex emu-annex emu-annex emu-annex h2 {
+  font-size: 0.9em;
+}
+emu-intro emu-intro emu-intro emu-intro emu-intro emu-intro h1,
+emu-clause emu-clause emu-clause emu-clause emu-clause emu-clause h1,
+emu-annex emu-annex emu-annex emu-annex emu-annex emu-annex h1 {
+  font-size: 0.9em;
+}
+
+emu-clause,
+emu-intro,
+emu-annex {
   display: block;
 }
 
-span.utils {
-  font-size: 18px;
-  line-height: 18px;
-  display: none;
-  position: absolute;
-  top: 100%;
-  left: 0;
-  right: 0;
-  font-weight: normal;
+/* these values are twice the font-size for the <h1> titles for clauses */
+emu-intro,
+emu-clause,
+emu-annex {
+  margin-top: 4em;
+}
+emu-intro emu-intro,
+emu-clause emu-clause,
+emu-annex emu-annex {
+  margin-top: 3.12em;
+}
+emu-intro emu-intro emu-intro,
+emu-clause emu-clause emu-clause,
+emu-annex emu-annex emu-annex {
+  margin-top: 2.5em;
+}
+emu-intro emu-intro emu-intro emu-intro,
+emu-clause emu-clause emu-clause emu-clause,
+emu-annex emu-annex emu-annex emu-annex {
+  margin-top: 2.22em;
+}
+emu-intro emu-intro emu-intro emu-intro emu-intro,
+emu-clause emu-clause emu-clause emu-clause emu-clause,
+emu-annex emu-annex emu-annex emu-annex emu-annex {
+  margin-top: 2em;
+}
+emu-intro emu-intro emu-intro emu-intro emu-intro emu-intro,
+emu-clause emu-clause emu-clause emu-clause emu-clause emu-clause,
+emu-annex emu-annex emu-annex emu-annex emu-annex emu-annex {
+  margin-top: 1.8em;
 }
 
-span.utils:before {
-    content: "⤷";
-    display: inline-block;
-    padding: 0 5px;
-}
-
-span.utils > * {
-  display: inline-block;
-  margin-right: 20px;
-}
-
-h1 span.utils span.anchor a,
-h2 span.utils span.anchor a,
-h3 span.utils span.anchor a,
-h4 span.utils span.anchor a,
-h5 span.utils span.anchor a,
-h6 span.utils span.anchor a {
-  text-decoration: none;
-  font-variant: small-caps;
-}
-
-h1 span.utils span.anchor a:hover,
-h2 span.utils span.anchor a:hover,
-h3 span.utils span.anchor a:hover,
-h4 span.utils span.anchor a:hover,
-h5 span.utils span.anchor a:hover,
-h6 span.utils span.anchor a:hover {
-  color: #333;
-}
-
-emu-intro h1, emu-clause h1, emu-annex h1 { font-size: 2em; }
-emu-intro h2, emu-clause h2, emu-annex h2 { font-size: 1.56em; }
-emu-intro h3, emu-clause h3, emu-annex h3 { font-size: 1.25em; }
-emu-intro h4, emu-clause h4, emu-annex h4 { font-size: 1.11em; }
-emu-intro h5, emu-clause h5, emu-annex h5 { font-size: 1em; }
-emu-intro h6, emu-clause h6, emu-annex h6 { font-size: 0.9em; }
-emu-intro emu-intro h1, emu-clause emu-clause h1, emu-annex emu-annex h1 { font-size: 1.56em; }
-emu-intro emu-intro h2, emu-clause emu-clause h2, emu-annex emu-annex h2 { font-size: 1.25em; }
-emu-intro emu-intro h3, emu-clause emu-clause h3, emu-annex emu-annex h3 { font-size: 1.11em; }
-emu-intro emu-intro h4, emu-clause emu-clause h4, emu-annex emu-annex h4 { font-size: 1em; }
-emu-intro emu-intro h5, emu-clause emu-clause h5, emu-annex emu-annex h5 { font-size: 0.9em; }
-emu-intro emu-intro emu-intro h1, emu-clause emu-clause emu-clause h1, emu-annex emu-annex emu-annex h1 { font-size: 1.25em; }
-emu-intro emu-intro emu-intro h2, emu-clause emu-clause emu-clause h2, emu-annex emu-annex emu-annex h2 { font-size: 1.11em; }
-emu-intro emu-intro emu-intro h3, emu-clause emu-clause emu-clause h3, emu-annex emu-annex emu-annex h3 { font-size: 1em; }
-emu-intro emu-intro emu-intro h4, emu-clause emu-clause emu-clause h4, emu-annex emu-annex emu-annex h4 { font-size: 0.9em; }
-emu-intro emu-intro emu-intro emu-intro h1, emu-clause emu-clause emu-clause emu-clause h1, emu-annex emu-annex emu-annex emu-annex h1 { font-size: 1.11em; }
-emu-intro emu-intro emu-intro emu-intro h2, emu-clause emu-clause emu-clause emu-clause h2, emu-annex emu-annex emu-annex emu-annex h2 { font-size: 1em; }
-emu-intro emu-intro emu-intro emu-intro h3, emu-clause emu-clause emu-clause emu-clause h3, emu-annex emu-annex emu-annex emu-annex h3 { font-size: 0.9em; }
-emu-intro emu-intro emu-intro emu-intro emu-intro h1, emu-clause emu-clause emu-clause emu-clause emu-clause h1, emu-annex emu-annex emu-annex emu-annex emu-annex h1 { font-size: 1em; }
-emu-intro emu-intro emu-intro emu-intro emu-intro h2, emu-clause emu-clause emu-clause emu-clause emu-clause h2, emu-annex emu-annex emu-annex emu-annex emu-annex h2 { font-size: 0.9em; }
-emu-intro emu-intro emu-intro emu-intro emu-intro emu-intro h1, emu-clause emu-clause emu-clause emu-clause emu-clause emu-clause h1, emu-annex emu-annex emu-annex emu-annex emu-annex emu-annex h1 { font-size: 0.9em }
-
-emu-clause, emu-intro, emu-annex {
-    display: block;
+#spec-container > emu-intro:first-of-type,
+#spec-container > emu-clause:first-of-type,
+#spec-container > emu-annex:first-of-type {
+  margin-top: 0;
 }
 
 /* Figures and tables */
-figure { display: block; margin: 1em 0 3em 0; }
-figure object { display: block; margin: 0 auto; }
-figure table.real-table { margin: 0 auto; }
+figure {
+  display: block;
+  margin: 1em 0 3em 0;
+}
+figure object {
+  display: block;
+  margin: 0 auto;
+}
+figure table.real-table {
+  margin: 0 auto;
+}
 figure figcaption {
-    display: block;
-    color: #555555;
-    font-weight: bold;
-    text-align: center;
+  display: block;
+  color: #555555;
+  font-weight: bold;
+  text-align: center;
 }
 
 emu-table table {
   margin: 0 auto;
 }
 
-emu-table table, table.real-table {
-    border-collapse: collapse;
+emu-table table,
+table.real-table {
+  border-collapse: collapse;
 }
 
-emu-table td, emu-table th, table.real-table td, table.real-table th {
-    border: 1px solid black;
-    padding: 0.4em;
-    vertical-align: baseline;
+emu-table td,
+emu-table th,
+table.real-table td,
+table.real-table th {
+  border: 1px solid black;
+  padding: 0.4em;
+  vertical-align: baseline;
 }
-emu-table th, emu-table thead td, table.real-table th {
-    background-color: #eeeeee;
+emu-table th,
+emu-table thead td,
+table.real-table th {
+  background-color: #eeeeee;
+}
+
+emu-table td {
+  background: #fff;
 }
 
 /* Note: the left content edges of table.lightweight-table >tbody >tr >td
    and div.display line up. */
 table.lightweight-table {
-    border-collapse: collapse;
-    margin: 0 0 0 1.5em;
+  border-collapse: collapse;
+  margin: 0 0 0 1.5em;
 }
-table.lightweight-table td, table.lightweight-table th {
-    border: none;
-    padding: 0 0.5em;
-    vertical-align: baseline;
+table.lightweight-table td,
+table.lightweight-table th {
+  border: none;
+  padding: 0 0.5em;
+  vertical-align: baseline;
 }
 
 /* diff styles */
 ins {
-    background-color: #e0f8e0;
-    text-decoration: none;
-    border-bottom: 1px solid #396;
+  background-color: #e0f8e0;
+  text-decoration: none;
+  border-bottom: 1px solid #396;
 }
 
 del {
-    background-color: #fee;
+  background-color: #fee;
 }
 
-ins.block, del.block,
-emu-production > ins, emu-production > del,
-emu-grammar > ins, emu-grammar > del {
+ins.block,
+del.block,
+emu-production > ins,
+emu-production > del,
+emu-grammar > ins,
+emu-grammar > del {
   display: block;
 }
-emu-rhs > ins, emu-rhs > del { 
+emu-rhs > ins,
+emu-rhs > del {
   display: inline;
 }
 
@@ -1405,7 +2078,7 @@ tr.del > td {
   -khtml-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
-  user-select: none;;
+  user-select: none;
 
   cursor: pointer;
 }
@@ -1413,7 +2086,8 @@ tr.del > td {
 #menu {
   display: flex;
   flex-direction: column;
-  width: 33%; height: 100vh;
+  width: 33%;
+  height: 100vh;
   max-width: 500px;
   box-sizing: border-box;
   background-color: #ddd;
@@ -1421,13 +2095,14 @@ tr.del > td {
   transition: opacity 0.1s linear;
   padding: 0 5px;
   position: fixed;
-  left: 0; top: 0;
+  left: 0;
+  top: 0;
   border-right: 2px solid #bbb;
 
   z-index: 2;
 }
 
-#menu-spacer {
+.menu-spacer {
   flex-basis: 33%;
   max-width: 500px;
   flex-grow: 0;
@@ -1482,7 +2157,8 @@ tr.del > td {
   padding: 0;
 }
 
-#menu-toc > ol , #menu-toc > ol ol {
+#menu-toc > ol,
+#menu-toc > ol ol {
   list-style-type: none;
   margin: 0;
   padding: 0;
@@ -1512,7 +2188,7 @@ tr.del > td {
   -khtml-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
-  user-select: none;;
+  user-select: none;
 
   cursor: pointer;
 }
@@ -1543,7 +2219,7 @@ tr.del > td {
   */
 }
 
-#menu-toc li.revealed-leaf> a {
+#menu-toc li.revealed-leaf > a {
   color: #206ca7;
   /*
   background-color: #222;
@@ -1579,6 +2255,34 @@ tr.del > td {
   font-size: 0.8em;
 }
 
+.menu-pane-header emu-opt,
+.menu-pane-header emu-t,
+.menu-pane-header emu-nt {
+  margin-right: 0px;
+  display: inline;
+  color: inherit;
+}
+
+.menu-pane-header emu-rhs {
+  display: inline;
+  padding-left: 0px;
+  text-indent: 0px;
+}
+
+.menu-pane-header emu-geq {
+  margin-left: 0px;
+}
+
+a.menu-pane-header-production {
+  color: inherit;
+}
+
+.menu-pane-header-production {
+  text-transform: none;
+  letter-spacing: 1.5px;
+  padding-left: 0.5em;
+}
+
 #menu-toc {
   display: flex;
   flex-direction: column;
@@ -1597,10 +2301,10 @@ tr.del > td {
   flex-grow: 0;
   flex-shrink: 0;
   width: 100%;
-  
+
   display: flex;
   flex-direction: column;
-  
+
   max-height: 300px;
 }
 
@@ -1625,43 +2329,42 @@ tr.del > td {
 }
 
 li.menu-search-result-clause:before {
-    content: 'clause';
-    width: 40px;
-    display: inline-block;
-    text-align: right;
-    padding-right: 1ex;
-    color: #666;
-    font-size: 75%;
+  content: 'clause';
+  width: 40px;
+  display: inline-block;
+  text-align: right;
+  padding-right: 1ex;
+  color: #666;
+  font-size: 75%;
 }
 li.menu-search-result-op:before {
-    content: 'op';
-    width: 40px;
-    display: inline-block;
-    text-align: right;
-    padding-right: 1ex;
-    color: #666;
-    font-size: 75%;
+  content: 'op';
+  width: 40px;
+  display: inline-block;
+  text-align: right;
+  padding-right: 1ex;
+  color: #666;
+  font-size: 75%;
 }
 
 li.menu-search-result-prod:before {
-    content: 'prod';
-    width: 40px;
-    display: inline-block;
-    text-align: right;
-    padding-right: 1ex;
-    color: #666;
-    font-size: 75%
+  content: 'prod';
+  width: 40px;
+  display: inline-block;
+  text-align: right;
+  padding-right: 1ex;
+  color: #666;
+  font-size: 75%;
 }
 
-
 li.menu-search-result-term:before {
-    content: 'term';
-    width: 40px;
-    display: inline-block;
-    text-align: right;
-    padding-right: 1ex;
-    color: #666;
-    font-size: 75%
+  content: 'term';
+  width: 40px;
+  display: inline-block;
+  text-align: right;
+  padding-right: 1ex;
+  color: #666;
+  font-size: 75%;
 }
 
 #menu-search-results ul {
@@ -1674,7 +2377,6 @@ li.menu-search-result-term:before {
   text-overflow: ellipsis;
 }
 
-
 #menu-trace-list {
   counter-reset: item;
   margin: 0 0 0 20px;
@@ -1686,19 +2388,19 @@ li.menu-search-result-term:before {
 }
 
 #menu-trace-list li .secnum:after {
-  content: " ";
+  content: ' ';
 }
 #menu-trace-list li:before {
-    content: counter(item) " ";
-    background-color: #222;
-    counter-increment: item;
-    color: #999;
-    width: 20px;
-    height: 20px;
-    line-height: 20px;
-    display: inline-block;
-    text-align: center;
-    margin: 2px 4px 2px 0;
+  content: counter(item) ' ';
+  background-color: #222;
+  counter-increment: item;
+  color: #999;
+  width: 20px;
+  height: 20px;
+  line-height: 20px;
+  display: inline-block;
+  text-align: center;
+  margin: 2px 4px 2px 0;
 }
 
 @media (max-width: 1000px) {
@@ -1740,24 +2442,29 @@ li.menu-search-result-term:before {
   }
 
   h1 .secnum:empty {
-    margin: 0; padding: 0;
+    margin: 0;
+    padding: 0;
   }
 }
 
-
 /* Toolbox */
-.toolbox {
-	position: absolute;
-	background: #ddd;
-	border: 1px solid #aaa;
+.toolbox-container {
+  position: absolute;
   display: none;
+  padding-bottom: 7px;
+}
+
+.toolbox-container.active {
+  display: inline-block;
+}
+
+.toolbox {
+  position: relative;
+  background: #ddd;
+  border: 1px solid #aaa;
   color: #eee;
   padding: 5px;
   border-radius: 3px;
-}
-
-.toolbox.active {
-  display: inline-block;
 }
 
 .toolbox a {
@@ -1769,28 +2476,29 @@ li.menu-search-result-term:before {
   text-decoration: underline;
 }
 
-.toolbox:after, .toolbox:before {
-	top: 100%;
-	left: 15px;
-	border: solid transparent;
-	content: " ";
-	height: 0;
-	width: 0;
-	position: absolute;
-	pointer-events: none;
+.toolbox:after,
+.toolbox:before {
+  top: 100%;
+  left: 15px;
+  border: solid transparent;
+  content: ' ';
+  height: 0;
+  width: 0;
+  position: absolute;
+  pointer-events: none;
 }
 
 .toolbox:after {
-	border-color: rgba(0, 0, 0, 0);
-	border-top-color: #ddd;
-	border-width: 10px;
-	margin-left: -10px;
+  border-color: rgba(0, 0, 0, 0);
+  border-top-color: #ddd;
+  border-width: 10px;
+  margin-left: -10px;
 }
 .toolbox:before {
-	border-color: rgba(204, 204, 204, 0);
-	border-top-color: #aaa;
-	border-width: 12px;
-	margin-left: -12px;
+  border-color: rgba(204, 204, 204, 0);
+  border-top-color: #aaa;
+  border-width: 12px;
+  margin-left: -12px;
 }
 
 #references-pane-container {
@@ -1807,11 +2515,6 @@ li.menu-search-result-term:before {
 #references-pane-table-container {
   overflow-x: hidden;
   overflow-y: auto;
-}
-
-#references-pane-spacer {
-  flex-basis: 33%;
-  max-width: 500px;
 }
 
 #references-pane {
@@ -1831,6 +2534,10 @@ li.menu-search-result-term:before {
   cursor: pointer;
 }
 
+#references-pane table tbody {
+  vertical-align: baseline;
+}
+
 #references-pane table tr td:first-child {
   text-align: right;
   padding-right: 5px;
@@ -1838,11 +2545,78 @@ li.menu-search-result-term:before {
 
 @media print {
   #menu-toggle {
-    display: none; 
+    display: none;
   }
 }
-</style></head><body><div id="menu-toggle">☰</div><div id="menu-spacer"></div><div id="menu"><div id="menu-search"><input type="text" id="menu-search-box" placeholder="Search..."><div id="menu-search-results" class="inactive"></div></div><div id="menu-pins"><div class="menu-pane-header">Pins</div><ul id="menu-pins-list"></ul></div><div class="menu-pane-header">Table of Contents</div><div id="menu-toc"><ol class="toc"><li><span class="item-toggle-none"></span><a href="#annex-implementation-dependent-behaviour" title="Implementation Dependent Behaviour"><span class="secnum">A</span> Implementation Dependent Behaviour</a></li><li><span class="item-toggle-none"></span><a href="#annex-incompatibilities" title="Additions and Changes That Introduce Incompatibilities with Prior Editions"><span class="secnum">B</span> Additions and Changes That Introduce Incompatibilities with Prior Editions</a></li></ol></div></div><div id="spec-container"><emu-annex id="annex-implementation-dependent-behaviour">
-  <h1 class="first"><span class="secnum">A</span> Implementation Dependent Behaviour</h1>
+
+[normative-optional],
+[legacy] {
+  border-left: 5px solid #ff6600;
+  padding: 0.5em;
+  display: block;
+  background: #ffeedd;
+}
+
+.clause-attributes-tag {
+  text-transform: uppercase;
+  color: #884400;
+}
+
+.clause-attributes-tag a {
+  color: #884400;
+}
+
+/* Shortcuts help dialog */
+
+#shortcuts-help {
+  position: fixed;
+  left: 5%;
+  margin: 0 auto;
+  right: 5%;
+  z-index: 10;
+  top: 10%;
+  top: calc(5vw + 5vh);
+  padding: 30px 90px;
+  max-width: 500px;
+  outline: solid 10000px rgba(255, 255, 255, 0.6);
+  border-radius: 5px;
+  border-width: 1px 1px 0 1px;
+  background-color: #ddd;
+  display: none;
+}
+
+#shortcuts-help.active {
+  display: block;
+}
+
+#shortcuts-help ul {
+  padding: 0;
+}
+
+#shortcuts-help li {
+  display: flex;
+  justify-content: space-between;
+}
+
+#shortcuts-help code {
+  padding: 3px 10px;
+  border-radius: 3px;
+  border-width: 1px 1px 0 1px;
+  border-color: #bbb;
+  background-color: #eee;
+  box-shadow: inset 0 -1px 0 #ccc;
+}
+</style></head><body><div id="shortcuts-help">
+<ul>
+  <li><span>Toggle shortcuts help</span><code>?</code></li>
+  <li><span>Toggle "can call user code" annotations</span><code>u</code></li>
+
+  <li><span>Jump to search box</span><code>/</code></li>
+</ul></div><div id="menu-toggle"><svg xmlns="http://www.w3.org/2000/svg" style="width:100%; height:100%; stroke:currentColor" viewBox="0 0 120 120">
+      <title>Menu</title>
+      <path stroke-width="10" stroke-linecap="round" d="M30,60 h60  M30,30 m0,5 h60  M30,90 m0,-5 h60"></path>
+    </svg></div><div id="menu-spacer" class="menu-spacer"></div><div id="menu"><div id="menu-search"><input type="text" id="menu-search-box" placeholder="Search..."><div id="menu-search-results" class="inactive"></div></div><div id="menu-pins"><div class="menu-pane-header">Pins</div><ul id="menu-pins-list"></ul></div><div class="menu-pane-header">Table of Contents</div><div id="menu-toc"><ol class="toc"><li><span class="item-toggle-none"></span><a href="#annex-implementation-dependent-behaviour" title="Implementation Dependent Behaviour"><span class="secnum">A</span> Implementation Dependent Behaviour</a></li><li><span class="item-toggle-none"></span><a href="#annex-incompatibilities" title="Additions and Changes That Introduce Incompatibilities with Prior Editions"><span class="secnum">B</span> Additions and Changes That Introduce Incompatibilities with Prior Editions</a></li></ol></div></div><div id="spec-container"><emu-annex id="annex-implementation-dependent-behaviour">
+  <h1><span class="secnum">A</span> Implementation Dependent Behaviour</h1>
 
   <p>
     The following aspects of the ECMAScript 2023 Internationalization API Specification are implementation dependent:
@@ -1862,7 +2636,7 @@ li.menu-search-result-term:before {
           The default time zone (<emu-xref href="#sup-defaulttimezone"></emu-xref>)
         </li>
         <li>
-          The set of available locales for each <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> (<emu-xref href="#sec-internal-slots"></emu-xref>)
+          The set of available locales for each constructor (<emu-xref href="#sec-internal-slots"></emu-xref>)
         </li>
         <li>
           The BestFitMatcher algorithm (<emu-xref href="#sec-bestfitmatcher"></emu-xref>)
@@ -2000,7 +2774,7 @@ li.menu-search-result-term:before {
       In PluralRules:
       <ul>
         <li>
-          <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> of Strings representing the possible results of plural selection and their corresponding order per locale. (<emu-xref href="#sec-initializepluralrules"></emu-xref>)
+          List of Strings representing the possible results of plural selection and their corresponding order per locale. (<emu-xref href="#sec-initializepluralrules"></emu-xref>)
         </li>
         <ins class="block">
         <li>
@@ -2045,7 +2819,7 @@ li.menu-search-result-term:before {
       <emu-xref href="#sec-the-intl-collator-constructor"></emu-xref>, <emu-xref href="#sec-intl-numberformat-constructor"></emu-xref>, <emu-xref href="#sec-intl-datetimeformat-constructor"></emu-xref> In ECMA-402, 1<sup>st</sup> Edition, constructors could be used to create Intl objects from arbitrary objects. This is no longer possible in 2nd Edition.
     </li>
     <li>
-      <emu-xref href="#sec-intl.datetimeformat.prototype.format"></emu-xref> In ECMA-402, 1<sup>st</sup> Edition, the <emu-val>"length"</emu-val> property of the <emu-xref href="#function-object"><a href="https://tc39.es/ecma262/#function-object">function object</a></emu-xref> <var>F</var> was set to <emu-val>+0</emu-val><sub>𝔽</sub>. In 2nd Edition, <emu-val>"length"</emu-val> is set to <emu-val>1</emu-val><sub>𝔽</sub>.
+      <emu-xref href="#sec-intl.datetimeformat.prototype.format"></emu-xref> In ECMA-402, 1<sup>st</sup> Edition, the <emu-val>"length"</emu-val> property of the function object <var>F</var> was set to <emu-val>+0</emu-val><sub>𝔽</sub>. In 2nd Edition, <emu-val>"length"</emu-val> is set to <emu-val>1</emu-val><sub>𝔽</sub>.
     </li>
     <li>
       <emu-xref href="#sec-intl.collator.prototype-@@tostringtag"></emu-xref> In ECMA-402, 7<sup></sup>th Edition, the @@toStringTag property of <code>Intl.Collator.prototype</code> was set to <emu-val>"Object"</emu-val>. In 8<sup>th</sup> Edition, @@toStringTag is set to <emu-val>"Intl.Collator"</emu-val>.
@@ -2063,7 +2837,7 @@ li.menu-search-result-term:before {
       <emu-xref href="#sec-Intl-toStringTag"></emu-xref> In ECMA-402, 7<sup>th</sup> Edition, the @@toStringTag property of <code>Intl</code> was not defined. In 8<sup>th</sup> Edition, @@toStringTag is set to <emu-val>"Intl"</emu-val>.
     </li>
     <li>
-      <emu-xref href="#sec-intl-numberformat-constructor"></emu-xref> In ECMA-402, 8<sup>th</sup> Edition, the NumberFormat <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> used to throw an error when style is <emu-val>"currency"</emu-val> and maximumFractionDigits was set to a value lower than the default fractional digits for that currency. This behaviour was corrected in the 9<sup>th</sup> edition, and it no longer throws an error.
+      <emu-xref href="#sec-intl-numberformat-constructor"></emu-xref> In ECMA-402, 8<sup>th</sup> Edition, the NumberFormat constructor used to throw an error when style is <emu-val>"currency"</emu-val> and maximumFractionDigits was set to a value lower than the default fractional digits for that currency. This behaviour was corrected in the 9<sup>th</sup> edition, and it no longer throws an error.
     </li>
   </ul>
 </emu-annex>

--- a/out/annexes/proposed.html
+++ b/out/annexes/proposed.html
@@ -1,6 +1,88 @@
 <!doctype html>
-<head><meta charset="utf-8"><script type="application/json" id="menu-search-biblio">[{"type":"clause","id":"annex-implementation-dependent-behaviour","aoid":null,"title":"Implementation Dependent Behaviour","titleHTML":"Implementation Dependent Behaviour","number":"A","namespace":"<no location>","location":"","referencingIds":[],"key":"Implementation Dependent Behaviour"},{"type":"clause","id":"annex-incompatibilities","aoid":null,"title":"Additions and Changes That Introduce Incompatibilities with Prior Editions","titleHTML":"Additions and Changes That Introduce Incompatibilities with Prior Editions","number":"B","namespace":"<no location>","location":"","referencingIds":[],"key":"Additions and Changes That Introduce Incompatibilities with Prior Editions"}]</script><script>"use strict";
+<head><meta charset="utf-8"><script>'use strict';
+let sdoBox = {
+  init() {
+    this.$alternativeId = null;
+    this.$outer = document.createElement('div');
+    this.$outer.classList.add('toolbox-container');
+    this.$container = document.createElement('div');
+    this.$container.classList.add('toolbox');
+    this.$displayLink = document.createElement('a');
+    this.$displayLink.setAttribute('href', '#');
+    this.$displayLink.textContent = 'Syntax-Directed Operations';
+    this.$displayLink.addEventListener('click', e => {
+      e.preventDefault();
+      e.stopPropagation();
+      referencePane.showSDOs(sdoMap[this.$alternativeId] || {}, this.$alternativeId);
+    });
+    this.$container.appendChild(this.$displayLink);
+    this.$outer.appendChild(this.$container);
+    document.body.appendChild(this.$outer);
+  },
 
+  activate(el) {
+    clearTimeout(this.deactiveTimeout);
+    Toolbox.deactivate();
+    this.$alternativeId = el.id;
+    let numSdos = Object.keys(sdoMap[this.$alternativeId] || {}).length;
+    this.$displayLink.textContent = 'Syntax-Directed Operations (' + numSdos + ')';
+    this.$outer.classList.add('active');
+    let top = el.offsetTop - this.$outer.offsetHeight;
+    let left = el.offsetLeft + 50 - 10; // 50px = padding-left(=75px) + text-indent(=-25px)
+    this.$outer.setAttribute('style', 'left: ' + left + 'px; top: ' + top + 'px');
+    if (top < document.body.scrollTop) {
+      this.$container.scrollIntoView();
+    }
+  },
+
+  deactivate() {
+    clearTimeout(this.deactiveTimeout);
+    this.$outer.classList.remove('active');
+  },
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+  if (typeof sdoMap == 'undefined') {
+    console.error('could not find sdo map');
+    return;
+  }
+  sdoBox.init();
+
+  let insideTooltip = false;
+  sdoBox.$outer.addEventListener('pointerenter', () => {
+    insideTooltip = true;
+  });
+  sdoBox.$outer.addEventListener('pointerleave', () => {
+    insideTooltip = false;
+    sdoBox.deactivate();
+  });
+
+  sdoBox.deactiveTimeout = null;
+  [].forEach.call(document.querySelectorAll('emu-grammar[type=definition] emu-rhs'), node => {
+    node.addEventListener('pointerenter', function () {
+      sdoBox.activate(this);
+    });
+
+    node.addEventListener('pointerleave', () => {
+      sdoBox.deactiveTimeout = setTimeout(() => {
+        if (!insideTooltip) {
+          sdoBox.deactivate();
+        }
+      }, 500);
+    });
+  });
+
+  document.addEventListener(
+    'keydown',
+    debounce(e => {
+      if (e.code === 'Escape') {
+        sdoBox.deactivate();
+      }
+    })
+  );
+});
+
+'use strict';
 function Search(menu) {
   this.menu = menu;
   this.$search = document.getElementById('menu-search');
@@ -11,8 +93,14 @@ function Search(menu) {
 
   document.addEventListener('keydown', this.documentKeydown.bind(this));
 
-  this.$searchBox.addEventListener('keydown', debounce(this.searchBoxKeydown.bind(this), { stopPropagation: true }));
-  this.$searchBox.addEventListener('keyup', debounce(this.searchBoxKeyup.bind(this), { stopPropagation: true }));
+  this.$searchBox.addEventListener(
+    'keydown',
+    debounce(this.searchBoxKeydown.bind(this), { stopPropagation: true })
+  );
+  this.$searchBox.addEventListener(
+    'keyup',
+    debounce(this.searchBoxKeyup.bind(this), { stopPropagation: true })
+  );
 
   // Perform an initial search if the box is not empty.
   if (this.$searchBox.value) {
@@ -21,26 +109,34 @@ function Search(menu) {
 }
 
 Search.prototype.loadBiblio = function () {
-  var $biblio = document.getElementById('menu-search-biblio');
-  if (!$biblio) {
-    this.biblio = [];
+  if (typeof biblio === 'undefined') {
+    console.error('could not find biblio');
+    this.biblio = { refToClause: {}, entries: [] };
   } else {
-    this.biblio = JSON.parse($biblio.textContent);
-    this.biblio.clauses = this.biblio.filter(function (e) { return e.type === 'clause' });
-    this.biblio.byId = this.biblio.reduce(function (map, entry) {
+    this.biblio = biblio;
+    this.biblio.clauses = this.biblio.entries.filter(e => e.type === 'clause');
+    this.biblio.byId = this.biblio.entries.reduce((map, entry) => {
       map[entry.id] = entry;
       return map;
     }, {});
+    let refParentClause = Object.create(null);
+    this.biblio.refParentClause = refParentClause;
+    let refsByClause = this.biblio.refsByClause;
+    Object.keys(refsByClause).forEach(clause => {
+      refsByClause[clause].forEach(ref => {
+        refParentClause[ref] = clause;
+      });
+    });
   }
-}
+};
 
 Search.prototype.documentKeydown = function (e) {
-  if (e.keyCode === 191) {
+  if (e.key === '/') {
     e.preventDefault();
     e.stopPropagation();
     this.triggerSearch();
   }
-}
+};
 
 Search.prototype.searchBoxKeydown = function (e) {
   e.stopPropagation();
@@ -51,7 +147,7 @@ Search.prototype.searchBoxKeydown = function (e) {
     e.preventDefault();
     this.selectResult();
   }
-}
+};
 
 Search.prototype.searchBoxKeyup = function (e) {
   if (e.keyCode === 13 || e.keyCode === 9) {
@@ -59,10 +155,9 @@ Search.prototype.searchBoxKeyup = function (e) {
   }
 
   this.search(e.target.value);
-}
+};
 
-
-Search.prototype.triggerSearch = function (e) {
+Search.prototype.triggerSearch = function () {
   if (this.menu.isVisible()) {
     this._closeAfterSearch = false;
   } else {
@@ -72,14 +167,14 @@ Search.prototype.triggerSearch = function (e) {
 
   this.$searchBox.focus();
   this.$searchBox.select();
-}
+};
 // bit 12 - Set if the result starts with searchString
 // bits 8-11: 8 - number of chunks multiplied by 2 if cases match, otherwise 1.
 // bits 1-7: 127 - length of the entry
 // General scheme: prefer case sensitive matches with fewer chunks, and otherwise
 // prefer shorter matches.
-function relevance(result, searchString) {
-  var relevance = 0;
+function relevance(result) {
+  let relevance = 0;
 
   relevance = Math.max(0, 8 - result.match.chunks) << 7;
 
@@ -88,10 +183,10 @@ function relevance(result, searchString) {
   }
 
   if (result.match.prefix) {
-    relevance += 2048
+    relevance += 2048;
   }
 
-  relevance += Math.max(0, 255 - result.entry.key.length);
+  relevance += Math.max(0, 255 - result.key.length);
 
   return relevance;
 }
@@ -110,36 +205,34 @@ Search.prototype.search = function (searchString) {
     return;
   }
 
-  var results;
+  let results;
 
-  if (/^[\d\.]*$/.test(searchString)) {
-    results = this.biblio.clauses.filter(function (clause) {
-      return clause.number.substring(0, searchString.length) === searchString;
-    }).map(function (clause) {
-      return { entry: clause };
-    });
+  if (/^[\d.]*$/.test(searchString)) {
+    results = this.biblio.clauses
+      .filter(clause => clause.number.substring(0, searchString.length) === searchString)
+      .map(clause => ({ key: getKey(clause), entry: clause }));
   } else {
     results = [];
 
-    for (var i = 0; i < this.biblio.length; i++) {
-      var entry = this.biblio[i];
-      if (!entry.key) {
+    for (let i = 0; i < this.biblio.entries.length; i++) {
+      let entry = this.biblio.entries[i];
+      let key = getKey(entry);
+      if (!key) {
         // biblio entries without a key aren't searchable
         continue;
       }
 
-      var match = fuzzysearch(searchString, entry.key);
+      let match = fuzzysearch(searchString, key);
       if (match) {
-        results.push({ entry: entry, match: match });
+        results.push({ key, entry, match });
       }
     }
 
-    results.forEach(function (result) {
+    results.forEach(result => {
       result.relevance = relevance(result, searchString);
     });
 
-    results = results.sort(function (a, b) { return b.relevance - a.relevance });
-
+    results = results.sort((a, b) => b.relevance - a.relevance);
   }
 
   if (results.length > 50) {
@@ -147,17 +240,17 @@ Search.prototype.search = function (searchString) {
   }
 
   this.displayResults(results);
-}
+};
 Search.prototype.hideSearch = function () {
   this.$search.classList.remove('active');
-}
+};
 
 Search.prototype.showSearch = function () {
   this.$search.classList.add('active');
-}
+};
 
 Search.prototype.selectResult = function () {
-  var $first = this.$searchResults.querySelector('li:first-child a');
+  let $first = this.$searchResults.querySelector('li:first-child a');
 
   if ($first) {
     document.location = $first.getAttribute('href');
@@ -171,53 +264,79 @@ Search.prototype.selectResult = function () {
   if (this._closeAfterSearch) {
     this.menu.hide();
   }
-}
+};
 
 Search.prototype.displayResults = function (results) {
   if (results.length > 0) {
     this.$searchResults.classList.remove('no-results');
 
-    var html = '<ul>';
+    let html = '<ul>';
 
-    results.forEach(function (result) {
-      var entry = result.entry;
-      var id = entry.id;
-      var cssClass = '';
-      var text = '';
+    results.forEach(result => {
+      let key = result.key;
+      let entry = result.entry;
+      let id = entry.id;
+      let cssClass = '';
+      let text = '';
 
       if (entry.type === 'clause') {
-        var number = entry.number ? entry.number + ' ' : '';
-        text = number + entry.key;
+        let number = entry.number ? entry.number + ' ' : '';
+        text = number + key;
         cssClass = 'clause';
         id = entry.id;
       } else if (entry.type === 'production') {
-        text = entry.key;
+        text = key;
         cssClass = 'prod';
         id = entry.id;
       } else if (entry.type === 'op') {
-        text = entry.key;
+        text = key;
         cssClass = 'op';
         id = entry.id || entry.refId;
       } else if (entry.type === 'term') {
-        text = entry.key;
+        text = key;
         cssClass = 'term';
         id = entry.id || entry.refId;
       }
 
       if (text) {
-        html += '<li class=menu-search-result-' + cssClass + '><a href="#' + id + '">' + text + '</a></li>';
+        // prettier-ignore
+        html += `<li class=menu-search-result-${cssClass}><a href="${makeLinkToId(id)}">${text}</a></li>`;
       }
     });
 
-    html += '</ul>'
+    html += '</ul>';
 
     this.$searchResults.innerHTML = html;
   } else {
     this.$searchResults.innerHTML = '';
     this.$searchResults.classList.add('no-results');
   }
-}
+};
 
+function getKey(item) {
+  if (item.key) {
+    return item.key;
+  }
+  switch (item.type) {
+    case 'clause':
+      return item.title || item.titleHTML;
+    case 'production':
+      return item.name;
+    case 'op':
+      return item.aoid;
+    case 'term':
+      return item.term;
+    case 'table':
+    case 'figure':
+    case 'example':
+    case 'note':
+      return item.caption;
+    case 'step':
+      return item.id;
+    default:
+      throw new Error("Can't get key for " + item.type);
+  }
+}
 
 function Menu() {
   this.$toggle = document.getElementById('menu-toggle');
@@ -229,7 +348,7 @@ function Menu() {
   this.$specContainer = document.getElementById('spec-container');
   this.search = new Search(this);
 
-  this._pinnedIds = {}; 
+  this._pinnedIds = {};
   this.loadPinEntries();
 
   // toggle menu
@@ -239,23 +358,23 @@ function Menu() {
   document.addEventListener('keydown', this.documentKeydown.bind(this));
 
   // toc expansion
-  var tocItems = this.$menu.querySelectorAll('#menu-toc li');
-  for (var i = 0; i < tocItems.length; i++) {
-    var $item = tocItems[i];
-    $item.addEventListener('click', function($item, event) {
+  let tocItems = this.$menu.querySelectorAll('#menu-toc li');
+  for (let i = 0; i < tocItems.length; i++) {
+    let $item = tocItems[i];
+    $item.addEventListener('click', event => {
       $item.classList.toggle('active');
       event.stopPropagation();
-    }.bind(null, $item));
+    });
   }
 
   // close toc on toc item selection
-  var tocLinks = this.$menu.querySelectorAll('#menu-toc li > a');
-  for (var i = 0; i < tocLinks.length; i++) {
-    var $link = tocLinks[i];
-    $link.addEventListener('click', function(event) {
+  let tocLinks = this.$menu.querySelectorAll('#menu-toc li > a');
+  for (let i = 0; i < tocLinks.length; i++) {
+    let $link = tocLinks[i];
+    $link.addEventListener('click', event => {
       this.toggle();
       event.stopPropagation();
-    }.bind(this));
+    });
   }
 
   // update active clause on scroll
@@ -263,14 +382,13 @@ function Menu() {
   this.updateActiveClause();
 
   // prevent menu scrolling from scrolling the body
-  this.$toc.addEventListener('wheel', function (e) {
-    var target = e.currentTarget;
-    var offTop = e.deltaY < 0 && target.scrollTop === 0;
+  this.$toc.addEventListener('wheel', e => {
+    let target = e.currentTarget;
+    let offTop = e.deltaY < 0 && target.scrollTop === 0;
     if (offTop) {
       e.preventDefault();
     }
-    var offBottom = e.deltaY > 0
-                    && target.offsetHeight + target.scrollTop >= target.scrollHeight;
+    let offBottom = e.deltaY > 0 && target.offsetHeight + target.scrollTop >= target.scrollHeight;
 
     if (offBottom) {
       e.preventDefault();
@@ -285,62 +403,66 @@ Menu.prototype.documentKeydown = function (e) {
   } else if (e.keyCode > 48 && e.keyCode < 58) {
     this.selectPin(e.keyCode - 49);
   }
-}
+};
 
 Menu.prototype.updateActiveClause = function () {
-  this.setActiveClause(findActiveClause(this.$specContainer))
-}
+  this.setActiveClause(findActiveClause(this.$specContainer));
+};
 
 Menu.prototype.setActiveClause = function (clause) {
   this.$activeClause = clause;
   this.revealInToc(this.$activeClause);
-}
+};
 
 Menu.prototype.revealInToc = function (path) {
-  var current = this.$toc.querySelectorAll('li.revealed');
-  for (var i = 0; i < current.length; i++) {
+  let current = this.$toc.querySelectorAll('li.revealed');
+  for (let i = 0; i < current.length; i++) {
     current[i].classList.remove('revealed');
     current[i].classList.remove('revealed-leaf');
   }
 
-  var current = this.$toc;
-  var index = 0;
-  while (index < path.length) {
-    var children = current.children;
-    for (var i = 0; i < children.length; i++) {
-      if ('#' + path[index].id === children[i].children[1].getAttribute('href') ) {
+  current = this.$toc;
+  let index = 0;
+  outer: while (index < path.length) {
+    let children = current.children;
+    for (let i = 0; i < children.length; i++) {
+      if ('#' + path[index].id === children[i].children[1].hash) {
         children[i].classList.add('revealed');
         if (index === path.length - 1) {
           children[i].classList.add('revealed-leaf');
-          var rect = children[i].getBoundingClientRect();
+          let rect = children[i].getBoundingClientRect();
           // this.$toc.getBoundingClientRect().top;
-          var tocRect = this.$toc.getBoundingClientRect();
+          let tocRect = this.$toc.getBoundingClientRect();
           if (rect.top + 10 > tocRect.bottom) {
-            this.$toc.scrollTop = this.$toc.scrollTop + (rect.top - tocRect.bottom) + (rect.bottom - rect.top);
+            this.$toc.scrollTop =
+              this.$toc.scrollTop + (rect.top - tocRect.bottom) + (rect.bottom - rect.top);
           } else if (rect.top < tocRect.top) {
             this.$toc.scrollTop = this.$toc.scrollTop - (tocRect.top - rect.top);
           }
         }
         current = children[i].querySelector('ol');
         index++;
-        break;
+        continue outer;
       }
     }
-
+    console.log('could not find location in table of contents', path);
+    break;
   }
-}
+};
 
 function findActiveClause(root, path) {
-  var clauses = new ClauseWalker(root);
-  var $clause;
-  var path = path || [];
+  let clauses = getChildClauses(root);
+  path = path || [];
 
-  while ($clause = clauses.nextNode()) {
-    var rect = $clause.getBoundingClientRect();
-    var $header = $clause.querySelector("h1");
-    var marginTop = parseInt(getComputedStyle($header)["margin-top"]);
+  for (let $clause of clauses) {
+    let rect = $clause.getBoundingClientRect();
+    let $header = $clause.querySelector('h1');
+    let marginTop = Math.max(
+      parseInt(getComputedStyle($clause)['margin-top']),
+      parseInt(getComputedStyle($header)['margin-top'])
+    );
 
-    if ((rect.top - marginTop) <= 0 && rect.bottom > 0) {
+    if (rect.top - marginTop <= 1 && rect.bottom > 0) {
       return findActiveClause($clause, path.concat($clause)) || path;
     }
   }
@@ -348,57 +470,49 @@ function findActiveClause(root, path) {
   return path;
 }
 
-function ClauseWalker(root) {
-  var previous;
-  var treeWalker = document.createTreeWalker(
-    root,
-    NodeFilter.SHOW_ELEMENT,
-    {
-      acceptNode: function (node) {
-        if (previous === node.parentNode) {
-          return NodeFilter.FILTER_REJECT;
-        } else {
-          previous = node;
-        }
-        if (node.nodeName === 'EMU-CLAUSE' || node.nodeName === 'EMU-INTRO' || node.nodeName === 'EMU-ANNEX') {
-          return NodeFilter.FILTER_ACCEPT;
-        } else {
-          return NodeFilter.FILTER_SKIP;
-        }
-      }
-    },
-    false
-    );
+function* getChildClauses(root) {
+  for (let el of root.children) {
+    switch (el.nodeName) {
+      // descend into <emu-import>
+      case 'EMU-IMPORT':
+        yield* getChildClauses(el);
+        break;
 
-  return treeWalker;
+      // accept <emu-clause>, <emu-intro>, and <emu-annex>
+      case 'EMU-CLAUSE':
+      case 'EMU-INTRO':
+      case 'EMU-ANNEX':
+        yield el;
+    }
+  }
 }
 
 Menu.prototype.toggle = function () {
   this.$menu.classList.toggle('active');
-}
+};
 
 Menu.prototype.show = function () {
   this.$menu.classList.add('active');
-}
+};
 
 Menu.prototype.hide = function () {
   this.$menu.classList.remove('active');
-}
+};
 
-Menu.prototype.isVisible = function() {
+Menu.prototype.isVisible = function () {
   return this.$menu.classList.contains('active');
-}
+};
 
 Menu.prototype.showPins = function () {
   this.$pins.classList.add('active');
-}
+};
 
 Menu.prototype.hidePins = function () {
   this.$pins.classList.remove('active');
-}
+};
 
 Menu.prototype.addPinEntry = function (id) {
-  var entry = this.search.biblio.byId[id];
+  let entry = this.search.biblio.byId[id];
   if (!entry) {
     // id was deleted after pin (or something) so remove it
     delete this._pinnedIds[id];
@@ -407,15 +521,16 @@ Menu.prototype.addPinEntry = function (id) {
   }
 
   if (entry.type === 'clause') {
-    var prefix;
+    let prefix;
     if (entry.number) {
       prefix = entry.number + ' ';
     } else {
       prefix = '';
     }
-    this.$pinList.innerHTML += '<li><a href="#' + entry.id + '">' + prefix + entry.titleHTML + '</a></li>';
+    // prettier-ignore
+    this.$pinList.innerHTML += `<li><a href="${makeLinkToId(entry.id)}">${prefix}${entry.titleHTML}</a></li>`;
   } else {
-    this.$pinList.innerHTML += '<li><a href="#' + entry.id + '">' + entry.key + '</a></li>';
+    this.$pinList.innerHTML += `<li><a href="${makeLinkToId(entry.id)}">${getKey(entry)}</a></li>`;
   }
 
   if (Object.keys(this._pinnedIds).length === 0) {
@@ -423,10 +538,10 @@ Menu.prototype.addPinEntry = function (id) {
   }
   this._pinnedIds[id] = true;
   this.persistPinEntries();
-}
+};
 
 Menu.prototype.removePinEntry = function (id) {
-  var item = this.$pinList.querySelector('a[href="#' + id + '"]').parentNode;
+  let item = this.$pinList.querySelector(`a[href="${makeLinkToId(id)}"]`).parentNode;
   this.$pinList.removeChild(item);
   delete this._pinnedIds[id];
   if (Object.keys(this._pinnedIds).length === 0) {
@@ -434,7 +549,7 @@ Menu.prototype.removePinEntry = function (id) {
   }
 
   this.persistPinEntries();
-}
+};
 
 Menu.prototype.persistPinEntries = function () {
   try {
@@ -444,7 +559,7 @@ Menu.prototype.persistPinEntries = function () {
   }
 
   localStorage.pinEntries = JSON.stringify(Object.keys(this._pinnedIds));
-}
+};
 
 Menu.prototype.loadPinEntries = function () {
   try {
@@ -453,13 +568,13 @@ Menu.prototype.loadPinEntries = function () {
     return;
   }
 
-  var pinsString = window.localStorage.pinEntries;
+  let pinsString = window.localStorage.pinEntries;
   if (!pinsString) return;
-  var pins = JSON.parse(pinsString);
-  for(var i = 0; i < pins.length; i++) {
+  let pins = JSON.parse(pinsString);
+  for (let i = 0; i < pins.length; i++) {
     this.addPinEntry(pins[i]);
   }
-}
+};
 
 Menu.prototype.togglePinEntry = function (id) {
   if (!id) {
@@ -471,62 +586,49 @@ Menu.prototype.togglePinEntry = function (id) {
   } else {
     this.addPinEntry(id);
   }
-}
+};
 
 Menu.prototype.selectPin = function (num) {
   document.location = this.$pinList.children[num].children[0].href;
-}
+};
 
-var menu;
-function init() {
-  menu = new Menu();
-  var $container = document.getElementById('spec-container');
-  $container.addEventListener('mouseover', debounce(function (e) {
-    Toolbox.activateIfMouseOver(e);
-  }));
-  document.addEventListener('keydown', debounce(function (e) {
-    if (e.code === "Escape" && Toolbox.active) {
-      Toolbox.deactivate();
-    }
-  }));
-}
+let menu;
 
 document.addEventListener('DOMContentLoaded', init);
 
 function debounce(fn, opts) {
   opts = opts || {};
-  var timeout;
-  return function(e) {
+  let timeout;
+  return function (e) {
     if (opts.stopPropagation) {
       e.stopPropagation();
     }
-    var args = arguments;
+    let args = arguments;
     if (timeout) {
       clearTimeout(timeout);
     }
-    timeout = setTimeout(function() {
+    timeout = setTimeout(() => {
       timeout = null;
       fn.apply(this, args);
-    }.bind(this), 150);
-  }
+    }, 150);
+  };
 }
 
-var CLAUSE_NODES = ['EMU-CLAUSE', 'EMU-INTRO', 'EMU-ANNEX'];
-function findLocalReferences ($elem) {
-  var name = $elem.innerHTML;
-  var references = [];
-
-  var parentClause = $elem.parentNode;
+let CLAUSE_NODES = ['EMU-CLAUSE', 'EMU-INTRO', 'EMU-ANNEX'];
+function findContainer($elem) {
+  let parentClause = $elem.parentNode;
   while (parentClause && CLAUSE_NODES.indexOf(parentClause.nodeName) === -1) {
     parentClause = parentClause.parentNode;
   }
+  return parentClause;
+}
 
-  if(!parentClause) return;
+function findLocalReferences(parentClause, name) {
+  let vars = parentClause.querySelectorAll('var');
+  let references = [];
 
-  var vars = parentClause.querySelectorAll('var');
-
-  for (var i = 0; i < vars.length; i++) {
-    var $var = vars[i];
+  for (let i = 0; i < vars.length; i++) {
+    let $var = vars[i];
 
     if ($var.innerHTML === name) {
       references.push($var);
@@ -536,21 +638,38 @@ function findLocalReferences ($elem) {
   return references;
 }
 
+let REFERENCED_CLASSES = Array.from({ length: 7 }, (x, i) => `referenced${i}`);
+function chooseHighlightIndex(parentClause) {
+  let counts = REFERENCED_CLASSES.map($class => parentClause.getElementsByClassName($class).length);
+  // Find the earliest index with the lowest count.
+  let minCount = Infinity;
+  let index = null;
+  for (let i = 0; i < counts.length; i++) {
+    if (counts[i] < minCount) {
+      minCount = counts[i];
+      index = i;
+    }
+  }
+  return index;
+}
+
 function toggleFindLocalReferences($elem) {
-  var references = findLocalReferences($elem);
+  let parentClause = findContainer($elem);
+  let references = findLocalReferences(parentClause, $elem.innerHTML);
   if ($elem.classList.contains('referenced')) {
-    references.forEach(function ($reference) {
-      $reference.classList.remove('referenced');
+    references.forEach($reference => {
+      $reference.classList.remove('referenced', ...REFERENCED_CLASSES);
     });
   } else {
-    references.forEach(function ($reference) {
-      $reference.classList.add('referenced');
+    let index = chooseHighlightIndex(parentClause);
+    references.forEach($reference => {
+      $reference.classList.add('referenced', `referenced${index}`);
     });
   }
 }
 
-function installFindLocalReferences () {
-  document.addEventListener('click', function (e) {
+function installFindLocalReferences() {
+  document.addEventListener('click', e => {
     if (e.target.nodeName === 'VAR') {
       toggleFindLocalReferences(e.target);
     }
@@ -558,9 +677,6 @@ function installFindLocalReferences () {
 }
 
 document.addEventListener('DOMContentLoaded', installFindLocalReferences);
-
-
-
 
 // The following license applies to the fuzzysearch function
 // The MIT License (MIT)
@@ -582,11 +698,11 @@ document.addEventListener('DOMContentLoaded', installFindLocalReferences);
 // COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-function fuzzysearch (searchString, haystack, caseInsensitive) {
-  var tlen = haystack.length;
-  var qlen = searchString.length;
-  var chunks = 1;
-  var finding = false;
+function fuzzysearch(searchString, haystack, caseInsensitive) {
+  let tlen = haystack.length;
+  let qlen = searchString.length;
+  let chunks = 1;
+  let finding = false;
 
   if (qlen > tlen) {
     return false;
@@ -602,10 +718,11 @@ function fuzzysearch (searchString, haystack, caseInsensitive) {
     }
   }
 
-  outer: for (var i = 0, j = 0; i < qlen; i++) {
-    var nch = searchString[i];
+  let j = 0;
+  outer: for (let i = 0; i < qlen; i++) {
+    let nch = searchString[i];
     while (j < tlen) {
-      var targetChar = haystack[j++];
+      let targetChar = haystack[j++];
       if (targetChar === nch) {
         finding = true;
         continue outer;
@@ -616,113 +733,24 @@ function fuzzysearch (searchString, haystack, caseInsensitive) {
       }
     }
 
-    if (caseInsensitive) { return false; }
+    if (caseInsensitive) {
+      return false;
+    }
 
     return fuzzysearch(searchString.toLowerCase(), haystack.toLowerCase(), true);
   }
 
-  return { caseMatch: !caseInsensitive, chunks: chunks, prefix: j <= qlen };
+  return { caseMatch: !caseInsensitive, chunks, prefix: j <= qlen };
 }
 
-var Toolbox = {
-  init: function () {
-    this.$container = document.createElement('div');
-    this.$container.classList.add('toolbox');
-    this.$permalink = document.createElement('a');
-    this.$permalink.textContent = 'Permalink';
-    this.$pinLink = document.createElement('a');
-    this.$pinLink.textContent = 'Pin';
-    this.$pinLink.setAttribute('href', '#');
-    this.$pinLink.addEventListener('click', function (e) {
-      e.preventDefault();
-      e.stopPropagation();
-      menu.togglePinEntry(this.entry.id);
-    }.bind(this));
-
-    this.$refsLink = document.createElement('a');
-    this.$refsLink.setAttribute('href', '#');
-    this.$refsLink.addEventListener('click', function (e) {
-      e.preventDefault();
-      e.stopPropagation();
-      referencePane.showReferencesFor(this.entry);
-    }.bind(this));
-    this.$container.appendChild(this.$permalink);
-    this.$container.appendChild(this.$pinLink);
-    this.$container.appendChild(this.$refsLink);
-    document.body.appendChild(this.$container);
-  },
-
-  activate: function (el, entry, target) {
-    if (el === this._activeEl) return;
-    this.active = true;
-    this.entry = entry;
-    this.$container.classList.add('active');
-    this.top = el.offsetTop - this.$container.offsetHeight - 10;
-    this.left = el.offsetLeft;
-    this.$container.setAttribute('style', 'left: ' + this.left + 'px; top: ' + this.top + 'px');
-    this.updatePermalink();
-    this.updateReferences();
-    this._activeEl = el;
-    if (this.top < document.body.scrollTop && el === target) {
-      // don't scroll unless it's a small thing (< 200px)
-      this.$container.scrollIntoView();
-    }
-  },
-
-  updatePermalink: function () {
-    this.$permalink.setAttribute('href', '#' + this.entry.id);
-  },
-
-  updateReferences: function () {
-    this.$refsLink.textContent = 'References (' + this.entry.referencingIds.length + ')';
-  },
-
-  activateIfMouseOver: function (e) {
-    var ref = this.findReferenceUnder(e.target);
-    if (ref && (!this.active || e.pageY > this._activeEl.offsetTop)) {
-      var entry = menu.search.biblio.byId[ref.id];
-      this.activate(ref.element, entry, e.target);
-    } else if (this.active && ((e.pageY < this.top) || e.pageY > (this._activeEl.offsetTop + this._activeEl.offsetHeight))) {
-      this.deactivate();
-    }
-  },
-
-  findReferenceUnder: function (el) {
-    while (el) {
-      var parent = el.parentNode;
-      if (el.nodeName === 'H1' && parent.nodeName.match(/EMU-CLAUSE|EMU-ANNEX|EMU-INTRO/) && parent.id) {
-        return { element: el, id: parent.id };
-      } else if (el.nodeName.match(/EMU-(?!CLAUSE|XREF|ANNEX|INTRO)|DFN/) &&
-                el.id && el.id[0] !== '_') {
-        if (el.nodeName === 'EMU-FIGURE' || el.nodeName === 'EMU-TABLE' || el.nodeName === 'EMU-EXAMPLE') {
-          // return the figcaption element
-          return { element: el.children[0].children[0], id: el.id };
-        } else if (el.nodeName === 'EMU-PRODUCTION') {
-          // return the LHS non-terminal element
-          return { element: el.children[0], id: el.id };
-        } else {
-          return { element: el, id: el.id };
-        }
-      }
-      el = parent;
-    }
-  },
-
-  deactivate: function () {
-    this.$container.classList.remove('active');
-    this._activeEl = null;
-    this.activeElBounds = null;
-    this.active = false;
-  }
-}
-
-var referencePane = {
-  init: function() {
+let referencePane = {
+  init() {
     this.$container = document.createElement('div');
     this.$container.setAttribute('id', 'references-pane-container');
 
-    var $spacer = document.createElement('div');
+    let $spacer = document.createElement('div');
     $spacer.setAttribute('id', 'references-pane-spacer');
+    $spacer.classList.add('menu-spacer');
 
     this.$pane = document.createElement('div');
     this.$pane.setAttribute('id', 'references-pane');
@@ -732,18 +760,19 @@ var referencePane = {
 
     this.$header = document.createElement('div');
     this.$header.classList.add('menu-pane-header');
-    this.$header.textContent = 'References to ';
+    this.$headerText = document.createElement('span');
+    this.$header.appendChild(this.$headerText);
     this.$headerRefId = document.createElement('a');
     this.$header.appendChild(this.$headerRefId);
     this.$closeButton = document.createElement('span');
     this.$closeButton.setAttribute('id', 'references-pane-close');
-    this.$closeButton.addEventListener('click', function (e) {
+    this.$closeButton.addEventListener('click', () => {
       this.deactivate();
-    }.bind(this));
+    });
     this.$header.appendChild(this.$closeButton);
 
     this.$pane.appendChild(this.$header);
-    var tableContainer = document.createElement('div');
+    let tableContainer = document.createElement('div');
     tableContainer.setAttribute('id', 'references-pane-table-container');
 
     this.$table = document.createElement('table');
@@ -757,70 +786,238 @@ var referencePane = {
     menu.$specContainer.appendChild(this.$container);
   },
 
-  activate: function () {
+  activate() {
     this.$container.classList.add('active');
   },
 
-  deactivate: function () {
+  deactivate() {
     this.$container.classList.remove('active');
+    this.state = null;
   },
 
   showReferencesFor(entry) {
     this.activate();
-    var newBody = document.createElement('tbody');
-    var previousId;
-    var previousCell;
-    var dupCount = 0;
+    this.state = { type: 'ref', id: entry.id };
+    this.$headerText.textContent = 'References to ';
+    let newBody = document.createElement('tbody');
+    let previousId;
+    let previousCell;
+    let dupCount = 0;
     this.$headerRefId.textContent = '#' + entry.id;
-    this.$headerRefId.setAttribute('href', '#' + entry.id);
-    entry.referencingIds.map(function (id) {
-      var target = document.getElementById(id);
-      var cid = findParentClauseId(target);
-      var clause = menu.search.biblio.byId[cid];
-      return { id: id, clause: clause }
-    }).sort(function (a, b) {
-      return sortByClauseNumber(a.clause, b.clause);
-    }).forEach(function (record, i) {
-      if (previousId === record.clause.id) {
-        previousCell.innerHTML += ' (<a href="#' + record.id + '">' + (dupCount + 2) + '</a>)';
-        dupCount++;
-      } else {
-        var row = newBody.insertRow();
-        var cell = row.insertCell();
-        cell.innerHTML = record.clause.number;
-        cell = row.insertCell();
-        cell.innerHTML = '<a href="#' + record.id + '">' + record.clause.titleHTML + '</a>';
-        previousCell = cell;
-        previousId = record.clause.id;
-        dupCount = 0;
-      }
-    }, this);
+    this.$headerRefId.setAttribute('href', makeLinkToId(entry.id));
+    this.$headerRefId.style.display = 'inline';
+    (entry.referencingIds || [])
+      .map(id => {
+        let cid = menu.search.biblio.refParentClause[id];
+        let clause = menu.search.biblio.byId[cid];
+        if (clause == null) {
+          throw new Error('could not find clause for id ' + cid);
+        }
+        return { id, clause };
+      })
+      .sort((a, b) => sortByClauseNumber(a.clause, b.clause))
+      .forEach(record => {
+        if (previousId === record.clause.id) {
+          previousCell.innerHTML += ` (<a href="${makeLinkToId(record.id)}">${dupCount + 2}</a>)`;
+          dupCount++;
+        } else {
+          let row = newBody.insertRow();
+          let cell = row.insertCell();
+          cell.innerHTML = record.clause.number;
+          cell = row.insertCell();
+          cell.innerHTML = `<a href="${makeLinkToId(record.id)}">${record.clause.titleHTML}</a>`;
+          previousCell = cell;
+          previousId = record.clause.id;
+          dupCount = 0;
+        }
+      }, this);
     this.$table.removeChild(this.$tableBody);
     this.$tableBody = newBody;
     this.$table.appendChild(this.$tableBody);
-  }
-}
-function findParentClauseId(node) {
-  while (node && node.nodeName !== 'EMU-CLAUSE' && node.nodeName !== 'EMU-INTRO' && node.nodeName !== 'EMU-ANNEX') {
-    node = node.parentNode;
-  }
-  if (!node) return null;
-  return node.getAttribute('id');
-}
+  },
 
-function sortByClauseNumber(c1, c2) {
-  var c1c = c1.number.split('.');
-  var c2c = c2.number.split('.');
+  showSDOs(sdos, alternativeId) {
+    let rhs = document.getElementById(alternativeId);
+    let parentName = rhs.parentNode.getAttribute('name');
+    let colons = rhs.parentNode.querySelector('emu-geq');
+    rhs = rhs.cloneNode(true);
+    rhs.querySelectorAll('emu-params,emu-constraints').forEach(e => {
+      e.remove();
+    });
+    rhs.querySelectorAll('[id]').forEach(e => {
+      e.removeAttribute('id');
+    });
+    rhs.querySelectorAll('a').forEach(e => {
+      e.parentNode.replaceChild(document.createTextNode(e.textContent), e);
+    });
 
-  for (var i = 0; i < c1c.length; i++) {
+    // prettier-ignore
+    this.$headerText.innerHTML = `Syntax-Directed Operations for<br><a href="${makeLinkToId(alternativeId)}" class="menu-pane-header-production"><emu-nt>${parentName}</emu-nt> ${colons.outerHTML} </a>`;
+    this.$headerText.querySelector('a').append(rhs);
+    this.showSDOsBody(sdos, alternativeId);
+  },
+
+  showSDOsBody(sdos, alternativeId) {
+    this.activate();
+    this.state = { type: 'sdo', id: alternativeId, html: this.$headerText.innerHTML };
+    this.$headerRefId.style.display = 'none';
+    let newBody = document.createElement('tbody');
+    Object.keys(sdos).forEach(sdoName => {
+      let pair = sdos[sdoName];
+      let clause = pair.clause;
+      let ids = pair.ids;
+      let first = ids[0];
+      let row = newBody.insertRow();
+      let cell = row.insertCell();
+      cell.innerHTML = clause;
+      cell = row.insertCell();
+      let html = '<a href="' + makeLinkToId(first) + '">' + sdoName + '</a>';
+      for (let i = 1; i < ids.length; ++i) {
+        html += ' (<a href="' + makeLinkToId(ids[i]) + '">' + (i + 1) + '</a>)';
+      }
+      cell.innerHTML = html;
+    });
+    this.$table.removeChild(this.$tableBody);
+    this.$tableBody = newBody;
+    this.$table.appendChild(this.$tableBody);
+  },
+};
+
+let Toolbox = {
+  init() {
+    this.$outer = document.createElement('div');
+    this.$outer.classList.add('toolbox-container');
+    this.$container = document.createElement('div');
+    this.$container.classList.add('toolbox');
+    this.$outer.appendChild(this.$container);
+    this.$permalink = document.createElement('a');
+    this.$permalink.textContent = 'Permalink';
+    this.$pinLink = document.createElement('a');
+    this.$pinLink.textContent = 'Pin';
+    this.$pinLink.setAttribute('href', '#');
+    this.$pinLink.addEventListener('click', e => {
+      e.preventDefault();
+      e.stopPropagation();
+      menu.togglePinEntry(this.entry.id);
+      this.$pinLink.textContent = menu._pinnedIds[this.entry.id] ? 'Unpin' : 'Pin';
+    });
+
+    this.$refsLink = document.createElement('a');
+    this.$refsLink.setAttribute('href', '#');
+    this.$refsLink.addEventListener('click', e => {
+      e.preventDefault();
+      e.stopPropagation();
+      referencePane.showReferencesFor(this.entry);
+    });
+    this.$container.appendChild(this.$permalink);
+    this.$container.appendChild(this.$pinLink);
+    this.$container.appendChild(this.$refsLink);
+    document.body.appendChild(this.$outer);
+  },
+
+  activate(el, entry, target) {
+    if (el === this._activeEl) return;
+    sdoBox.deactivate();
+    this.active = true;
+    this.entry = entry;
+    this.$pinLink.textContent = menu._pinnedIds[entry.id] ? 'Unpin' : 'Pin';
+    this.$outer.classList.add('active');
+    this.top = el.offsetTop - this.$outer.offsetHeight;
+    this.left = el.offsetLeft - 10;
+    this.$outer.setAttribute('style', 'left: ' + this.left + 'px; top: ' + this.top + 'px');
+    this.updatePermalink();
+    this.updateReferences();
+    this._activeEl = el;
+    if (this.top < document.body.scrollTop && el === target) {
+      // don't scroll unless it's a small thing (< 200px)
+      this.$outer.scrollIntoView();
+    }
+  },
+
+  updatePermalink() {
+    this.$permalink.setAttribute('href', makeLinkToId(this.entry.id));
+  },
+
+  updateReferences() {
+    this.$refsLink.textContent = `References (${(this.entry.referencingIds || []).length})`;
+  },
+
+  activateIfMouseOver(e) {
+    let ref = this.findReferenceUnder(e.target);
+    if (ref && (!this.active || e.pageY > this._activeEl.offsetTop)) {
+      let entry = menu.search.biblio.byId[ref.id];
+      this.activate(ref.element, entry, e.target);
+    } else if (
+      this.active &&
+      (e.pageY < this.top || e.pageY > this._activeEl.offsetTop + this._activeEl.offsetHeight)
+    ) {
+      this.deactivate();
+    }
+  },
+
+  findReferenceUnder(el) {
+    while (el) {
+      let parent = el.parentNode;
+      if (el.nodeName === 'EMU-RHS' || el.nodeName === 'EMU-PRODUCTION') {
+        return null;
+      }
+      if (
+        el.nodeName === 'H1' &&
+        parent.nodeName.match(/EMU-CLAUSE|EMU-ANNEX|EMU-INTRO/) &&
+        parent.id
+      ) {
+        return { element: el, id: parent.id };
+      } else if (el.nodeName === 'EMU-NT') {
+        if (
+          parent.nodeName === 'EMU-PRODUCTION' &&
+          parent.id &&
+          parent.id[0] !== '_' &&
+          parent.firstElementChild === el
+        ) {
+          // return the LHS non-terminal element
+          return { element: el, id: parent.id };
+        }
+        return null;
+      } else if (
+        el.nodeName.match(/EMU-(?!CLAUSE|XREF|ANNEX|INTRO)|DFN/) &&
+        el.id &&
+        el.id[0] !== '_'
+      ) {
+        if (
+          el.nodeName === 'EMU-FIGURE' ||
+          el.nodeName === 'EMU-TABLE' ||
+          el.nodeName === 'EMU-EXAMPLE'
+        ) {
+          // return the figcaption element
+          return { element: el.children[0].children[0], id: el.id };
+        } else {
+          return { element: el, id: el.id };
+        }
+      }
+      el = parent;
+    }
+  },
+
+  deactivate() {
+    this.$outer.classList.remove('active');
+    this._activeEl = null;
+    this.active = false;
+  },
+};
+
+function sortByClauseNumber(clause1, clause2) {
+  let c1c = clause1.number.split('.');
+  let c2c = clause2.number.split('.');
+
+  for (let i = 0; i < c1c.length; i++) {
     if (i >= c2c.length) {
       return 1;
     }
 
-    var c1 = c1c[i];
-    var c2 = c2c[i];
-    var c1cn = Number(c1);
-    var c2cn = Number(c2);
+    let c1 = c1c[i];
+    let c2 = c2c[i];
+    let c1cn = Number(c1);
+    let c2cn = Number(c2);
 
     if (Number.isNaN(c1cn) && Number.isNaN(c2cn)) {
       if (c1 > c2) {
@@ -832,7 +1029,7 @@ function sortByClauseNumber(c1, c2) {
       return -1;
     } else if (Number.isNaN(c1cn) && !Number.isNaN(c2cn)) {
       return 1;
-    } else if(c1cn > c2cn) {
+    } else if (c1cn > c2cn) {
       return 1;
     } else if (c1cn < c2cn) {
       return -1;
@@ -845,59 +1042,314 @@ function sortByClauseNumber(c1, c2) {
   return -1;
 }
 
-document.addEventListener('DOMContentLoaded', function () {
+function makeLinkToId(id) {
+  let hash = '#' + id;
+  if (typeof idToSection === 'undefined' || !idToSection[id]) {
+    return hash;
+  }
+  let targetSec = idToSection[id];
+  return (targetSec === 'index' ? './' : targetSec + '.html') + hash;
+}
+
+function doShortcut(e) {
+  if (!(e.target instanceof HTMLElement)) {
+    return;
+  }
+  let target = e.target;
+  let name = target.nodeName.toLowerCase();
+  if (name === 'textarea' || name === 'input' || name === 'select' || target.isContentEditable) {
+    return;
+  }
+  if (e.altKey || e.ctrlKey || e.metaKey) {
+    return;
+  }
+  if (e.key === 'm' && usesMultipage) {
+    let pathParts = location.pathname.split('/');
+    let hash = location.hash;
+    if (pathParts[pathParts.length - 2] === 'multipage') {
+      if (hash === '') {
+        let sectionName = pathParts[pathParts.length - 1];
+        if (sectionName.endsWith('.html')) {
+          sectionName = sectionName.slice(0, -5);
+        }
+        if (idToSection['sec-' + sectionName] !== undefined) {
+          hash = '#sec-' + sectionName;
+        }
+      }
+      location = pathParts.slice(0, -2).join('/') + '/' + hash;
+    } else {
+      location = 'multipage/' + hash;
+    }
+  } else if (e.key === 'u') {
+    document.documentElement.classList.toggle('show-ao-annotations');
+  } else if (e.key === '?') {
+    document.getElementById('shortcuts-help').classList.toggle('active');
+  }
+}
+
+function init() {
+  menu = new Menu();
+  let $container = document.getElementById('spec-container');
+  $container.addEventListener(
+    'mouseover',
+    debounce(e => {
+      Toolbox.activateIfMouseOver(e);
+    })
+  );
+  document.addEventListener(
+    'keydown',
+    debounce(e => {
+      if (e.code === 'Escape') {
+        if (Toolbox.active) {
+          Toolbox.deactivate();
+        }
+        document.getElementById('shortcuts-help').classList.remove('active');
+      }
+    })
+  );
+}
+
+document.addEventListener('keypress', doShortcut);
+
+document.addEventListener('DOMContentLoaded', () => {
   Toolbox.init();
   referencePane.init();
-})
-var CLAUSE_NODES = ['EMU-CLAUSE', 'EMU-INTRO', 'EMU-ANNEX'];
-function findLocalReferences ($elem) {
-  var name = $elem.innerHTML;
-  var references = [];
+});
 
-  var parentClause = $elem.parentNode;
-  while (parentClause && CLAUSE_NODES.indexOf(parentClause.nodeName) === -1) {
-    parentClause = parentClause.parentNode;
+// preserve state during navigation
+
+function getTocPath(li) {
+  let path = [];
+  let pointer = li;
+  while (true) {
+    let parent = pointer.parentElement;
+    if (parent == null) {
+      return null;
+    }
+    let index = [].indexOf.call(parent.children, pointer);
+    if (index == -1) {
+      return null;
+    }
+    path.unshift(index);
+    pointer = parent.parentElement;
+    if (pointer == null) {
+      return null;
+    }
+    if (pointer.id === 'menu-toc') {
+      break;
+    }
+    if (pointer.tagName !== 'LI') {
+      return null;
+    }
   }
+  return path;
+}
 
-  if(!parentClause) return;
+function activateTocPath(path) {
+  try {
+    let pointer = document.getElementById('menu-toc');
+    for (let index of path) {
+      pointer = pointer.querySelector('ol').children[index];
+    }
+    pointer.classList.add('active');
+  } catch (e) {
+    // pass
+  }
+}
 
-  var vars = parentClause.querySelectorAll('var');
+function getActiveTocPaths() {
+  return [...menu.$menu.querySelectorAll('.active')].map(getTocPath).filter(p => p != null);
+}
 
-  for (var i = 0; i < vars.length; i++) {
-    var $var = vars[i];
-
-    if ($var.innerHTML === name) {
-      references.push($var);
+function loadStateFromSessionStorage() {
+  if (!window.sessionStorage || typeof menu === 'undefined' || window.navigating) {
+    return;
+  }
+  if (sessionStorage.referencePaneState != null) {
+    let state = JSON.parse(sessionStorage.referencePaneState);
+    if (state != null) {
+      if (state.type === 'ref') {
+        let entry = menu.search.biblio.byId[state.id];
+        if (entry != null) {
+          referencePane.showReferencesFor(entry);
+        }
+      } else if (state.type === 'sdo') {
+        let sdos = sdoMap[state.id];
+        if (sdos != null) {
+          referencePane.$headerText.innerHTML = state.html;
+          referencePane.showSDOsBody(sdos, state.id);
+        }
+      }
+      delete sessionStorage.referencePaneState;
     }
   }
 
-  return references;
-}
+  if (sessionStorage.activeTocPaths != null) {
+    document
+      .getElementById('menu-toc')
+      .querySelectorAll('.active')
+      .forEach(e => {
+        e.classList.remove('active');
+      });
+    let active = JSON.parse(sessionStorage.activeTocPaths);
+    active.forEach(activateTocPath);
+    delete sessionStorage.activeTocPaths;
+  }
 
-function toggleFindLocalReferences($elem) {
-  var references = findLocalReferences($elem);
-  if ($elem.classList.contains('referenced')) {
-    references.forEach(function ($reference) {
-      $reference.classList.remove('referenced');
-    });
-  } else {
-    references.forEach(function ($reference) {
-      $reference.classList.add('referenced');
-    });
+  if (sessionStorage.searchValue != null) {
+    let value = JSON.parse(sessionStorage.searchValue);
+    menu.search.$searchBox.value = value;
+    menu.search.search(value);
+    delete sessionStorage.searchValue;
+  }
+
+  if (sessionStorage.tocScroll != null) {
+    let tocScroll = JSON.parse(sessionStorage.tocScroll);
+    menu.$toc.scrollTop = tocScroll;
+    delete sessionStorage.tocScroll;
   }
 }
 
-function installFindLocalReferences () {
-  document.addEventListener('click', function (e) {
-    if (e.target.nodeName === 'VAR') {
-      toggleFindLocalReferences(e.target);
+document.addEventListener('DOMContentLoaded', loadStateFromSessionStorage);
+
+window.addEventListener('pageshow', loadStateFromSessionStorage);
+
+window.addEventListener('beforeunload', () => {
+  if (!window.sessionStorage || typeof menu === 'undefined') {
+    return;
+  }
+  sessionStorage.referencePaneState = JSON.stringify(referencePane.state || null);
+  sessionStorage.activeTocPaths = JSON.stringify(getActiveTocPaths());
+  sessionStorage.searchValue = JSON.stringify(menu.search.$searchBox.value);
+  sessionStorage.tocScroll = JSON.stringify(menu.$toc.scrollTop);
+});
+
+'use strict';
+
+// Manually prefix algorithm step list items with hidden counter representations
+// corresponding with their markers so they get selected and copied with content.
+// We read list-style-type to avoid divergence with the style sheet, but
+// for efficiency assume that all lists at the same nesting depth use the same
+// style (except for those associated with replacement steps).
+// We also precompute some initial items for each supported style type.
+// https://w3c.github.io/csswg-drafts/css-counter-styles/
+
+const lowerLetters = Array.from({ length: 26 }, (_, i) =>
+  String.fromCharCode('a'.charCodeAt(0) + i)
+);
+// Implement the lower-alpha 'alphabetic' algorithm,
+// adjusting for indexing from 0 rather than 1.
+// https://w3c.github.io/csswg-drafts/css-counter-styles/#simple-alphabetic
+// https://w3c.github.io/csswg-drafts/css-counter-styles/#alphabetic-system
+const lowerAlphaTextForIndex = i => {
+  let S = '';
+  for (const N = lowerLetters.length; i >= 0; i--) {
+    S = lowerLetters[i % N] + S;
+    i = Math.floor(i / N);
+  }
+  return S;
+};
+
+const weightedLowerRomanSymbols = Object.entries({
+  m: 1000,
+  cm: 900,
+  d: 500,
+  cd: 400,
+  c: 100,
+  xc: 90,
+  l: 50,
+  xl: 40,
+  x: 10,
+  ix: 9,
+  v: 5,
+  iv: 4,
+  i: 1,
+});
+// Implement the lower-roman 'additive' algorithm,
+// adjusting for indexing from 0 rather than 1.
+// https://w3c.github.io/csswg-drafts/css-counter-styles/#simple-numeric
+// https://w3c.github.io/csswg-drafts/css-counter-styles/#additive-system
+const lowerRomanTextForIndex = i => {
+  let value = i + 1;
+  let S = '';
+  for (const [symbol, weight] of weightedLowerRomanSymbols) {
+    if (!value) break;
+    if (weight > value) continue;
+    const reps = Math.floor(value / weight);
+    S += symbol.repeat(reps);
+    value -= weight * reps;
+  }
+  return S;
+};
+
+// Memoize pure index-to-text functions with an exposed cache for fast retrieval.
+const makeCounter = (pureGetTextForIndex, precomputeCount = 30) => {
+  const cache = Array.from({ length: precomputeCount }, (_, i) => pureGetTextForIndex(i));
+  const getTextForIndex = i => {
+    if (i >= cache.length) cache[i] = pureGetTextForIndex(i);
+    return cache[i];
+  };
+  return { getTextForIndex, cache };
+};
+
+const counterByStyle = {
+  __proto__: null,
+  decimal: makeCounter(i => String(i + 1)),
+  'lower-alpha': makeCounter(lowerAlphaTextForIndex),
+  'upper-alpha': makeCounter(i => lowerAlphaTextForIndex(i).toUpperCase()),
+  'lower-roman': makeCounter(lowerRomanTextForIndex),
+  'upper-roman': makeCounter(i => lowerRomanTextForIndex(i).toUpperCase()),
+};
+const fallbackCounter = makeCounter(() => '?');
+const counterByDepth = [];
+
+function addStepNumberText(
+  ol,
+  depth = 0,
+  special = [...ol.classList].some(c => c.startsWith('nested-'))
+) {
+  let counter = !special && counterByDepth[depth];
+  if (!counter) {
+    const counterStyle = getComputedStyle(ol)['list-style-type'];
+    counter = counterByStyle[counterStyle];
+    if (!counter) {
+      console.warn('unsupported list-style-type', {
+        ol,
+        counterStyle,
+        id: ol.closest('[id]')?.getAttribute('id'),
+      });
+      counterByStyle[counterStyle] = fallbackCounter;
+      counter = fallbackCounter;
     }
+    if (!special) {
+      counterByDepth[depth] = counter;
+    }
+  }
+  const { cache, getTextForIndex } = counter;
+  let i = (Number(ol.getAttribute('start')) || 1) - 1;
+  for (const li of ol.children) {
+    const marker = document.createElement('span');
+    marker.textContent = `${i < cache.length ? cache[i] : getTextForIndex(i)}. `;
+    marker.setAttribute('aria-hidden', 'true');
+    li.prepend(marker);
+    for (const sublist of li.querySelectorAll(':scope > ol')) {
+      addStepNumberText(sublist, depth + 1, special);
+    }
+    i++;
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('emu-alg > ol').forEach(ol => {
+    addStepNumberText(ol);
   });
-}
+});
 
-document.addEventListener('DOMContentLoaded', installFindLocalReferences);
-</script><style>body {
+let sdoMap = JSON.parse(`{}`);
+let biblio = JSON.parse(`{"refsByClause":{},"entries":[{"type":"clause","id":"annex-implementation-dependent-behaviour","titleHTML":"Implementation Dependent Behaviour","number":"A"},{"type":"clause","id":"annex-incompatibilities","titleHTML":"Additions and Changes That Introduce Incompatibilities with Prior Editions","number":"B"}]}`);
+;let usesMultipage = false</script><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.0.1/styles/base16/solarized-light.min.css"><style>body {
   display: flex;
+  word-wrap: break-word;
   font-size: 18px;
   line-height: 1.5;
   font-family: Cambria, Palatino Linotype, Palatino, Liberation Serif, serif;
@@ -912,6 +1364,7 @@ document.addEventListener('DOMContentLoaded', installFindLocalReferences);
   flex-basis: 66%;
   box-sizing: border-box;
   overflow: hidden;
+  padding-bottom: 1em;
 }
 
 body.oldtoc {
@@ -919,8 +1372,8 @@ body.oldtoc {
 }
 
 a {
-    text-decoration: none;
-    color: #206ca7;
+  text-decoration: none;
+  color: #206ca7;
 }
 
 a:visited {
@@ -928,15 +1381,51 @@ a:visited {
 }
 
 a:hover {
-    text-decoration: underline;
-    color: #239dee;
+  text-decoration: underline;
+  color: #239dee;
 }
 
+a.e-user-code,
+span.e-user-code {
+  white-space: nowrap;
+}
+
+a.e-user-code::before,
+span.e-user-code::before {
+  display: none;
+  color: brown;
+  background-color: white;
+  border: 2pt solid brown;
+  padding: 0.3ex;
+  margin: 0 0.25em 0 0;
+  line-height: 1;
+  vertical-align: text-top;
+  text-transform: uppercase;
+  font-family: 'Comic Code', sans-serif;
+  font-weight: 900;
+  font-size: x-small;
+}
+
+a.e-user-code:hover::before,
+span.e-user-code:hover::before {
+  background-color: brown;
+  color: white;
+}
+
+html.show-ao-annotations a.e-user-code::before,
+html.show-ao-annotations span.e-user-code::before {
+  display: inline-block;
+}
+
+a.e-user-code::before,
+span.e-user-code::before {
+  content: 'UC';
+}
 
 code {
-    font-weight: bold;
-    font-family: Consolas, Monaco, monospace;
-    white-space: pre;
+  font-weight: bold;
+  font-family: Consolas, Monaco, monospace;
+  white-space: pre;
 }
 
 pre code {
@@ -950,13 +1439,13 @@ pre code.hljs {
 }
 
 ol.toc {
-    list-style: none;
-    padding-left: 0;
+  list-style: none;
+  padding-left: 0;
 }
 
 ol.toc ol.toc {
-    padding-left: 2ex;
-    list-style: none;
+  padding-left: 2ex;
+  list-style: none;
 }
 
 var {
@@ -965,8 +1454,40 @@ var {
   cursor: pointer;
 }
 
-var.referenced {
+var.referenced0 {
+  color: inherit;
   background-color: #ffff33;
+  box-shadow: 0 0 0 2px #ffff33;
+}
+var.referenced1 {
+  color: inherit;
+  background-color: #ff87a2;
+  box-shadow: 0 0 0 2px #ff87a2;
+}
+var.referenced2 {
+  color: inherit;
+  background-color: #96e885;
+  box-shadow: 0 0 0 2px #96e885;
+}
+var.referenced3 {
+  color: inherit;
+  background-color: #3eeed2;
+  box-shadow: 0 0 0 2px #3eeed2;
+}
+var.referenced4 {
+  color: inherit;
+  background-color: #eacfb6;
+  box-shadow: 0 0 0 2px #eacfb6;
+}
+var.referenced5 {
+  color: inherit;
+  background-color: #82ddff;
+  box-shadow: 0 0 0 2px #82ddff;
+}
+var.referenced6 {
+  color: inherit;
+  background-color: #ffbcf2;
+  box-shadow: 0 0 0 2px #ffbcf2;
 }
 
 emu-const {
@@ -1015,6 +1536,10 @@ emu-alg ol.nested-lots ol {
   list-style-type: lower-roman;
 }
 
+emu-alg [aria-hidden=true] {
+  font-size: 0;
+}
+
 emu-eqn {
   display: block;
   margin-left: 4em;
@@ -1030,29 +1555,32 @@ emu-eqn div:first-child {
 }
 
 emu-note {
-    margin: 1em 0;
-    color: #666;
-    border-left: 5px solid #ccc;
-    display: flex;
-    flex-direction: row;
+  margin: 1em 0;
+  display: flex;
+  flex-direction: row;
+  color: inherit;
+  border-left: 5px solid #52e052;
+  background: #e9fbe9;
+  padding: 10px 10px 10px 0;
 }
 
 emu-note > span.note {
-    flex-basis: 100px;
-    min-width: 100px;
-    flex-grow: 0;
-    flex-shrink: 1;
-    text-transform: uppercase;
-    padding-left: 5px;
+  flex-basis: 100px;
+  min-width: 100px;
+  flex-grow: 0;
+  flex-shrink: 1;
+  text-transform: uppercase;
+  padding-left: 5px;
 }
 
-emu-note[type=editor] {
+emu-note[type='editor'] {
   border-left-color: #faa;
 }
 
 emu-note > div.note-contents {
   flex-grow: 1;
   flex-shrink: 1;
+  overflow: auto;
 }
 
 emu-note > div.note-contents > p:first-of-type {
@@ -1063,9 +1591,9 @@ emu-note > div.note-contents > p:last-of-type {
   margin-bottom: 0;
 }
 
-emu-table td code {
+emu-table:not(.code) td code {
   white-space: normal;
-} 
+}
 
 emu-figure {
   display: block;
@@ -1090,99 +1618,120 @@ emu-table figure {
 }
 
 emu-production {
-    display: block;
+  display: block;
 }
 
-emu-grammar[type="example"] emu-production,
-emu-grammar[type="definition"] emu-production {
-    margin-top: 1em;
-    margin-bottom: 1em;
-    margin-left: 5ex;
+emu-grammar[type='example'] emu-production,
+emu-grammar[type='definition'] emu-production {
+  margin-top: 1em;
+  margin-bottom: 1em;
+  margin-left: 5ex;
 }
 
-emu-grammar.inline, emu-production.inline,
-emu-grammar.inline emu-production emu-rhs, emu-production.inline emu-rhs,
-emu-grammar[collapsed] emu-production emu-rhs, emu-production[collapsed] emu-rhs {
-    display: inline;
-    padding-left: 1ex;
-    margin-left: 0;
+emu-grammar.inline,
+emu-production.inline,
+emu-grammar.inline emu-production emu-rhs,
+emu-production.inline emu-rhs,
+emu-grammar[collapsed] emu-production emu-rhs {
+  display: inline;
+  padding-left: 1ex;
+  margin-left: 0;
 }
 
-emu-grammar[collapsed] emu-production, emu-production[collapsed] {
-    margin: 0;
+emu-production[collapsed] emu-rhs {
+  display: inline;
+  padding-left: 0.5ex;
+  margin-left: 0;
+}
+
+emu-grammar[collapsed] emu-production,
+emu-production[collapsed] {
+  margin: 0;
 }
 
 emu-constraints {
-    font-size: .75em;
-    margin-right: 1ex;
+  font-size: 0.75em;
+  margin-right: 0.5ex;
 }
 
 emu-gann {
-    margin-right: 1ex;
+  margin-right: 0.5ex;
 }
 
 emu-gann emu-t:last-child,
 emu-gann emu-gprose:last-child,
 emu-gann emu-nt:last-child {
-    margin-right: 0;
+  margin-right: 0;
 }
 
 emu-geq {
-    margin-left: 1ex;
-    font-weight: bold;
+  margin-left: 0.5ex;
+  font-weight: bold;
 }
 
 emu-oneof {
-    font-weight: bold;
-    margin-left: 1ex;
+  font-weight: bold;
+  margin-left: 0.5ex;
 }
 
 emu-nt {
-    display: inline-block;
-    font-style: italic;
-    white-space: nowrap;
-    text-indent: 0;
+  display: inline-block;
+  font-style: italic;
+  white-space: nowrap;
+  text-indent: 0;
 }
 
-emu-nt a, emu-nt a:visited {
+emu-nt a,
+emu-nt a:visited {
   color: #333;
 }
 
 emu-rhs emu-nt {
-    margin-right: 1ex;
+  margin-right: 0.5ex;
 }
 
 emu-t {
-    display: inline-block;
-    font-family: monospace;
-    font-weight: bold;
-    white-space: nowrap;
-    text-indent: 0;
+  display: inline-block;
+  font-family: monospace;
+  font-weight: bold;
+  white-space: nowrap;
+  text-indent: 0;
 }
 
 emu-production emu-t {
-    margin-right: 1ex;
+  margin-right: 0.5ex;
 }
 
 emu-rhs {
-    display: block;
-    padding-left: 75px;
-    text-indent: -25px;
+  display: block;
+  padding-left: 75px;
+  text-indent: -25px;
+}
+
+emu-production:not([collapsed]) emu-rhs {
+  border: 0.2ex dashed transparent;
+}
+
+emu-production:not([collapsed]) emu-rhs:hover {
+  border-color: #888;
+  background-color: #f0f0f0;
 }
 
 emu-mods {
-    font-size: .85em;
-    vertical-align: sub;
-    font-style: normal;
-    font-weight: normal;
+  font-size: 0.85em;
+  vertical-align: sub;
+  font-style: normal;
+  font-weight: normal;
 }
 
-emu-params, emu-opt {
+emu-params,
+emu-opt {
   margin-right: 1ex;
   font-family: monospace;
 }
 
-emu-params, emu-constraints {
+emu-params,
+emu-constraints {
   color: #2aa198;
 }
 
@@ -1191,12 +1740,12 @@ emu-opt {
 }
 
 emu-gprose {
-    font-size: 0.9em;
-    font-family: Helvetica, Arial, sans-serif;
+  font-size: 0.9em;
+  font-family: Helvetica, Arial, sans-serif;
 }
 
 emu-production emu-gprose {
-    margin-right: 1ex;
+  margin-right: 1ex;
 }
 
 h1.shortname {
@@ -1208,20 +1757,19 @@ h1.shortname {
 h1.version {
   color: #f60;
   font-size: 1.5em;
-  margin: 0;
 }
 
 h1.title {
-  margin-top: 0;
   color: #f60;
 }
 
-h1.first {
-  margin-top: 0;
-}
-
-h1, h2, h3, h4, h5, h6 {
-    position: relative;
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  position: relative;
 }
 
 h1 .secnum {
@@ -1233,142 +1781,267 @@ h1 span.title {
   order: 2;
 }
 
+h1 {
+  font-size: 2.67em;
+  margin-bottom: 0;
+  line-height: 1em;
+}
+h2 {
+  font-size: 2em;
+}
+h3 {
+  font-size: 1.56em;
+}
+h4 {
+  font-size: 1.25em;
+}
+h5 {
+  font-size: 1.11em;
+}
+h6 {
+  font-size: 1em;
+}
 
-h1 { font-size: 2.67em; margin-top: 2em; margin-bottom: 0; line-height: 1em;}
-h2 { font-size: 2em; }
-h3 { font-size: 1.56em; }
-h4 { font-size: 1.25em; }
-h5 { font-size: 1.11em; }
-h6 { font-size: 1em; }
+pre code.hljs {
+  background: transparent;
+}
 
-h1:hover span.utils {
+emu-clause[id],
+emu-annex[id],
+emu-intro[id] {
+  scroll-margin-top: 2ex;
+}
+
+emu-intro h1,
+emu-clause h1,
+emu-annex h1 {
+  font-size: 2em;
+}
+emu-intro h2,
+emu-clause h2,
+emu-annex h2 {
+  font-size: 1.56em;
+}
+emu-intro h3,
+emu-clause h3,
+emu-annex h3 {
+  font-size: 1.25em;
+}
+emu-intro h4,
+emu-clause h4,
+emu-annex h4 {
+  font-size: 1.11em;
+}
+emu-intro h5,
+emu-clause h5,
+emu-annex h5 {
+  font-size: 1em;
+}
+emu-intro h6,
+emu-clause h6,
+emu-annex h6 {
+  font-size: 0.9em;
+}
+emu-intro emu-intro h1,
+emu-clause emu-clause h1,
+emu-annex emu-annex h1 {
+  font-size: 1.56em;
+}
+emu-intro emu-intro h2,
+emu-clause emu-clause h2,
+emu-annex emu-annex h2 {
+  font-size: 1.25em;
+}
+emu-intro emu-intro h3,
+emu-clause emu-clause h3,
+emu-annex emu-annex h3 {
+  font-size: 1.11em;
+}
+emu-intro emu-intro h4,
+emu-clause emu-clause h4,
+emu-annex emu-annex h4 {
+  font-size: 1em;
+}
+emu-intro emu-intro h5,
+emu-clause emu-clause h5,
+emu-annex emu-annex h5 {
+  font-size: 0.9em;
+}
+emu-intro emu-intro emu-intro h1,
+emu-clause emu-clause emu-clause h1,
+emu-annex emu-annex emu-annex h1 {
+  font-size: 1.25em;
+}
+emu-intro emu-intro emu-intro h2,
+emu-clause emu-clause emu-clause h2,
+emu-annex emu-annex emu-annex h2 {
+  font-size: 1.11em;
+}
+emu-intro emu-intro emu-intro h3,
+emu-clause emu-clause emu-clause h3,
+emu-annex emu-annex emu-annex h3 {
+  font-size: 1em;
+}
+emu-intro emu-intro emu-intro h4,
+emu-clause emu-clause emu-clause h4,
+emu-annex emu-annex emu-annex h4 {
+  font-size: 0.9em;
+}
+emu-intro emu-intro emu-intro emu-intro h1,
+emu-clause emu-clause emu-clause emu-clause h1,
+emu-annex emu-annex emu-annex emu-annex h1 {
+  font-size: 1.11em;
+}
+emu-intro emu-intro emu-intro emu-intro h2,
+emu-clause emu-clause emu-clause emu-clause h2,
+emu-annex emu-annex emu-annex emu-annex h2 {
+  font-size: 1em;
+}
+emu-intro emu-intro emu-intro emu-intro h3,
+emu-clause emu-clause emu-clause emu-clause h3,
+emu-annex emu-annex emu-annex emu-annex h3 {
+  font-size: 0.9em;
+}
+emu-intro emu-intro emu-intro emu-intro emu-intro h1,
+emu-clause emu-clause emu-clause emu-clause emu-clause h1,
+emu-annex emu-annex emu-annex emu-annex emu-annex h1 {
+  font-size: 1em;
+}
+emu-intro emu-intro emu-intro emu-intro emu-intro h2,
+emu-clause emu-clause emu-clause emu-clause emu-clause h2,
+emu-annex emu-annex emu-annex emu-annex emu-annex h2 {
+  font-size: 0.9em;
+}
+emu-intro emu-intro emu-intro emu-intro emu-intro emu-intro h1,
+emu-clause emu-clause emu-clause emu-clause emu-clause emu-clause h1,
+emu-annex emu-annex emu-annex emu-annex emu-annex emu-annex h1 {
+  font-size: 0.9em;
+}
+
+emu-clause,
+emu-intro,
+emu-annex {
   display: block;
 }
 
-span.utils {
-  font-size: 18px;
-  line-height: 18px;
-  display: none;
-  position: absolute;
-  top: 100%;
-  left: 0;
-  right: 0;
-  font-weight: normal;
+/* these values are twice the font-size for the <h1> titles for clauses */
+emu-intro,
+emu-clause,
+emu-annex {
+  margin-top: 4em;
+}
+emu-intro emu-intro,
+emu-clause emu-clause,
+emu-annex emu-annex {
+  margin-top: 3.12em;
+}
+emu-intro emu-intro emu-intro,
+emu-clause emu-clause emu-clause,
+emu-annex emu-annex emu-annex {
+  margin-top: 2.5em;
+}
+emu-intro emu-intro emu-intro emu-intro,
+emu-clause emu-clause emu-clause emu-clause,
+emu-annex emu-annex emu-annex emu-annex {
+  margin-top: 2.22em;
+}
+emu-intro emu-intro emu-intro emu-intro emu-intro,
+emu-clause emu-clause emu-clause emu-clause emu-clause,
+emu-annex emu-annex emu-annex emu-annex emu-annex {
+  margin-top: 2em;
+}
+emu-intro emu-intro emu-intro emu-intro emu-intro emu-intro,
+emu-clause emu-clause emu-clause emu-clause emu-clause emu-clause,
+emu-annex emu-annex emu-annex emu-annex emu-annex emu-annex {
+  margin-top: 1.8em;
 }
 
-span.utils:before {
-    content: "⤷";
-    display: inline-block;
-    padding: 0 5px;
-}
-
-span.utils > * {
-  display: inline-block;
-  margin-right: 20px;
-}
-
-h1 span.utils span.anchor a,
-h2 span.utils span.anchor a,
-h3 span.utils span.anchor a,
-h4 span.utils span.anchor a,
-h5 span.utils span.anchor a,
-h6 span.utils span.anchor a {
-  text-decoration: none;
-  font-variant: small-caps;
-}
-
-h1 span.utils span.anchor a:hover,
-h2 span.utils span.anchor a:hover,
-h3 span.utils span.anchor a:hover,
-h4 span.utils span.anchor a:hover,
-h5 span.utils span.anchor a:hover,
-h6 span.utils span.anchor a:hover {
-  color: #333;
-}
-
-emu-intro h1, emu-clause h1, emu-annex h1 { font-size: 2em; }
-emu-intro h2, emu-clause h2, emu-annex h2 { font-size: 1.56em; }
-emu-intro h3, emu-clause h3, emu-annex h3 { font-size: 1.25em; }
-emu-intro h4, emu-clause h4, emu-annex h4 { font-size: 1.11em; }
-emu-intro h5, emu-clause h5, emu-annex h5 { font-size: 1em; }
-emu-intro h6, emu-clause h6, emu-annex h6 { font-size: 0.9em; }
-emu-intro emu-intro h1, emu-clause emu-clause h1, emu-annex emu-annex h1 { font-size: 1.56em; }
-emu-intro emu-intro h2, emu-clause emu-clause h2, emu-annex emu-annex h2 { font-size: 1.25em; }
-emu-intro emu-intro h3, emu-clause emu-clause h3, emu-annex emu-annex h3 { font-size: 1.11em; }
-emu-intro emu-intro h4, emu-clause emu-clause h4, emu-annex emu-annex h4 { font-size: 1em; }
-emu-intro emu-intro h5, emu-clause emu-clause h5, emu-annex emu-annex h5 { font-size: 0.9em; }
-emu-intro emu-intro emu-intro h1, emu-clause emu-clause emu-clause h1, emu-annex emu-annex emu-annex h1 { font-size: 1.25em; }
-emu-intro emu-intro emu-intro h2, emu-clause emu-clause emu-clause h2, emu-annex emu-annex emu-annex h2 { font-size: 1.11em; }
-emu-intro emu-intro emu-intro h3, emu-clause emu-clause emu-clause h3, emu-annex emu-annex emu-annex h3 { font-size: 1em; }
-emu-intro emu-intro emu-intro h4, emu-clause emu-clause emu-clause h4, emu-annex emu-annex emu-annex h4 { font-size: 0.9em; }
-emu-intro emu-intro emu-intro emu-intro h1, emu-clause emu-clause emu-clause emu-clause h1, emu-annex emu-annex emu-annex emu-annex h1 { font-size: 1.11em; }
-emu-intro emu-intro emu-intro emu-intro h2, emu-clause emu-clause emu-clause emu-clause h2, emu-annex emu-annex emu-annex emu-annex h2 { font-size: 1em; }
-emu-intro emu-intro emu-intro emu-intro h3, emu-clause emu-clause emu-clause emu-clause h3, emu-annex emu-annex emu-annex emu-annex h3 { font-size: 0.9em; }
-emu-intro emu-intro emu-intro emu-intro emu-intro h1, emu-clause emu-clause emu-clause emu-clause emu-clause h1, emu-annex emu-annex emu-annex emu-annex emu-annex h1 { font-size: 1em; }
-emu-intro emu-intro emu-intro emu-intro emu-intro h2, emu-clause emu-clause emu-clause emu-clause emu-clause h2, emu-annex emu-annex emu-annex emu-annex emu-annex h2 { font-size: 0.9em; }
-emu-intro emu-intro emu-intro emu-intro emu-intro emu-intro h1, emu-clause emu-clause emu-clause emu-clause emu-clause emu-clause h1, emu-annex emu-annex emu-annex emu-annex emu-annex emu-annex h1 { font-size: 0.9em }
-
-emu-clause, emu-intro, emu-annex {
-    display: block;
+#spec-container > emu-intro:first-of-type,
+#spec-container > emu-clause:first-of-type,
+#spec-container > emu-annex:first-of-type {
+  margin-top: 0;
 }
 
 /* Figures and tables */
-figure { display: block; margin: 1em 0 3em 0; }
-figure object { display: block; margin: 0 auto; }
-figure table.real-table { margin: 0 auto; }
+figure {
+  display: block;
+  margin: 1em 0 3em 0;
+}
+figure object {
+  display: block;
+  margin: 0 auto;
+}
+figure table.real-table {
+  margin: 0 auto;
+}
 figure figcaption {
-    display: block;
-    color: #555555;
-    font-weight: bold;
-    text-align: center;
+  display: block;
+  color: #555555;
+  font-weight: bold;
+  text-align: center;
 }
 
 emu-table table {
   margin: 0 auto;
 }
 
-emu-table table, table.real-table {
-    border-collapse: collapse;
+emu-table table,
+table.real-table {
+  border-collapse: collapse;
 }
 
-emu-table td, emu-table th, table.real-table td, table.real-table th {
-    border: 1px solid black;
-    padding: 0.4em;
-    vertical-align: baseline;
+emu-table td,
+emu-table th,
+table.real-table td,
+table.real-table th {
+  border: 1px solid black;
+  padding: 0.4em;
+  vertical-align: baseline;
 }
-emu-table th, emu-table thead td, table.real-table th {
-    background-color: #eeeeee;
+emu-table th,
+emu-table thead td,
+table.real-table th {
+  background-color: #eeeeee;
+}
+
+emu-table td {
+  background: #fff;
 }
 
 /* Note: the left content edges of table.lightweight-table >tbody >tr >td
    and div.display line up. */
 table.lightweight-table {
-    border-collapse: collapse;
-    margin: 0 0 0 1.5em;
+  border-collapse: collapse;
+  margin: 0 0 0 1.5em;
 }
-table.lightweight-table td, table.lightweight-table th {
-    border: none;
-    padding: 0 0.5em;
-    vertical-align: baseline;
+table.lightweight-table td,
+table.lightweight-table th {
+  border: none;
+  padding: 0 0.5em;
+  vertical-align: baseline;
 }
 
 /* diff styles */
 ins {
-    background-color: #e0f8e0;
-    text-decoration: none;
-    border-bottom: 1px solid #396;
+  background-color: #e0f8e0;
+  text-decoration: none;
+  border-bottom: 1px solid #396;
 }
 
 del {
-    background-color: #fee;
+  background-color: #fee;
 }
 
-ins.block, del.block,
-emu-production > ins, emu-production > del,
-emu-grammar > ins, emu-grammar > del {
+ins.block,
+del.block,
+emu-production > ins,
+emu-production > del,
+emu-grammar > ins,
+emu-grammar > del {
   display: block;
 }
-emu-rhs > ins, emu-rhs > del { 
+emu-rhs > ins,
+emu-rhs > del {
   display: inline;
 }
 
@@ -1405,7 +2078,7 @@ tr.del > td {
   -khtml-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
-  user-select: none;;
+  user-select: none;
 
   cursor: pointer;
 }
@@ -1413,7 +2086,8 @@ tr.del > td {
 #menu {
   display: flex;
   flex-direction: column;
-  width: 33%; height: 100vh;
+  width: 33%;
+  height: 100vh;
   max-width: 500px;
   box-sizing: border-box;
   background-color: #ddd;
@@ -1421,13 +2095,14 @@ tr.del > td {
   transition: opacity 0.1s linear;
   padding: 0 5px;
   position: fixed;
-  left: 0; top: 0;
+  left: 0;
+  top: 0;
   border-right: 2px solid #bbb;
 
   z-index: 2;
 }
 
-#menu-spacer {
+.menu-spacer {
   flex-basis: 33%;
   max-width: 500px;
   flex-grow: 0;
@@ -1482,7 +2157,8 @@ tr.del > td {
   padding: 0;
 }
 
-#menu-toc > ol , #menu-toc > ol ol {
+#menu-toc > ol,
+#menu-toc > ol ol {
   list-style-type: none;
   margin: 0;
   padding: 0;
@@ -1512,7 +2188,7 @@ tr.del > td {
   -khtml-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
-  user-select: none;;
+  user-select: none;
 
   cursor: pointer;
 }
@@ -1543,7 +2219,7 @@ tr.del > td {
   */
 }
 
-#menu-toc li.revealed-leaf> a {
+#menu-toc li.revealed-leaf > a {
   color: #206ca7;
   /*
   background-color: #222;
@@ -1579,6 +2255,34 @@ tr.del > td {
   font-size: 0.8em;
 }
 
+.menu-pane-header emu-opt,
+.menu-pane-header emu-t,
+.menu-pane-header emu-nt {
+  margin-right: 0px;
+  display: inline;
+  color: inherit;
+}
+
+.menu-pane-header emu-rhs {
+  display: inline;
+  padding-left: 0px;
+  text-indent: 0px;
+}
+
+.menu-pane-header emu-geq {
+  margin-left: 0px;
+}
+
+a.menu-pane-header-production {
+  color: inherit;
+}
+
+.menu-pane-header-production {
+  text-transform: none;
+  letter-spacing: 1.5px;
+  padding-left: 0.5em;
+}
+
 #menu-toc {
   display: flex;
   flex-direction: column;
@@ -1597,10 +2301,10 @@ tr.del > td {
   flex-grow: 0;
   flex-shrink: 0;
   width: 100%;
-  
+
   display: flex;
   flex-direction: column;
-  
+
   max-height: 300px;
 }
 
@@ -1625,43 +2329,42 @@ tr.del > td {
 }
 
 li.menu-search-result-clause:before {
-    content: 'clause';
-    width: 40px;
-    display: inline-block;
-    text-align: right;
-    padding-right: 1ex;
-    color: #666;
-    font-size: 75%;
+  content: 'clause';
+  width: 40px;
+  display: inline-block;
+  text-align: right;
+  padding-right: 1ex;
+  color: #666;
+  font-size: 75%;
 }
 li.menu-search-result-op:before {
-    content: 'op';
-    width: 40px;
-    display: inline-block;
-    text-align: right;
-    padding-right: 1ex;
-    color: #666;
-    font-size: 75%;
+  content: 'op';
+  width: 40px;
+  display: inline-block;
+  text-align: right;
+  padding-right: 1ex;
+  color: #666;
+  font-size: 75%;
 }
 
 li.menu-search-result-prod:before {
-    content: 'prod';
-    width: 40px;
-    display: inline-block;
-    text-align: right;
-    padding-right: 1ex;
-    color: #666;
-    font-size: 75%
+  content: 'prod';
+  width: 40px;
+  display: inline-block;
+  text-align: right;
+  padding-right: 1ex;
+  color: #666;
+  font-size: 75%;
 }
 
-
 li.menu-search-result-term:before {
-    content: 'term';
-    width: 40px;
-    display: inline-block;
-    text-align: right;
-    padding-right: 1ex;
-    color: #666;
-    font-size: 75%
+  content: 'term';
+  width: 40px;
+  display: inline-block;
+  text-align: right;
+  padding-right: 1ex;
+  color: #666;
+  font-size: 75%;
 }
 
 #menu-search-results ul {
@@ -1674,7 +2377,6 @@ li.menu-search-result-term:before {
   text-overflow: ellipsis;
 }
 
-
 #menu-trace-list {
   counter-reset: item;
   margin: 0 0 0 20px;
@@ -1686,19 +2388,19 @@ li.menu-search-result-term:before {
 }
 
 #menu-trace-list li .secnum:after {
-  content: " ";
+  content: ' ';
 }
 #menu-trace-list li:before {
-    content: counter(item) " ";
-    background-color: #222;
-    counter-increment: item;
-    color: #999;
-    width: 20px;
-    height: 20px;
-    line-height: 20px;
-    display: inline-block;
-    text-align: center;
-    margin: 2px 4px 2px 0;
+  content: counter(item) ' ';
+  background-color: #222;
+  counter-increment: item;
+  color: #999;
+  width: 20px;
+  height: 20px;
+  line-height: 20px;
+  display: inline-block;
+  text-align: center;
+  margin: 2px 4px 2px 0;
 }
 
 @media (max-width: 1000px) {
@@ -1740,24 +2442,29 @@ li.menu-search-result-term:before {
   }
 
   h1 .secnum:empty {
-    margin: 0; padding: 0;
+    margin: 0;
+    padding: 0;
   }
 }
 
-
 /* Toolbox */
-.toolbox {
-	position: absolute;
-	background: #ddd;
-	border: 1px solid #aaa;
+.toolbox-container {
+  position: absolute;
   display: none;
+  padding-bottom: 7px;
+}
+
+.toolbox-container.active {
+  display: inline-block;
+}
+
+.toolbox {
+  position: relative;
+  background: #ddd;
+  border: 1px solid #aaa;
   color: #eee;
   padding: 5px;
   border-radius: 3px;
-}
-
-.toolbox.active {
-  display: inline-block;
 }
 
 .toolbox a {
@@ -1769,28 +2476,29 @@ li.menu-search-result-term:before {
   text-decoration: underline;
 }
 
-.toolbox:after, .toolbox:before {
-	top: 100%;
-	left: 15px;
-	border: solid transparent;
-	content: " ";
-	height: 0;
-	width: 0;
-	position: absolute;
-	pointer-events: none;
+.toolbox:after,
+.toolbox:before {
+  top: 100%;
+  left: 15px;
+  border: solid transparent;
+  content: ' ';
+  height: 0;
+  width: 0;
+  position: absolute;
+  pointer-events: none;
 }
 
 .toolbox:after {
-	border-color: rgba(0, 0, 0, 0);
-	border-top-color: #ddd;
-	border-width: 10px;
-	margin-left: -10px;
+  border-color: rgba(0, 0, 0, 0);
+  border-top-color: #ddd;
+  border-width: 10px;
+  margin-left: -10px;
 }
 .toolbox:before {
-	border-color: rgba(204, 204, 204, 0);
-	border-top-color: #aaa;
-	border-width: 12px;
-	margin-left: -12px;
+  border-color: rgba(204, 204, 204, 0);
+  border-top-color: #aaa;
+  border-width: 12px;
+  margin-left: -12px;
 }
 
 #references-pane-container {
@@ -1807,11 +2515,6 @@ li.menu-search-result-term:before {
 #references-pane-table-container {
   overflow-x: hidden;
   overflow-y: auto;
-}
-
-#references-pane-spacer {
-  flex-basis: 33%;
-  max-width: 500px;
 }
 
 #references-pane {
@@ -1831,6 +2534,10 @@ li.menu-search-result-term:before {
   cursor: pointer;
 }
 
+#references-pane table tbody {
+  vertical-align: baseline;
+}
+
 #references-pane table tr td:first-child {
   text-align: right;
   padding-right: 5px;
@@ -1838,11 +2545,78 @@ li.menu-search-result-term:before {
 
 @media print {
   #menu-toggle {
-    display: none; 
+    display: none;
   }
 }
-</style></head><body><div id="menu-toggle">☰</div><div id="menu-spacer"></div><div id="menu"><div id="menu-search"><input type="text" id="menu-search-box" placeholder="Search..."><div id="menu-search-results" class="inactive"></div></div><div id="menu-pins"><div class="menu-pane-header">Pins</div><ul id="menu-pins-list"></ul></div><div class="menu-pane-header">Table of Contents</div><div id="menu-toc"><ol class="toc"><li><span class="item-toggle-none"></span><a href="#annex-implementation-dependent-behaviour" title="Implementation Dependent Behaviour"><span class="secnum">A</span> Implementation Dependent Behaviour</a></li><li><span class="item-toggle-none"></span><a href="#annex-incompatibilities" title="Additions and Changes That Introduce Incompatibilities with Prior Editions"><span class="secnum">B</span> Additions and Changes That Introduce Incompatibilities with Prior Editions</a></li></ol></div></div><div id="spec-container"><emu-annex id="annex-implementation-dependent-behaviour">
-  <h1 class="first"><span class="secnum">A</span> Implementation Dependent Behaviour</h1>
+
+[normative-optional],
+[legacy] {
+  border-left: 5px solid #ff6600;
+  padding: 0.5em;
+  display: block;
+  background: #ffeedd;
+}
+
+.clause-attributes-tag {
+  text-transform: uppercase;
+  color: #884400;
+}
+
+.clause-attributes-tag a {
+  color: #884400;
+}
+
+/* Shortcuts help dialog */
+
+#shortcuts-help {
+  position: fixed;
+  left: 5%;
+  margin: 0 auto;
+  right: 5%;
+  z-index: 10;
+  top: 10%;
+  top: calc(5vw + 5vh);
+  padding: 30px 90px;
+  max-width: 500px;
+  outline: solid 10000px rgba(255, 255, 255, 0.6);
+  border-radius: 5px;
+  border-width: 1px 1px 0 1px;
+  background-color: #ddd;
+  display: none;
+}
+
+#shortcuts-help.active {
+  display: block;
+}
+
+#shortcuts-help ul {
+  padding: 0;
+}
+
+#shortcuts-help li {
+  display: flex;
+  justify-content: space-between;
+}
+
+#shortcuts-help code {
+  padding: 3px 10px;
+  border-radius: 3px;
+  border-width: 1px 1px 0 1px;
+  border-color: #bbb;
+  background-color: #eee;
+  box-shadow: inset 0 -1px 0 #ccc;
+}
+</style></head><body><div id="shortcuts-help">
+<ul>
+  <li><span>Toggle shortcuts help</span><code>?</code></li>
+  <li><span>Toggle "can call user code" annotations</span><code>u</code></li>
+
+  <li><span>Jump to search box</span><code>/</code></li>
+</ul></div><div id="menu-toggle"><svg xmlns="http://www.w3.org/2000/svg" style="width:100%; height:100%; stroke:currentColor" viewBox="0 0 120 120">
+      <title>Menu</title>
+      <path stroke-width="10" stroke-linecap="round" d="M30,60 h60  M30,30 m0,5 h60  M30,90 m0,-5 h60"></path>
+    </svg></div><div id="menu-spacer" class="menu-spacer"></div><div id="menu"><div id="menu-search"><input type="text" id="menu-search-box" placeholder="Search..."><div id="menu-search-results" class="inactive"></div></div><div id="menu-pins"><div class="menu-pane-header">Pins</div><ul id="menu-pins-list"></ul></div><div class="menu-pane-header">Table of Contents</div><div id="menu-toc"><ol class="toc"><li><span class="item-toggle-none"></span><a href="#annex-implementation-dependent-behaviour" title="Implementation Dependent Behaviour"><span class="secnum">A</span> Implementation Dependent Behaviour</a></li><li><span class="item-toggle-none"></span><a href="#annex-incompatibilities" title="Additions and Changes That Introduce Incompatibilities with Prior Editions"><span class="secnum">B</span> Additions and Changes That Introduce Incompatibilities with Prior Editions</a></li></ol></div></div><div id="spec-container"><emu-annex id="annex-implementation-dependent-behaviour">
+  <h1><span class="secnum">A</span> Implementation Dependent Behaviour</h1>
 
   <p>
     The following aspects of the ECMAScript 2023 Internationalization API Specification are implementation dependent:
@@ -1862,7 +2636,7 @@ li.menu-search-result-term:before {
           The default time zone (<emu-xref href="#sup-defaulttimezone"></emu-xref>)
         </li>
         <li>
-          The set of available locales for each <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> (<emu-xref href="#sec-internal-slots"></emu-xref>)
+          The set of available locales for each constructor (<emu-xref href="#sec-internal-slots"></emu-xref>)
         </li>
         <li>
           The BestFitMatcher algorithm (<emu-xref href="#sec-bestfitmatcher"></emu-xref>)
@@ -1998,7 +2772,7 @@ li.menu-search-result-term:before {
       In PluralRules:
       <ul>
         <li>
-          <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> of Strings representing the possible results of plural selection and their corresponding order per locale. (<emu-xref href="#sec-initializepluralrules"></emu-xref>)
+          List of Strings representing the possible results of plural selection and their corresponding order per locale. (<emu-xref href="#sec-initializepluralrules"></emu-xref>)
         </li>
         <li>
           The PluralRuleSelect algorithm (<emu-xref href="#sec-pluralruleselect"></emu-xref>)
@@ -2041,7 +2815,7 @@ li.menu-search-result-term:before {
       <emu-xref href="#sec-the-intl-collator-constructor"></emu-xref>, <emu-xref href="#sec-intl-numberformat-constructor"></emu-xref>, <emu-xref href="#sec-intl-datetimeformat-constructor"></emu-xref> In ECMA-402, 1<sup>st</sup> Edition, constructors could be used to create Intl objects from arbitrary objects. This is no longer possible in 2nd Edition.
     </li>
     <li>
-      <emu-xref href="#sec-intl.datetimeformat.prototype.format"></emu-xref> In ECMA-402, 1<sup>st</sup> Edition, the <emu-val>"length"</emu-val> property of the <emu-xref href="#function-object"><a href="https://tc39.es/ecma262/#function-object">function object</a></emu-xref> <var>F</var> was set to <emu-val>+0</emu-val><sub>𝔽</sub>. In 2nd Edition, <emu-val>"length"</emu-val> is set to <emu-val>1</emu-val><sub>𝔽</sub>.
+      <emu-xref href="#sec-intl.datetimeformat.prototype.format"></emu-xref> In ECMA-402, 1<sup>st</sup> Edition, the <emu-val>"length"</emu-val> property of the function object <var>F</var> was set to <emu-val>+0</emu-val><sub>𝔽</sub>. In 2nd Edition, <emu-val>"length"</emu-val> is set to <emu-val>1</emu-val><sub>𝔽</sub>.
     </li>
     <li>
       <emu-xref href="#sec-intl.collator.prototype-@@tostringtag"></emu-xref> In ECMA-402, 7<sup></sup>th Edition, the @@toStringTag property of <code>Intl.Collator.prototype</code> was set to <emu-val>"Object"</emu-val>. In 8<sup>th</sup> Edition, @@toStringTag is set to <emu-val>"Intl.Collator"</emu-val>.
@@ -2059,7 +2833,7 @@ li.menu-search-result-term:before {
       <emu-xref href="#sec-Intl-toStringTag"></emu-xref> In ECMA-402, 7<sup>th</sup> Edition, the @@toStringTag property of <code>Intl</code> was not defined. In 8<sup>th</sup> Edition, @@toStringTag is set to <emu-val>"Intl"</emu-val>.
     </li>
     <li>
-      <emu-xref href="#sec-intl-numberformat-constructor"></emu-xref> In ECMA-402, 8<sup>th</sup> Edition, the NumberFormat <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> used to throw an error when style is <emu-val>"currency"</emu-val> and maximumFractionDigits was set to a value lower than the default fractional digits for that currency. This behaviour was corrected in the 9<sup>th</sup> edition, and it no longer throws an error.
+      <emu-xref href="#sec-intl-numberformat-constructor"></emu-xref> In ECMA-402, 8<sup>th</sup> Edition, the NumberFormat constructor used to throw an error when style is <emu-val>"currency"</emu-val> and maximumFractionDigits was set to a value lower than the default fractional digits for that currency. This behaviour was corrected in the 9<sup>th</sup> edition, and it no longer throws an error.
     </li>
   </ul>
 </emu-annex>

--- a/out/negotiation/diff.html
+++ b/out/negotiation/diff.html
@@ -1,6 +1,88 @@
 <!doctype html>
-<head><meta charset="utf-8"><script type="application/json" id="menu-search-biblio">[{"type":"clause","id":"sec-internal-slots","aoid":null,"title":"Internal slots of Service Constructors","titleHTML":"Internal slots of Service Constructors","number":"1.1","namespace":"<no location>","location":"","referencingIds":["_ref_1"],"key":"Internal slots of Service Constructors"},{"type":"op","aoid":"CanonicalizeLocaleList","refId":"sec-canonicalizelocalelist","location":"","referencingIds":[],"key":"CanonicalizeLocaleList"},{"type":"clause","id":"sec-canonicalizelocalelist","aoid":"CanonicalizeLocaleList","title":"CanonicalizeLocaleList ( locales )","titleHTML":"CanonicalizeLocaleList ( <var>locales</var> )","number":"1.2.1","namespace":"<no location>","location":"","referencingIds":["_ref_14","_ref_16"],"key":"CanonicalizeLocaleList ( locales )"},{"type":"op","aoid":"BestAvailableLocale","refId":"sec-bestavailablelocale","location":"","referencingIds":[],"key":"BestAvailableLocale"},{"type":"clause","id":"sec-bestavailablelocale","aoid":"BestAvailableLocale","title":"BestAvailableLocale ( availableLocales, locale )","titleHTML":"BestAvailableLocale ( <var>availableLocales</var>, <var>locale</var> )","number":"1.2.2","namespace":"<no location>","location":"","referencingIds":["_ref_15","_ref_28"],"key":"BestAvailableLocale ( availableLocales, locale )"},{"type":"op","aoid":"LookupMatcher","refId":"sec-lookupmatcher","location":"","referencingIds":[],"key":"LookupMatcher"},{"type":"clause","id":"sec-lookupmatcher","aoid":"LookupMatcher","title":"LookupMatcher ( availableLocales, requestedLocales )","titleHTML":"LookupMatcher ( <var>availableLocales</var>, <var>requestedLocales</var> )","number":"1.2.3","namespace":"<no location>","location":"","referencingIds":["_ref_17","_ref_18"],"key":"LookupMatcher ( availableLocales, requestedLocales )"},{"type":"op","aoid":"BestFitMatcher","refId":"sec-bestfitmatcher","location":"","referencingIds":[],"key":"BestFitMatcher"},{"type":"clause","id":"sec-bestfitmatcher","aoid":"BestFitMatcher","title":"BestFitMatcher ( availableLocales, requestedLocales )","titleHTML":"BestFitMatcher ( <var>availableLocales</var>, <var>requestedLocales</var> )","number":"1.2.4","namespace":"<no location>","location":"","referencingIds":["_ref_19"],"key":"BestFitMatcher ( availableLocales, requestedLocales )"},{"type":"op","aoid":"UnicodeExtensionComponents","refId":"sec-unicode-extension-components","location":"","referencingIds":[],"key":"UnicodeExtensionComponents"},{"type":"clause","id":"sec-unicode-extension-components","aoid":"UnicodeExtensionComponents","title":"UnicodeExtensionComponents ( extension )","titleHTML":"UnicodeExtensionComponents ( <var>extension</var> )","number":"1.2.5","namespace":"<no location>","location":"","referencingIds":["_ref_20"],"key":"UnicodeExtensionComponents ( extension )"},{"type":"op","aoid":"InsertUnicodeExtensionAndCanonicalize","refId":"sec-insert-unicode-extension-and-canonicalize","location":"","referencingIds":[],"key":"InsertUnicodeExtensionAndCanonicalize"},{"type":"clause","id":"sec-insert-unicode-extension-and-canonicalize","aoid":"InsertUnicodeExtensionAndCanonicalize","title":"InsertUnicodeExtensionAndCanonicalize ( locale, extension )","titleHTML":"InsertUnicodeExtensionAndCanonicalize ( <var>locale</var>, <var>extension</var> )","number":"1.2.6","namespace":"<no location>","location":"","referencingIds":["_ref_27"],"key":"InsertUnicodeExtensionAndCanonicalize ( locale, extension )"},{"type":"op","aoid":"ResolveLocale","refId":"sec-resolvelocale","location":"","referencingIds":[],"key":"ResolveLocale"},{"type":"clause","id":"sec-resolvelocale","aoid":"ResolveLocale","title":"ResolveLocale ( availableLocales, requestedLocales, options, relevantExtensionKeys, localeData )","titleHTML":"ResolveLocale ( <var>availableLocales</var>, <var>requestedLocales</var>, <var>options</var>, <var>relevantExtensionKeys</var>, <var>localeData</var> )","number":"1.2.7","namespace":"<no location>","location":"","referencingIds":["_ref_0"],"key":"ResolveLocale ( availableLocales, requestedLocales, options, relevantExtensionKeys, localeData )"},{"type":"op","aoid":"LookupSupportedLocales","refId":"sec-lookupsupportedlocales","location":"","referencingIds":[],"key":"LookupSupportedLocales"},{"type":"clause","id":"sec-lookupsupportedlocales","aoid":"LookupSupportedLocales","title":"LookupSupportedLocales ( availableLocales, requestedLocales )","titleHTML":"LookupSupportedLocales ( <var>availableLocales</var>, <var>requestedLocales</var> )","number":"1.2.8","namespace":"<no location>","location":"","referencingIds":["_ref_31"],"key":"LookupSupportedLocales ( availableLocales, requestedLocales )"},{"type":"op","aoid":"BestFitSupportedLocales","refId":"sec-bestfitsupportedlocales","location":"","referencingIds":[],"key":"BestFitSupportedLocales"},{"type":"clause","id":"sec-bestfitsupportedlocales","aoid":"BestFitSupportedLocales","title":"BestFitSupportedLocales ( availableLocales, requestedLocales )","titleHTML":"BestFitSupportedLocales ( <var>availableLocales</var>, <var>requestedLocales</var> )","number":"1.2.9","namespace":"<no location>","location":"","referencingIds":["_ref_30"],"key":"BestFitSupportedLocales ( availableLocales, requestedLocales )"},{"type":"op","aoid":"SupportedLocales","refId":"sec-supportedlocales","location":"","referencingIds":[],"key":"SupportedLocales"},{"type":"clause","id":"sec-supportedlocales","aoid":"SupportedLocales","title":"SupportedLocales ( availableLocales, requestedLocales, options )","titleHTML":"SupportedLocales ( <var>availableLocales</var>, <var>requestedLocales</var>, <var>options</var> )","number":"1.2.10","namespace":"<no location>","location":"","referencingIds":[],"key":"SupportedLocales ( availableLocales, requestedLocales, options )"},{"type":"op","aoid":"GetOptionsObject","refId":"sec-getoptionsobject","location":"","referencingIds":[],"key":"GetOptionsObject"},{"type":"clause","id":"sec-getoptionsobject","aoid":"GetOptionsObject","title":"GetOptionsObject ( options )","titleHTML":"GetOptionsObject ( <var>options</var> )","number":"1.2.11","namespace":"<no location>","location":"","referencingIds":["_ref_34"],"key":"GetOptionsObject ( options )"},{"type":"op","aoid":"CoerceOptionsToObject","refId":"sec-coerceoptionstoobject","location":"","referencingIds":[],"key":"CoerceOptionsToObject"},{"type":"clause","id":"sec-coerceoptionstoobject","aoid":"CoerceOptionsToObject","title":"CoerceOptionsToObject ( options )","titleHTML":"CoerceOptionsToObject ( <var>options</var> )","number":"1.2.12","namespace":"<no location>","location":"","referencingIds":["_ref_29"],"key":"CoerceOptionsToObject ( options )"},{"type":"clause","id":"sec-getoption","aoid":null,"title":"\n        GetOption (\n          options: an Object,\n          property: a property key,\n          type: boolean, number, or string,\n          values: empty or a List of ECMAScript language values,\n          default: required or an ECMAScript language value,\n        )\n      ","titleHTML":"\n        GetOption (\n          <var>options</var>: an Object,\n          <var>property</var>: a property key,\n          <var>type</var>: <emu-const>boolean</emu-const>, <emu-const>number</emu-const>, or <emu-const>string</emu-const>,\n          <var>values</var>: <emu-const>empty</emu-const> or a List of ECMAScript language values,\n          <var>default</var>: <emu-const>required</emu-const> or an ECMAScript language value,\n        )\n      ","number":"1.2.13","namespace":"<no location>","location":"","referencingIds":[],"key":"\n        GetOption (\n          options: an Object,\n          property: a property key,\n          type: boolean, number, or string,\n          values: empty or a List of ECMAScript language values,\n          default: required or an ECMAScript language value,\n        )\n      "},{"type":"op","aoid":"GetStringOrBooleanOption","refId":"sec-getstringorbooleanoption","location":"","referencingIds":[],"key":"GetStringOrBooleanOption"},{"type":"clause","id":"sec-getstringorbooleanoption","aoid":"GetStringOrBooleanOption","title":"GetStringOrBooleanOption ( options, property, values, trueValue, falsyValue, fallback )","titleHTML":"GetStringOrBooleanOption ( <var>options</var>, <var>property</var>, <var>values</var>, <var>trueValue</var>, <var>falsyValue</var>, <var>fallback</var> )","number":"1.2.14","namespace":"<no location>","location":"","referencingIds":[],"key":"GetStringOrBooleanOption ( options, property, values, trueValue, falsyValue, fallback )"},{"type":"op","aoid":"DefaultNumberOption","refId":"sec-defaultnumberoption","location":"","referencingIds":[],"key":"DefaultNumberOption"},{"type":"clause","id":"sec-defaultnumberoption","aoid":"DefaultNumberOption","title":"DefaultNumberOption ( value, minimum, maximum, fallback )","titleHTML":"DefaultNumberOption ( <var>value</var>, <var>minimum</var>, <var>maximum</var>, <var>fallback</var> )","number":"1.2.15","namespace":"<no location>","location":"","referencingIds":["_ref_46"],"key":"DefaultNumberOption ( value, minimum, maximum, fallback )"},{"type":"op","aoid":"GetNumberOption","refId":"sec-getnumberoption","location":"","referencingIds":[],"key":"GetNumberOption"},{"type":"clause","id":"sec-getnumberoption","aoid":"GetNumberOption","title":"GetNumberOption ( options, property, minimum, maximum, fallback )","titleHTML":"GetNumberOption ( <var>options</var>, <var>property</var>, <var>minimum</var>, <var>maximum</var>, <var>fallback</var> )","number":"1.2.16","namespace":"<no location>","location":"","referencingIds":[],"key":"GetNumberOption ( options, property, minimum, maximum, fallback )"},{"type":"op","aoid":"PartitionPattern","refId":"sec-partitionpattern","location":"","referencingIds":[],"key":"PartitionPattern"},{"type":"clause","id":"sec-partitionpattern","aoid":"PartitionPattern","title":"PartitionPattern ( pattern )","titleHTML":"PartitionPattern ( <var>pattern</var> )","number":"1.2.17","namespace":"<no location>","location":"","referencingIds":[],"key":"PartitionPattern ( pattern )"},{"type":"clause","id":"sec-abstract-operations","aoid":null,"title":"Abstract Operations","titleHTML":"Abstract Operations","number":"1.2","namespace":"<no location>","location":"","referencingIds":[],"key":"Abstract Operations"},{"type":"clause","id":"locale-and-parameter-negotiation","aoid":null,"title":"Locale and Parameter Negotiation","titleHTML":"Locale and Parameter Negotiation","number":"1","namespace":"<no location>","location":"","referencingIds":[],"key":"Locale and Parameter Negotiation"}]</script><script>"use strict";
+<head><meta charset="utf-8"><script>'use strict';
+let sdoBox = {
+  init() {
+    this.$alternativeId = null;
+    this.$outer = document.createElement('div');
+    this.$outer.classList.add('toolbox-container');
+    this.$container = document.createElement('div');
+    this.$container.classList.add('toolbox');
+    this.$displayLink = document.createElement('a');
+    this.$displayLink.setAttribute('href', '#');
+    this.$displayLink.textContent = 'Syntax-Directed Operations';
+    this.$displayLink.addEventListener('click', e => {
+      e.preventDefault();
+      e.stopPropagation();
+      referencePane.showSDOs(sdoMap[this.$alternativeId] || {}, this.$alternativeId);
+    });
+    this.$container.appendChild(this.$displayLink);
+    this.$outer.appendChild(this.$container);
+    document.body.appendChild(this.$outer);
+  },
 
+  activate(el) {
+    clearTimeout(this.deactiveTimeout);
+    Toolbox.deactivate();
+    this.$alternativeId = el.id;
+    let numSdos = Object.keys(sdoMap[this.$alternativeId] || {}).length;
+    this.$displayLink.textContent = 'Syntax-Directed Operations (' + numSdos + ')';
+    this.$outer.classList.add('active');
+    let top = el.offsetTop - this.$outer.offsetHeight;
+    let left = el.offsetLeft + 50 - 10; // 50px = padding-left(=75px) + text-indent(=-25px)
+    this.$outer.setAttribute('style', 'left: ' + left + 'px; top: ' + top + 'px');
+    if (top < document.body.scrollTop) {
+      this.$container.scrollIntoView();
+    }
+  },
+
+  deactivate() {
+    clearTimeout(this.deactiveTimeout);
+    this.$outer.classList.remove('active');
+  },
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+  if (typeof sdoMap == 'undefined') {
+    console.error('could not find sdo map');
+    return;
+  }
+  sdoBox.init();
+
+  let insideTooltip = false;
+  sdoBox.$outer.addEventListener('pointerenter', () => {
+    insideTooltip = true;
+  });
+  sdoBox.$outer.addEventListener('pointerleave', () => {
+    insideTooltip = false;
+    sdoBox.deactivate();
+  });
+
+  sdoBox.deactiveTimeout = null;
+  [].forEach.call(document.querySelectorAll('emu-grammar[type=definition] emu-rhs'), node => {
+    node.addEventListener('pointerenter', function () {
+      sdoBox.activate(this);
+    });
+
+    node.addEventListener('pointerleave', () => {
+      sdoBox.deactiveTimeout = setTimeout(() => {
+        if (!insideTooltip) {
+          sdoBox.deactivate();
+        }
+      }, 500);
+    });
+  });
+
+  document.addEventListener(
+    'keydown',
+    debounce(e => {
+      if (e.code === 'Escape') {
+        sdoBox.deactivate();
+      }
+    })
+  );
+});
+
+'use strict';
 function Search(menu) {
   this.menu = menu;
   this.$search = document.getElementById('menu-search');
@@ -11,8 +93,14 @@ function Search(menu) {
 
   document.addEventListener('keydown', this.documentKeydown.bind(this));
 
-  this.$searchBox.addEventListener('keydown', debounce(this.searchBoxKeydown.bind(this), { stopPropagation: true }));
-  this.$searchBox.addEventListener('keyup', debounce(this.searchBoxKeyup.bind(this), { stopPropagation: true }));
+  this.$searchBox.addEventListener(
+    'keydown',
+    debounce(this.searchBoxKeydown.bind(this), { stopPropagation: true })
+  );
+  this.$searchBox.addEventListener(
+    'keyup',
+    debounce(this.searchBoxKeyup.bind(this), { stopPropagation: true })
+  );
 
   // Perform an initial search if the box is not empty.
   if (this.$searchBox.value) {
@@ -21,26 +109,34 @@ function Search(menu) {
 }
 
 Search.prototype.loadBiblio = function () {
-  var $biblio = document.getElementById('menu-search-biblio');
-  if (!$biblio) {
-    this.biblio = [];
+  if (typeof biblio === 'undefined') {
+    console.error('could not find biblio');
+    this.biblio = { refToClause: {}, entries: [] };
   } else {
-    this.biblio = JSON.parse($biblio.textContent);
-    this.biblio.clauses = this.biblio.filter(function (e) { return e.type === 'clause' });
-    this.biblio.byId = this.biblio.reduce(function (map, entry) {
+    this.biblio = biblio;
+    this.biblio.clauses = this.biblio.entries.filter(e => e.type === 'clause');
+    this.biblio.byId = this.biblio.entries.reduce((map, entry) => {
       map[entry.id] = entry;
       return map;
     }, {});
+    let refParentClause = Object.create(null);
+    this.biblio.refParentClause = refParentClause;
+    let refsByClause = this.biblio.refsByClause;
+    Object.keys(refsByClause).forEach(clause => {
+      refsByClause[clause].forEach(ref => {
+        refParentClause[ref] = clause;
+      });
+    });
   }
-}
+};
 
 Search.prototype.documentKeydown = function (e) {
-  if (e.keyCode === 191) {
+  if (e.key === '/') {
     e.preventDefault();
     e.stopPropagation();
     this.triggerSearch();
   }
-}
+};
 
 Search.prototype.searchBoxKeydown = function (e) {
   e.stopPropagation();
@@ -51,7 +147,7 @@ Search.prototype.searchBoxKeydown = function (e) {
     e.preventDefault();
     this.selectResult();
   }
-}
+};
 
 Search.prototype.searchBoxKeyup = function (e) {
   if (e.keyCode === 13 || e.keyCode === 9) {
@@ -59,10 +155,9 @@ Search.prototype.searchBoxKeyup = function (e) {
   }
 
   this.search(e.target.value);
-}
+};
 
-
-Search.prototype.triggerSearch = function (e) {
+Search.prototype.triggerSearch = function () {
   if (this.menu.isVisible()) {
     this._closeAfterSearch = false;
   } else {
@@ -72,14 +167,14 @@ Search.prototype.triggerSearch = function (e) {
 
   this.$searchBox.focus();
   this.$searchBox.select();
-}
+};
 // bit 12 - Set if the result starts with searchString
 // bits 8-11: 8 - number of chunks multiplied by 2 if cases match, otherwise 1.
 // bits 1-7: 127 - length of the entry
 // General scheme: prefer case sensitive matches with fewer chunks, and otherwise
 // prefer shorter matches.
-function relevance(result, searchString) {
-  var relevance = 0;
+function relevance(result) {
+  let relevance = 0;
 
   relevance = Math.max(0, 8 - result.match.chunks) << 7;
 
@@ -88,10 +183,10 @@ function relevance(result, searchString) {
   }
 
   if (result.match.prefix) {
-    relevance += 2048
+    relevance += 2048;
   }
 
-  relevance += Math.max(0, 255 - result.entry.key.length);
+  relevance += Math.max(0, 255 - result.key.length);
 
   return relevance;
 }
@@ -110,36 +205,34 @@ Search.prototype.search = function (searchString) {
     return;
   }
 
-  var results;
+  let results;
 
-  if (/^[\d\.]*$/.test(searchString)) {
-    results = this.biblio.clauses.filter(function (clause) {
-      return clause.number.substring(0, searchString.length) === searchString;
-    }).map(function (clause) {
-      return { entry: clause };
-    });
+  if (/^[\d.]*$/.test(searchString)) {
+    results = this.biblio.clauses
+      .filter(clause => clause.number.substring(0, searchString.length) === searchString)
+      .map(clause => ({ key: getKey(clause), entry: clause }));
   } else {
     results = [];
 
-    for (var i = 0; i < this.biblio.length; i++) {
-      var entry = this.biblio[i];
-      if (!entry.key) {
+    for (let i = 0; i < this.biblio.entries.length; i++) {
+      let entry = this.biblio.entries[i];
+      let key = getKey(entry);
+      if (!key) {
         // biblio entries without a key aren't searchable
         continue;
       }
 
-      var match = fuzzysearch(searchString, entry.key);
+      let match = fuzzysearch(searchString, key);
       if (match) {
-        results.push({ entry: entry, match: match });
+        results.push({ key, entry, match });
       }
     }
 
-    results.forEach(function (result) {
+    results.forEach(result => {
       result.relevance = relevance(result, searchString);
     });
 
-    results = results.sort(function (a, b) { return b.relevance - a.relevance });
-
+    results = results.sort((a, b) => b.relevance - a.relevance);
   }
 
   if (results.length > 50) {
@@ -147,17 +240,17 @@ Search.prototype.search = function (searchString) {
   }
 
   this.displayResults(results);
-}
+};
 Search.prototype.hideSearch = function () {
   this.$search.classList.remove('active');
-}
+};
 
 Search.prototype.showSearch = function () {
   this.$search.classList.add('active');
-}
+};
 
 Search.prototype.selectResult = function () {
-  var $first = this.$searchResults.querySelector('li:first-child a');
+  let $first = this.$searchResults.querySelector('li:first-child a');
 
   if ($first) {
     document.location = $first.getAttribute('href');
@@ -171,53 +264,79 @@ Search.prototype.selectResult = function () {
   if (this._closeAfterSearch) {
     this.menu.hide();
   }
-}
+};
 
 Search.prototype.displayResults = function (results) {
   if (results.length > 0) {
     this.$searchResults.classList.remove('no-results');
 
-    var html = '<ul>';
+    let html = '<ul>';
 
-    results.forEach(function (result) {
-      var entry = result.entry;
-      var id = entry.id;
-      var cssClass = '';
-      var text = '';
+    results.forEach(result => {
+      let key = result.key;
+      let entry = result.entry;
+      let id = entry.id;
+      let cssClass = '';
+      let text = '';
 
       if (entry.type === 'clause') {
-        var number = entry.number ? entry.number + ' ' : '';
-        text = number + entry.key;
+        let number = entry.number ? entry.number + ' ' : '';
+        text = number + key;
         cssClass = 'clause';
         id = entry.id;
       } else if (entry.type === 'production') {
-        text = entry.key;
+        text = key;
         cssClass = 'prod';
         id = entry.id;
       } else if (entry.type === 'op') {
-        text = entry.key;
+        text = key;
         cssClass = 'op';
         id = entry.id || entry.refId;
       } else if (entry.type === 'term') {
-        text = entry.key;
+        text = key;
         cssClass = 'term';
         id = entry.id || entry.refId;
       }
 
       if (text) {
-        html += '<li class=menu-search-result-' + cssClass + '><a href="#' + id + '">' + text + '</a></li>';
+        // prettier-ignore
+        html += `<li class=menu-search-result-${cssClass}><a href="${makeLinkToId(id)}">${text}</a></li>`;
       }
     });
 
-    html += '</ul>'
+    html += '</ul>';
 
     this.$searchResults.innerHTML = html;
   } else {
     this.$searchResults.innerHTML = '';
     this.$searchResults.classList.add('no-results');
   }
-}
+};
 
+function getKey(item) {
+  if (item.key) {
+    return item.key;
+  }
+  switch (item.type) {
+    case 'clause':
+      return item.title || item.titleHTML;
+    case 'production':
+      return item.name;
+    case 'op':
+      return item.aoid;
+    case 'term':
+      return item.term;
+    case 'table':
+    case 'figure':
+    case 'example':
+    case 'note':
+      return item.caption;
+    case 'step':
+      return item.id;
+    default:
+      throw new Error("Can't get key for " + item.type);
+  }
+}
 
 function Menu() {
   this.$toggle = document.getElementById('menu-toggle');
@@ -229,7 +348,7 @@ function Menu() {
   this.$specContainer = document.getElementById('spec-container');
   this.search = new Search(this);
 
-  this._pinnedIds = {}; 
+  this._pinnedIds = {};
   this.loadPinEntries();
 
   // toggle menu
@@ -239,23 +358,23 @@ function Menu() {
   document.addEventListener('keydown', this.documentKeydown.bind(this));
 
   // toc expansion
-  var tocItems = this.$menu.querySelectorAll('#menu-toc li');
-  for (var i = 0; i < tocItems.length; i++) {
-    var $item = tocItems[i];
-    $item.addEventListener('click', function($item, event) {
+  let tocItems = this.$menu.querySelectorAll('#menu-toc li');
+  for (let i = 0; i < tocItems.length; i++) {
+    let $item = tocItems[i];
+    $item.addEventListener('click', event => {
       $item.classList.toggle('active');
       event.stopPropagation();
-    }.bind(null, $item));
+    });
   }
 
   // close toc on toc item selection
-  var tocLinks = this.$menu.querySelectorAll('#menu-toc li > a');
-  for (var i = 0; i < tocLinks.length; i++) {
-    var $link = tocLinks[i];
-    $link.addEventListener('click', function(event) {
+  let tocLinks = this.$menu.querySelectorAll('#menu-toc li > a');
+  for (let i = 0; i < tocLinks.length; i++) {
+    let $link = tocLinks[i];
+    $link.addEventListener('click', event => {
       this.toggle();
       event.stopPropagation();
-    }.bind(this));
+    });
   }
 
   // update active clause on scroll
@@ -263,14 +382,13 @@ function Menu() {
   this.updateActiveClause();
 
   // prevent menu scrolling from scrolling the body
-  this.$toc.addEventListener('wheel', function (e) {
-    var target = e.currentTarget;
-    var offTop = e.deltaY < 0 && target.scrollTop === 0;
+  this.$toc.addEventListener('wheel', e => {
+    let target = e.currentTarget;
+    let offTop = e.deltaY < 0 && target.scrollTop === 0;
     if (offTop) {
       e.preventDefault();
     }
-    var offBottom = e.deltaY > 0
-                    && target.offsetHeight + target.scrollTop >= target.scrollHeight;
+    let offBottom = e.deltaY > 0 && target.offsetHeight + target.scrollTop >= target.scrollHeight;
 
     if (offBottom) {
       e.preventDefault();
@@ -285,62 +403,66 @@ Menu.prototype.documentKeydown = function (e) {
   } else if (e.keyCode > 48 && e.keyCode < 58) {
     this.selectPin(e.keyCode - 49);
   }
-}
+};
 
 Menu.prototype.updateActiveClause = function () {
-  this.setActiveClause(findActiveClause(this.$specContainer))
-}
+  this.setActiveClause(findActiveClause(this.$specContainer));
+};
 
 Menu.prototype.setActiveClause = function (clause) {
   this.$activeClause = clause;
   this.revealInToc(this.$activeClause);
-}
+};
 
 Menu.prototype.revealInToc = function (path) {
-  var current = this.$toc.querySelectorAll('li.revealed');
-  for (var i = 0; i < current.length; i++) {
+  let current = this.$toc.querySelectorAll('li.revealed');
+  for (let i = 0; i < current.length; i++) {
     current[i].classList.remove('revealed');
     current[i].classList.remove('revealed-leaf');
   }
 
-  var current = this.$toc;
-  var index = 0;
-  while (index < path.length) {
-    var children = current.children;
-    for (var i = 0; i < children.length; i++) {
-      if ('#' + path[index].id === children[i].children[1].getAttribute('href') ) {
+  current = this.$toc;
+  let index = 0;
+  outer: while (index < path.length) {
+    let children = current.children;
+    for (let i = 0; i < children.length; i++) {
+      if ('#' + path[index].id === children[i].children[1].hash) {
         children[i].classList.add('revealed');
         if (index === path.length - 1) {
           children[i].classList.add('revealed-leaf');
-          var rect = children[i].getBoundingClientRect();
+          let rect = children[i].getBoundingClientRect();
           // this.$toc.getBoundingClientRect().top;
-          var tocRect = this.$toc.getBoundingClientRect();
+          let tocRect = this.$toc.getBoundingClientRect();
           if (rect.top + 10 > tocRect.bottom) {
-            this.$toc.scrollTop = this.$toc.scrollTop + (rect.top - tocRect.bottom) + (rect.bottom - rect.top);
+            this.$toc.scrollTop =
+              this.$toc.scrollTop + (rect.top - tocRect.bottom) + (rect.bottom - rect.top);
           } else if (rect.top < tocRect.top) {
             this.$toc.scrollTop = this.$toc.scrollTop - (tocRect.top - rect.top);
           }
         }
         current = children[i].querySelector('ol');
         index++;
-        break;
+        continue outer;
       }
     }
-
+    console.log('could not find location in table of contents', path);
+    break;
   }
-}
+};
 
 function findActiveClause(root, path) {
-  var clauses = new ClauseWalker(root);
-  var $clause;
-  var path = path || [];
+  let clauses = getChildClauses(root);
+  path = path || [];
 
-  while ($clause = clauses.nextNode()) {
-    var rect = $clause.getBoundingClientRect();
-    var $header = $clause.querySelector("h1");
-    var marginTop = parseInt(getComputedStyle($header)["margin-top"]);
+  for (let $clause of clauses) {
+    let rect = $clause.getBoundingClientRect();
+    let $header = $clause.querySelector('h1');
+    let marginTop = Math.max(
+      parseInt(getComputedStyle($clause)['margin-top']),
+      parseInt(getComputedStyle($header)['margin-top'])
+    );
 
-    if ((rect.top - marginTop) <= 0 && rect.bottom > 0) {
+    if (rect.top - marginTop <= 1 && rect.bottom > 0) {
       return findActiveClause($clause, path.concat($clause)) || path;
     }
   }
@@ -348,57 +470,49 @@ function findActiveClause(root, path) {
   return path;
 }
 
-function ClauseWalker(root) {
-  var previous;
-  var treeWalker = document.createTreeWalker(
-    root,
-    NodeFilter.SHOW_ELEMENT,
-    {
-      acceptNode: function (node) {
-        if (previous === node.parentNode) {
-          return NodeFilter.FILTER_REJECT;
-        } else {
-          previous = node;
-        }
-        if (node.nodeName === 'EMU-CLAUSE' || node.nodeName === 'EMU-INTRO' || node.nodeName === 'EMU-ANNEX') {
-          return NodeFilter.FILTER_ACCEPT;
-        } else {
-          return NodeFilter.FILTER_SKIP;
-        }
-      }
-    },
-    false
-    );
+function* getChildClauses(root) {
+  for (let el of root.children) {
+    switch (el.nodeName) {
+      // descend into <emu-import>
+      case 'EMU-IMPORT':
+        yield* getChildClauses(el);
+        break;
 
-  return treeWalker;
+      // accept <emu-clause>, <emu-intro>, and <emu-annex>
+      case 'EMU-CLAUSE':
+      case 'EMU-INTRO':
+      case 'EMU-ANNEX':
+        yield el;
+    }
+  }
 }
 
 Menu.prototype.toggle = function () {
   this.$menu.classList.toggle('active');
-}
+};
 
 Menu.prototype.show = function () {
   this.$menu.classList.add('active');
-}
+};
 
 Menu.prototype.hide = function () {
   this.$menu.classList.remove('active');
-}
+};
 
-Menu.prototype.isVisible = function() {
+Menu.prototype.isVisible = function () {
   return this.$menu.classList.contains('active');
-}
+};
 
 Menu.prototype.showPins = function () {
   this.$pins.classList.add('active');
-}
+};
 
 Menu.prototype.hidePins = function () {
   this.$pins.classList.remove('active');
-}
+};
 
 Menu.prototype.addPinEntry = function (id) {
-  var entry = this.search.biblio.byId[id];
+  let entry = this.search.biblio.byId[id];
   if (!entry) {
     // id was deleted after pin (or something) so remove it
     delete this._pinnedIds[id];
@@ -407,15 +521,16 @@ Menu.prototype.addPinEntry = function (id) {
   }
 
   if (entry.type === 'clause') {
-    var prefix;
+    let prefix;
     if (entry.number) {
       prefix = entry.number + ' ';
     } else {
       prefix = '';
     }
-    this.$pinList.innerHTML += '<li><a href="#' + entry.id + '">' + prefix + entry.titleHTML + '</a></li>';
+    // prettier-ignore
+    this.$pinList.innerHTML += `<li><a href="${makeLinkToId(entry.id)}">${prefix}${entry.titleHTML}</a></li>`;
   } else {
-    this.$pinList.innerHTML += '<li><a href="#' + entry.id + '">' + entry.key + '</a></li>';
+    this.$pinList.innerHTML += `<li><a href="${makeLinkToId(entry.id)}">${getKey(entry)}</a></li>`;
   }
 
   if (Object.keys(this._pinnedIds).length === 0) {
@@ -423,10 +538,10 @@ Menu.prototype.addPinEntry = function (id) {
   }
   this._pinnedIds[id] = true;
   this.persistPinEntries();
-}
+};
 
 Menu.prototype.removePinEntry = function (id) {
-  var item = this.$pinList.querySelector('a[href="#' + id + '"]').parentNode;
+  let item = this.$pinList.querySelector(`a[href="${makeLinkToId(id)}"]`).parentNode;
   this.$pinList.removeChild(item);
   delete this._pinnedIds[id];
   if (Object.keys(this._pinnedIds).length === 0) {
@@ -434,7 +549,7 @@ Menu.prototype.removePinEntry = function (id) {
   }
 
   this.persistPinEntries();
-}
+};
 
 Menu.prototype.persistPinEntries = function () {
   try {
@@ -444,7 +559,7 @@ Menu.prototype.persistPinEntries = function () {
   }
 
   localStorage.pinEntries = JSON.stringify(Object.keys(this._pinnedIds));
-}
+};
 
 Menu.prototype.loadPinEntries = function () {
   try {
@@ -453,13 +568,13 @@ Menu.prototype.loadPinEntries = function () {
     return;
   }
 
-  var pinsString = window.localStorage.pinEntries;
+  let pinsString = window.localStorage.pinEntries;
   if (!pinsString) return;
-  var pins = JSON.parse(pinsString);
-  for(var i = 0; i < pins.length; i++) {
+  let pins = JSON.parse(pinsString);
+  for (let i = 0; i < pins.length; i++) {
     this.addPinEntry(pins[i]);
   }
-}
+};
 
 Menu.prototype.togglePinEntry = function (id) {
   if (!id) {
@@ -471,62 +586,49 @@ Menu.prototype.togglePinEntry = function (id) {
   } else {
     this.addPinEntry(id);
   }
-}
+};
 
 Menu.prototype.selectPin = function (num) {
   document.location = this.$pinList.children[num].children[0].href;
-}
+};
 
-var menu;
-function init() {
-  menu = new Menu();
-  var $container = document.getElementById('spec-container');
-  $container.addEventListener('mouseover', debounce(function (e) {
-    Toolbox.activateIfMouseOver(e);
-  }));
-  document.addEventListener('keydown', debounce(function (e) {
-    if (e.code === "Escape" && Toolbox.active) {
-      Toolbox.deactivate();
-    }
-  }));
-}
+let menu;
 
 document.addEventListener('DOMContentLoaded', init);
 
 function debounce(fn, opts) {
   opts = opts || {};
-  var timeout;
-  return function(e) {
+  let timeout;
+  return function (e) {
     if (opts.stopPropagation) {
       e.stopPropagation();
     }
-    var args = arguments;
+    let args = arguments;
     if (timeout) {
       clearTimeout(timeout);
     }
-    timeout = setTimeout(function() {
+    timeout = setTimeout(() => {
       timeout = null;
       fn.apply(this, args);
-    }.bind(this), 150);
-  }
+    }, 150);
+  };
 }
 
-var CLAUSE_NODES = ['EMU-CLAUSE', 'EMU-INTRO', 'EMU-ANNEX'];
-function findLocalReferences ($elem) {
-  var name = $elem.innerHTML;
-  var references = [];
-
-  var parentClause = $elem.parentNode;
+let CLAUSE_NODES = ['EMU-CLAUSE', 'EMU-INTRO', 'EMU-ANNEX'];
+function findContainer($elem) {
+  let parentClause = $elem.parentNode;
   while (parentClause && CLAUSE_NODES.indexOf(parentClause.nodeName) === -1) {
     parentClause = parentClause.parentNode;
   }
+  return parentClause;
+}
 
-  if(!parentClause) return;
+function findLocalReferences(parentClause, name) {
+  let vars = parentClause.querySelectorAll('var');
+  let references = [];
 
-  var vars = parentClause.querySelectorAll('var');
-
-  for (var i = 0; i < vars.length; i++) {
-    var $var = vars[i];
+  for (let i = 0; i < vars.length; i++) {
+    let $var = vars[i];
 
     if ($var.innerHTML === name) {
       references.push($var);
@@ -536,21 +638,38 @@ function findLocalReferences ($elem) {
   return references;
 }
 
+let REFERENCED_CLASSES = Array.from({ length: 7 }, (x, i) => `referenced${i}`);
+function chooseHighlightIndex(parentClause) {
+  let counts = REFERENCED_CLASSES.map($class => parentClause.getElementsByClassName($class).length);
+  // Find the earliest index with the lowest count.
+  let minCount = Infinity;
+  let index = null;
+  for (let i = 0; i < counts.length; i++) {
+    if (counts[i] < minCount) {
+      minCount = counts[i];
+      index = i;
+    }
+  }
+  return index;
+}
+
 function toggleFindLocalReferences($elem) {
-  var references = findLocalReferences($elem);
+  let parentClause = findContainer($elem);
+  let references = findLocalReferences(parentClause, $elem.innerHTML);
   if ($elem.classList.contains('referenced')) {
-    references.forEach(function ($reference) {
-      $reference.classList.remove('referenced');
+    references.forEach($reference => {
+      $reference.classList.remove('referenced', ...REFERENCED_CLASSES);
     });
   } else {
-    references.forEach(function ($reference) {
-      $reference.classList.add('referenced');
+    let index = chooseHighlightIndex(parentClause);
+    references.forEach($reference => {
+      $reference.classList.add('referenced', `referenced${index}`);
     });
   }
 }
 
-function installFindLocalReferences () {
-  document.addEventListener('click', function (e) {
+function installFindLocalReferences() {
+  document.addEventListener('click', e => {
     if (e.target.nodeName === 'VAR') {
       toggleFindLocalReferences(e.target);
     }
@@ -558,9 +677,6 @@ function installFindLocalReferences () {
 }
 
 document.addEventListener('DOMContentLoaded', installFindLocalReferences);
-
-
-
 
 // The following license applies to the fuzzysearch function
 // The MIT License (MIT)
@@ -582,11 +698,11 @@ document.addEventListener('DOMContentLoaded', installFindLocalReferences);
 // COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-function fuzzysearch (searchString, haystack, caseInsensitive) {
-  var tlen = haystack.length;
-  var qlen = searchString.length;
-  var chunks = 1;
-  var finding = false;
+function fuzzysearch(searchString, haystack, caseInsensitive) {
+  let tlen = haystack.length;
+  let qlen = searchString.length;
+  let chunks = 1;
+  let finding = false;
 
   if (qlen > tlen) {
     return false;
@@ -602,10 +718,11 @@ function fuzzysearch (searchString, haystack, caseInsensitive) {
     }
   }
 
-  outer: for (var i = 0, j = 0; i < qlen; i++) {
-    var nch = searchString[i];
+  let j = 0;
+  outer: for (let i = 0; i < qlen; i++) {
+    let nch = searchString[i];
     while (j < tlen) {
-      var targetChar = haystack[j++];
+      let targetChar = haystack[j++];
       if (targetChar === nch) {
         finding = true;
         continue outer;
@@ -616,113 +733,24 @@ function fuzzysearch (searchString, haystack, caseInsensitive) {
       }
     }
 
-    if (caseInsensitive) { return false; }
+    if (caseInsensitive) {
+      return false;
+    }
 
     return fuzzysearch(searchString.toLowerCase(), haystack.toLowerCase(), true);
   }
 
-  return { caseMatch: !caseInsensitive, chunks: chunks, prefix: j <= qlen };
+  return { caseMatch: !caseInsensitive, chunks, prefix: j <= qlen };
 }
 
-var Toolbox = {
-  init: function () {
-    this.$container = document.createElement('div');
-    this.$container.classList.add('toolbox');
-    this.$permalink = document.createElement('a');
-    this.$permalink.textContent = 'Permalink';
-    this.$pinLink = document.createElement('a');
-    this.$pinLink.textContent = 'Pin';
-    this.$pinLink.setAttribute('href', '#');
-    this.$pinLink.addEventListener('click', function (e) {
-      e.preventDefault();
-      e.stopPropagation();
-      menu.togglePinEntry(this.entry.id);
-    }.bind(this));
-
-    this.$refsLink = document.createElement('a');
-    this.$refsLink.setAttribute('href', '#');
-    this.$refsLink.addEventListener('click', function (e) {
-      e.preventDefault();
-      e.stopPropagation();
-      referencePane.showReferencesFor(this.entry);
-    }.bind(this));
-    this.$container.appendChild(this.$permalink);
-    this.$container.appendChild(this.$pinLink);
-    this.$container.appendChild(this.$refsLink);
-    document.body.appendChild(this.$container);
-  },
-
-  activate: function (el, entry, target) {
-    if (el === this._activeEl) return;
-    this.active = true;
-    this.entry = entry;
-    this.$container.classList.add('active');
-    this.top = el.offsetTop - this.$container.offsetHeight - 10;
-    this.left = el.offsetLeft;
-    this.$container.setAttribute('style', 'left: ' + this.left + 'px; top: ' + this.top + 'px');
-    this.updatePermalink();
-    this.updateReferences();
-    this._activeEl = el;
-    if (this.top < document.body.scrollTop && el === target) {
-      // don't scroll unless it's a small thing (< 200px)
-      this.$container.scrollIntoView();
-    }
-  },
-
-  updatePermalink: function () {
-    this.$permalink.setAttribute('href', '#' + this.entry.id);
-  },
-
-  updateReferences: function () {
-    this.$refsLink.textContent = 'References (' + this.entry.referencingIds.length + ')';
-  },
-
-  activateIfMouseOver: function (e) {
-    var ref = this.findReferenceUnder(e.target);
-    if (ref && (!this.active || e.pageY > this._activeEl.offsetTop)) {
-      var entry = menu.search.biblio.byId[ref.id];
-      this.activate(ref.element, entry, e.target);
-    } else if (this.active && ((e.pageY < this.top) || e.pageY > (this._activeEl.offsetTop + this._activeEl.offsetHeight))) {
-      this.deactivate();
-    }
-  },
-
-  findReferenceUnder: function (el) {
-    while (el) {
-      var parent = el.parentNode;
-      if (el.nodeName === 'H1' && parent.nodeName.match(/EMU-CLAUSE|EMU-ANNEX|EMU-INTRO/) && parent.id) {
-        return { element: el, id: parent.id };
-      } else if (el.nodeName.match(/EMU-(?!CLAUSE|XREF|ANNEX|INTRO)|DFN/) &&
-                el.id && el.id[0] !== '_') {
-        if (el.nodeName === 'EMU-FIGURE' || el.nodeName === 'EMU-TABLE' || el.nodeName === 'EMU-EXAMPLE') {
-          // return the figcaption element
-          return { element: el.children[0].children[0], id: el.id };
-        } else if (el.nodeName === 'EMU-PRODUCTION') {
-          // return the LHS non-terminal element
-          return { element: el.children[0], id: el.id };
-        } else {
-          return { element: el, id: el.id };
-        }
-      }
-      el = parent;
-    }
-  },
-
-  deactivate: function () {
-    this.$container.classList.remove('active');
-    this._activeEl = null;
-    this.activeElBounds = null;
-    this.active = false;
-  }
-}
-
-var referencePane = {
-  init: function() {
+let referencePane = {
+  init() {
     this.$container = document.createElement('div');
     this.$container.setAttribute('id', 'references-pane-container');
 
-    var $spacer = document.createElement('div');
+    let $spacer = document.createElement('div');
     $spacer.setAttribute('id', 'references-pane-spacer');
+    $spacer.classList.add('menu-spacer');
 
     this.$pane = document.createElement('div');
     this.$pane.setAttribute('id', 'references-pane');
@@ -732,18 +760,19 @@ var referencePane = {
 
     this.$header = document.createElement('div');
     this.$header.classList.add('menu-pane-header');
-    this.$header.textContent = 'References to ';
+    this.$headerText = document.createElement('span');
+    this.$header.appendChild(this.$headerText);
     this.$headerRefId = document.createElement('a');
     this.$header.appendChild(this.$headerRefId);
     this.$closeButton = document.createElement('span');
     this.$closeButton.setAttribute('id', 'references-pane-close');
-    this.$closeButton.addEventListener('click', function (e) {
+    this.$closeButton.addEventListener('click', () => {
       this.deactivate();
-    }.bind(this));
+    });
     this.$header.appendChild(this.$closeButton);
 
     this.$pane.appendChild(this.$header);
-    var tableContainer = document.createElement('div');
+    let tableContainer = document.createElement('div');
     tableContainer.setAttribute('id', 'references-pane-table-container');
 
     this.$table = document.createElement('table');
@@ -757,70 +786,238 @@ var referencePane = {
     menu.$specContainer.appendChild(this.$container);
   },
 
-  activate: function () {
+  activate() {
     this.$container.classList.add('active');
   },
 
-  deactivate: function () {
+  deactivate() {
     this.$container.classList.remove('active');
+    this.state = null;
   },
 
   showReferencesFor(entry) {
     this.activate();
-    var newBody = document.createElement('tbody');
-    var previousId;
-    var previousCell;
-    var dupCount = 0;
+    this.state = { type: 'ref', id: entry.id };
+    this.$headerText.textContent = 'References to ';
+    let newBody = document.createElement('tbody');
+    let previousId;
+    let previousCell;
+    let dupCount = 0;
     this.$headerRefId.textContent = '#' + entry.id;
-    this.$headerRefId.setAttribute('href', '#' + entry.id);
-    entry.referencingIds.map(function (id) {
-      var target = document.getElementById(id);
-      var cid = findParentClauseId(target);
-      var clause = menu.search.biblio.byId[cid];
-      return { id: id, clause: clause }
-    }).sort(function (a, b) {
-      return sortByClauseNumber(a.clause, b.clause);
-    }).forEach(function (record, i) {
-      if (previousId === record.clause.id) {
-        previousCell.innerHTML += ' (<a href="#' + record.id + '">' + (dupCount + 2) + '</a>)';
-        dupCount++;
-      } else {
-        var row = newBody.insertRow();
-        var cell = row.insertCell();
-        cell.innerHTML = record.clause.number;
-        cell = row.insertCell();
-        cell.innerHTML = '<a href="#' + record.id + '">' + record.clause.titleHTML + '</a>';
-        previousCell = cell;
-        previousId = record.clause.id;
-        dupCount = 0;
-      }
-    }, this);
+    this.$headerRefId.setAttribute('href', makeLinkToId(entry.id));
+    this.$headerRefId.style.display = 'inline';
+    (entry.referencingIds || [])
+      .map(id => {
+        let cid = menu.search.biblio.refParentClause[id];
+        let clause = menu.search.biblio.byId[cid];
+        if (clause == null) {
+          throw new Error('could not find clause for id ' + cid);
+        }
+        return { id, clause };
+      })
+      .sort((a, b) => sortByClauseNumber(a.clause, b.clause))
+      .forEach(record => {
+        if (previousId === record.clause.id) {
+          previousCell.innerHTML += ` (<a href="${makeLinkToId(record.id)}">${dupCount + 2}</a>)`;
+          dupCount++;
+        } else {
+          let row = newBody.insertRow();
+          let cell = row.insertCell();
+          cell.innerHTML = record.clause.number;
+          cell = row.insertCell();
+          cell.innerHTML = `<a href="${makeLinkToId(record.id)}">${record.clause.titleHTML}</a>`;
+          previousCell = cell;
+          previousId = record.clause.id;
+          dupCount = 0;
+        }
+      }, this);
     this.$table.removeChild(this.$tableBody);
     this.$tableBody = newBody;
     this.$table.appendChild(this.$tableBody);
-  }
-}
-function findParentClauseId(node) {
-  while (node && node.nodeName !== 'EMU-CLAUSE' && node.nodeName !== 'EMU-INTRO' && node.nodeName !== 'EMU-ANNEX') {
-    node = node.parentNode;
-  }
-  if (!node) return null;
-  return node.getAttribute('id');
-}
+  },
 
-function sortByClauseNumber(c1, c2) {
-  var c1c = c1.number.split('.');
-  var c2c = c2.number.split('.');
+  showSDOs(sdos, alternativeId) {
+    let rhs = document.getElementById(alternativeId);
+    let parentName = rhs.parentNode.getAttribute('name');
+    let colons = rhs.parentNode.querySelector('emu-geq');
+    rhs = rhs.cloneNode(true);
+    rhs.querySelectorAll('emu-params,emu-constraints').forEach(e => {
+      e.remove();
+    });
+    rhs.querySelectorAll('[id]').forEach(e => {
+      e.removeAttribute('id');
+    });
+    rhs.querySelectorAll('a').forEach(e => {
+      e.parentNode.replaceChild(document.createTextNode(e.textContent), e);
+    });
 
-  for (var i = 0; i < c1c.length; i++) {
+    // prettier-ignore
+    this.$headerText.innerHTML = `Syntax-Directed Operations for<br><a href="${makeLinkToId(alternativeId)}" class="menu-pane-header-production"><emu-nt>${parentName}</emu-nt> ${colons.outerHTML} </a>`;
+    this.$headerText.querySelector('a').append(rhs);
+    this.showSDOsBody(sdos, alternativeId);
+  },
+
+  showSDOsBody(sdos, alternativeId) {
+    this.activate();
+    this.state = { type: 'sdo', id: alternativeId, html: this.$headerText.innerHTML };
+    this.$headerRefId.style.display = 'none';
+    let newBody = document.createElement('tbody');
+    Object.keys(sdos).forEach(sdoName => {
+      let pair = sdos[sdoName];
+      let clause = pair.clause;
+      let ids = pair.ids;
+      let first = ids[0];
+      let row = newBody.insertRow();
+      let cell = row.insertCell();
+      cell.innerHTML = clause;
+      cell = row.insertCell();
+      let html = '<a href="' + makeLinkToId(first) + '">' + sdoName + '</a>';
+      for (let i = 1; i < ids.length; ++i) {
+        html += ' (<a href="' + makeLinkToId(ids[i]) + '">' + (i + 1) + '</a>)';
+      }
+      cell.innerHTML = html;
+    });
+    this.$table.removeChild(this.$tableBody);
+    this.$tableBody = newBody;
+    this.$table.appendChild(this.$tableBody);
+  },
+};
+
+let Toolbox = {
+  init() {
+    this.$outer = document.createElement('div');
+    this.$outer.classList.add('toolbox-container');
+    this.$container = document.createElement('div');
+    this.$container.classList.add('toolbox');
+    this.$outer.appendChild(this.$container);
+    this.$permalink = document.createElement('a');
+    this.$permalink.textContent = 'Permalink';
+    this.$pinLink = document.createElement('a');
+    this.$pinLink.textContent = 'Pin';
+    this.$pinLink.setAttribute('href', '#');
+    this.$pinLink.addEventListener('click', e => {
+      e.preventDefault();
+      e.stopPropagation();
+      menu.togglePinEntry(this.entry.id);
+      this.$pinLink.textContent = menu._pinnedIds[this.entry.id] ? 'Unpin' : 'Pin';
+    });
+
+    this.$refsLink = document.createElement('a');
+    this.$refsLink.setAttribute('href', '#');
+    this.$refsLink.addEventListener('click', e => {
+      e.preventDefault();
+      e.stopPropagation();
+      referencePane.showReferencesFor(this.entry);
+    });
+    this.$container.appendChild(this.$permalink);
+    this.$container.appendChild(this.$pinLink);
+    this.$container.appendChild(this.$refsLink);
+    document.body.appendChild(this.$outer);
+  },
+
+  activate(el, entry, target) {
+    if (el === this._activeEl) return;
+    sdoBox.deactivate();
+    this.active = true;
+    this.entry = entry;
+    this.$pinLink.textContent = menu._pinnedIds[entry.id] ? 'Unpin' : 'Pin';
+    this.$outer.classList.add('active');
+    this.top = el.offsetTop - this.$outer.offsetHeight;
+    this.left = el.offsetLeft - 10;
+    this.$outer.setAttribute('style', 'left: ' + this.left + 'px; top: ' + this.top + 'px');
+    this.updatePermalink();
+    this.updateReferences();
+    this._activeEl = el;
+    if (this.top < document.body.scrollTop && el === target) {
+      // don't scroll unless it's a small thing (< 200px)
+      this.$outer.scrollIntoView();
+    }
+  },
+
+  updatePermalink() {
+    this.$permalink.setAttribute('href', makeLinkToId(this.entry.id));
+  },
+
+  updateReferences() {
+    this.$refsLink.textContent = `References (${(this.entry.referencingIds || []).length})`;
+  },
+
+  activateIfMouseOver(e) {
+    let ref = this.findReferenceUnder(e.target);
+    if (ref && (!this.active || e.pageY > this._activeEl.offsetTop)) {
+      let entry = menu.search.biblio.byId[ref.id];
+      this.activate(ref.element, entry, e.target);
+    } else if (
+      this.active &&
+      (e.pageY < this.top || e.pageY > this._activeEl.offsetTop + this._activeEl.offsetHeight)
+    ) {
+      this.deactivate();
+    }
+  },
+
+  findReferenceUnder(el) {
+    while (el) {
+      let parent = el.parentNode;
+      if (el.nodeName === 'EMU-RHS' || el.nodeName === 'EMU-PRODUCTION') {
+        return null;
+      }
+      if (
+        el.nodeName === 'H1' &&
+        parent.nodeName.match(/EMU-CLAUSE|EMU-ANNEX|EMU-INTRO/) &&
+        parent.id
+      ) {
+        return { element: el, id: parent.id };
+      } else if (el.nodeName === 'EMU-NT') {
+        if (
+          parent.nodeName === 'EMU-PRODUCTION' &&
+          parent.id &&
+          parent.id[0] !== '_' &&
+          parent.firstElementChild === el
+        ) {
+          // return the LHS non-terminal element
+          return { element: el, id: parent.id };
+        }
+        return null;
+      } else if (
+        el.nodeName.match(/EMU-(?!CLAUSE|XREF|ANNEX|INTRO)|DFN/) &&
+        el.id &&
+        el.id[0] !== '_'
+      ) {
+        if (
+          el.nodeName === 'EMU-FIGURE' ||
+          el.nodeName === 'EMU-TABLE' ||
+          el.nodeName === 'EMU-EXAMPLE'
+        ) {
+          // return the figcaption element
+          return { element: el.children[0].children[0], id: el.id };
+        } else {
+          return { element: el, id: el.id };
+        }
+      }
+      el = parent;
+    }
+  },
+
+  deactivate() {
+    this.$outer.classList.remove('active');
+    this._activeEl = null;
+    this.active = false;
+  },
+};
+
+function sortByClauseNumber(clause1, clause2) {
+  let c1c = clause1.number.split('.');
+  let c2c = clause2.number.split('.');
+
+  for (let i = 0; i < c1c.length; i++) {
     if (i >= c2c.length) {
       return 1;
     }
 
-    var c1 = c1c[i];
-    var c2 = c2c[i];
-    var c1cn = Number(c1);
-    var c2cn = Number(c2);
+    let c1 = c1c[i];
+    let c2 = c2c[i];
+    let c1cn = Number(c1);
+    let c2cn = Number(c2);
 
     if (Number.isNaN(c1cn) && Number.isNaN(c2cn)) {
       if (c1 > c2) {
@@ -832,7 +1029,7 @@ function sortByClauseNumber(c1, c2) {
       return -1;
     } else if (Number.isNaN(c1cn) && !Number.isNaN(c2cn)) {
       return 1;
-    } else if(c1cn > c2cn) {
+    } else if (c1cn > c2cn) {
       return 1;
     } else if (c1cn < c2cn) {
       return -1;
@@ -845,59 +1042,314 @@ function sortByClauseNumber(c1, c2) {
   return -1;
 }
 
-document.addEventListener('DOMContentLoaded', function () {
+function makeLinkToId(id) {
+  let hash = '#' + id;
+  if (typeof idToSection === 'undefined' || !idToSection[id]) {
+    return hash;
+  }
+  let targetSec = idToSection[id];
+  return (targetSec === 'index' ? './' : targetSec + '.html') + hash;
+}
+
+function doShortcut(e) {
+  if (!(e.target instanceof HTMLElement)) {
+    return;
+  }
+  let target = e.target;
+  let name = target.nodeName.toLowerCase();
+  if (name === 'textarea' || name === 'input' || name === 'select' || target.isContentEditable) {
+    return;
+  }
+  if (e.altKey || e.ctrlKey || e.metaKey) {
+    return;
+  }
+  if (e.key === 'm' && usesMultipage) {
+    let pathParts = location.pathname.split('/');
+    let hash = location.hash;
+    if (pathParts[pathParts.length - 2] === 'multipage') {
+      if (hash === '') {
+        let sectionName = pathParts[pathParts.length - 1];
+        if (sectionName.endsWith('.html')) {
+          sectionName = sectionName.slice(0, -5);
+        }
+        if (idToSection['sec-' + sectionName] !== undefined) {
+          hash = '#sec-' + sectionName;
+        }
+      }
+      location = pathParts.slice(0, -2).join('/') + '/' + hash;
+    } else {
+      location = 'multipage/' + hash;
+    }
+  } else if (e.key === 'u') {
+    document.documentElement.classList.toggle('show-ao-annotations');
+  } else if (e.key === '?') {
+    document.getElementById('shortcuts-help').classList.toggle('active');
+  }
+}
+
+function init() {
+  menu = new Menu();
+  let $container = document.getElementById('spec-container');
+  $container.addEventListener(
+    'mouseover',
+    debounce(e => {
+      Toolbox.activateIfMouseOver(e);
+    })
+  );
+  document.addEventListener(
+    'keydown',
+    debounce(e => {
+      if (e.code === 'Escape') {
+        if (Toolbox.active) {
+          Toolbox.deactivate();
+        }
+        document.getElementById('shortcuts-help').classList.remove('active');
+      }
+    })
+  );
+}
+
+document.addEventListener('keypress', doShortcut);
+
+document.addEventListener('DOMContentLoaded', () => {
   Toolbox.init();
   referencePane.init();
-})
-var CLAUSE_NODES = ['EMU-CLAUSE', 'EMU-INTRO', 'EMU-ANNEX'];
-function findLocalReferences ($elem) {
-  var name = $elem.innerHTML;
-  var references = [];
+});
 
-  var parentClause = $elem.parentNode;
-  while (parentClause && CLAUSE_NODES.indexOf(parentClause.nodeName) === -1) {
-    parentClause = parentClause.parentNode;
+// preserve state during navigation
+
+function getTocPath(li) {
+  let path = [];
+  let pointer = li;
+  while (true) {
+    let parent = pointer.parentElement;
+    if (parent == null) {
+      return null;
+    }
+    let index = [].indexOf.call(parent.children, pointer);
+    if (index == -1) {
+      return null;
+    }
+    path.unshift(index);
+    pointer = parent.parentElement;
+    if (pointer == null) {
+      return null;
+    }
+    if (pointer.id === 'menu-toc') {
+      break;
+    }
+    if (pointer.tagName !== 'LI') {
+      return null;
+    }
   }
+  return path;
+}
 
-  if(!parentClause) return;
+function activateTocPath(path) {
+  try {
+    let pointer = document.getElementById('menu-toc');
+    for (let index of path) {
+      pointer = pointer.querySelector('ol').children[index];
+    }
+    pointer.classList.add('active');
+  } catch (e) {
+    // pass
+  }
+}
 
-  var vars = parentClause.querySelectorAll('var');
+function getActiveTocPaths() {
+  return [...menu.$menu.querySelectorAll('.active')].map(getTocPath).filter(p => p != null);
+}
 
-  for (var i = 0; i < vars.length; i++) {
-    var $var = vars[i];
-
-    if ($var.innerHTML === name) {
-      references.push($var);
+function loadStateFromSessionStorage() {
+  if (!window.sessionStorage || typeof menu === 'undefined' || window.navigating) {
+    return;
+  }
+  if (sessionStorage.referencePaneState != null) {
+    let state = JSON.parse(sessionStorage.referencePaneState);
+    if (state != null) {
+      if (state.type === 'ref') {
+        let entry = menu.search.biblio.byId[state.id];
+        if (entry != null) {
+          referencePane.showReferencesFor(entry);
+        }
+      } else if (state.type === 'sdo') {
+        let sdos = sdoMap[state.id];
+        if (sdos != null) {
+          referencePane.$headerText.innerHTML = state.html;
+          referencePane.showSDOsBody(sdos, state.id);
+        }
+      }
+      delete sessionStorage.referencePaneState;
     }
   }
 
-  return references;
-}
+  if (sessionStorage.activeTocPaths != null) {
+    document
+      .getElementById('menu-toc')
+      .querySelectorAll('.active')
+      .forEach(e => {
+        e.classList.remove('active');
+      });
+    let active = JSON.parse(sessionStorage.activeTocPaths);
+    active.forEach(activateTocPath);
+    delete sessionStorage.activeTocPaths;
+  }
 
-function toggleFindLocalReferences($elem) {
-  var references = findLocalReferences($elem);
-  if ($elem.classList.contains('referenced')) {
-    references.forEach(function ($reference) {
-      $reference.classList.remove('referenced');
-    });
-  } else {
-    references.forEach(function ($reference) {
-      $reference.classList.add('referenced');
-    });
+  if (sessionStorage.searchValue != null) {
+    let value = JSON.parse(sessionStorage.searchValue);
+    menu.search.$searchBox.value = value;
+    menu.search.search(value);
+    delete sessionStorage.searchValue;
+  }
+
+  if (sessionStorage.tocScroll != null) {
+    let tocScroll = JSON.parse(sessionStorage.tocScroll);
+    menu.$toc.scrollTop = tocScroll;
+    delete sessionStorage.tocScroll;
   }
 }
 
-function installFindLocalReferences () {
-  document.addEventListener('click', function (e) {
-    if (e.target.nodeName === 'VAR') {
-      toggleFindLocalReferences(e.target);
+document.addEventListener('DOMContentLoaded', loadStateFromSessionStorage);
+
+window.addEventListener('pageshow', loadStateFromSessionStorage);
+
+window.addEventListener('beforeunload', () => {
+  if (!window.sessionStorage || typeof menu === 'undefined') {
+    return;
+  }
+  sessionStorage.referencePaneState = JSON.stringify(referencePane.state || null);
+  sessionStorage.activeTocPaths = JSON.stringify(getActiveTocPaths());
+  sessionStorage.searchValue = JSON.stringify(menu.search.$searchBox.value);
+  sessionStorage.tocScroll = JSON.stringify(menu.$toc.scrollTop);
+});
+
+'use strict';
+
+// Manually prefix algorithm step list items with hidden counter representations
+// corresponding with their markers so they get selected and copied with content.
+// We read list-style-type to avoid divergence with the style sheet, but
+// for efficiency assume that all lists at the same nesting depth use the same
+// style (except for those associated with replacement steps).
+// We also precompute some initial items for each supported style type.
+// https://w3c.github.io/csswg-drafts/css-counter-styles/
+
+const lowerLetters = Array.from({ length: 26 }, (_, i) =>
+  String.fromCharCode('a'.charCodeAt(0) + i)
+);
+// Implement the lower-alpha 'alphabetic' algorithm,
+// adjusting for indexing from 0 rather than 1.
+// https://w3c.github.io/csswg-drafts/css-counter-styles/#simple-alphabetic
+// https://w3c.github.io/csswg-drafts/css-counter-styles/#alphabetic-system
+const lowerAlphaTextForIndex = i => {
+  let S = '';
+  for (const N = lowerLetters.length; i >= 0; i--) {
+    S = lowerLetters[i % N] + S;
+    i = Math.floor(i / N);
+  }
+  return S;
+};
+
+const weightedLowerRomanSymbols = Object.entries({
+  m: 1000,
+  cm: 900,
+  d: 500,
+  cd: 400,
+  c: 100,
+  xc: 90,
+  l: 50,
+  xl: 40,
+  x: 10,
+  ix: 9,
+  v: 5,
+  iv: 4,
+  i: 1,
+});
+// Implement the lower-roman 'additive' algorithm,
+// adjusting for indexing from 0 rather than 1.
+// https://w3c.github.io/csswg-drafts/css-counter-styles/#simple-numeric
+// https://w3c.github.io/csswg-drafts/css-counter-styles/#additive-system
+const lowerRomanTextForIndex = i => {
+  let value = i + 1;
+  let S = '';
+  for (const [symbol, weight] of weightedLowerRomanSymbols) {
+    if (!value) break;
+    if (weight > value) continue;
+    const reps = Math.floor(value / weight);
+    S += symbol.repeat(reps);
+    value -= weight * reps;
+  }
+  return S;
+};
+
+// Memoize pure index-to-text functions with an exposed cache for fast retrieval.
+const makeCounter = (pureGetTextForIndex, precomputeCount = 30) => {
+  const cache = Array.from({ length: precomputeCount }, (_, i) => pureGetTextForIndex(i));
+  const getTextForIndex = i => {
+    if (i >= cache.length) cache[i] = pureGetTextForIndex(i);
+    return cache[i];
+  };
+  return { getTextForIndex, cache };
+};
+
+const counterByStyle = {
+  __proto__: null,
+  decimal: makeCounter(i => String(i + 1)),
+  'lower-alpha': makeCounter(lowerAlphaTextForIndex),
+  'upper-alpha': makeCounter(i => lowerAlphaTextForIndex(i).toUpperCase()),
+  'lower-roman': makeCounter(lowerRomanTextForIndex),
+  'upper-roman': makeCounter(i => lowerRomanTextForIndex(i).toUpperCase()),
+};
+const fallbackCounter = makeCounter(() => '?');
+const counterByDepth = [];
+
+function addStepNumberText(
+  ol,
+  depth = 0,
+  special = [...ol.classList].some(c => c.startsWith('nested-'))
+) {
+  let counter = !special && counterByDepth[depth];
+  if (!counter) {
+    const counterStyle = getComputedStyle(ol)['list-style-type'];
+    counter = counterByStyle[counterStyle];
+    if (!counter) {
+      console.warn('unsupported list-style-type', {
+        ol,
+        counterStyle,
+        id: ol.closest('[id]')?.getAttribute('id'),
+      });
+      counterByStyle[counterStyle] = fallbackCounter;
+      counter = fallbackCounter;
     }
+    if (!special) {
+      counterByDepth[depth] = counter;
+    }
+  }
+  const { cache, getTextForIndex } = counter;
+  let i = (Number(ol.getAttribute('start')) || 1) - 1;
+  for (const li of ol.children) {
+    const marker = document.createElement('span');
+    marker.textContent = `${i < cache.length ? cache[i] : getTextForIndex(i)}. `;
+    marker.setAttribute('aria-hidden', 'true');
+    li.prepend(marker);
+    for (const sublist of li.querySelectorAll(':scope > ol')) {
+      addStepNumberText(sublist, depth + 1, special);
+    }
+    i++;
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('emu-alg > ol').forEach(ol => {
+    addStepNumberText(ol);
   });
-}
+});
 
-document.addEventListener('DOMContentLoaded', installFindLocalReferences);
-</script><style>body {
+let sdoMap = JSON.parse(`{}`);
+let biblio = JSON.parse(`{"refsByClause":{"sec-internal-slots":["_ref_0"],"sec-abstract-operations":["_ref_1"],"sec-lookupmatcher":["_ref_2","_ref_3"],"sec-bestfitmatcher":["_ref_4","_ref_5"],"sec-resolvelocale":["_ref_6","_ref_7","_ref_8","_ref_9"],"sec-lookupsupportedlocales":["_ref_10"],"sec-supportedlocales":["_ref_11","_ref_12","_ref_13","_ref_14"],"sec-getoptionsobject":["_ref_15"],"sec-coerceoptionstoobject":["_ref_16","_ref_17"],"sec-getnumberoption":["_ref_18"]},"entries":[{"type":"clause","id":"sec-internal-slots","titleHTML":"Internal slots of Service Constructors","number":"1.1","referencingIds":["_ref_1"]},{"type":"op","aoid":"CanonicalizeLocaleList","refId":"sec-canonicalizelocalelist"},{"type":"clause","id":"sec-canonicalizelocalelist","title":"CanonicalizeLocaleList ( locales )","titleHTML":"CanonicalizeLocaleList ( <var>locales</var> )","number":"1.2.1","referencingIds":["_ref_2","_ref_4"]},{"type":"op","aoid":"BestAvailableLocale","refId":"sec-bestavailablelocale"},{"type":"clause","id":"sec-bestavailablelocale","title":"BestAvailableLocale ( availableLocales, locale )","titleHTML":"BestAvailableLocale ( <var>availableLocales</var>, <var>locale</var> )","number":"1.2.2","referencingIds":["_ref_3","_ref_10"]},{"type":"op","aoid":"LookupMatcher","refId":"sec-lookupmatcher"},{"type":"clause","id":"sec-lookupmatcher","title":"LookupMatcher ( availableLocales, requestedLocales )","titleHTML":"LookupMatcher ( <var>availableLocales</var>, <var>requestedLocales</var> )","number":"1.2.3","referencingIds":["_ref_5","_ref_6"]},{"type":"op","aoid":"BestFitMatcher","refId":"sec-bestfitmatcher"},{"type":"clause","id":"sec-bestfitmatcher","title":"BestFitMatcher ( availableLocales, requestedLocales )","titleHTML":"BestFitMatcher ( <var>availableLocales</var>, <var>requestedLocales</var> )","number":"1.2.4","referencingIds":["_ref_7"]},{"type":"op","aoid":"UnicodeExtensionComponents","refId":"sec-unicode-extension-components"},{"type":"clause","id":"sec-unicode-extension-components","title":"UnicodeExtensionComponents ( extension )","titleHTML":"UnicodeExtensionComponents ( <var>extension</var> )","number":"1.2.5","referencingIds":["_ref_8"]},{"type":"op","aoid":"InsertUnicodeExtensionAndCanonicalize","refId":"sec-insert-unicode-extension-and-canonicalize"},{"type":"clause","id":"sec-insert-unicode-extension-and-canonicalize","title":"InsertUnicodeExtensionAndCanonicalize ( locale, extension )","titleHTML":"InsertUnicodeExtensionAndCanonicalize ( <var>locale</var>, <var>extension</var> )","number":"1.2.6","referencingIds":["_ref_9"]},{"type":"op","aoid":"ResolveLocale","refId":"sec-resolvelocale"},{"type":"clause","id":"sec-resolvelocale","title":"ResolveLocale ( availableLocales, requestedLocales, options, relevantExtensionKeys, localeData )","titleHTML":"ResolveLocale ( <var>availableLocales</var>, <var>requestedLocales</var>, <var>options</var>, <var>relevantExtensionKeys</var>, <var>localeData</var> )","number":"1.2.7","referencingIds":["_ref_0"]},{"type":"op","aoid":"LookupSupportedLocales","refId":"sec-lookupsupportedlocales"},{"type":"clause","id":"sec-lookupsupportedlocales","title":"LookupSupportedLocales ( availableLocales, requestedLocales )","titleHTML":"LookupSupportedLocales ( <var>availableLocales</var>, <var>requestedLocales</var> )","number":"1.2.8","referencingIds":["_ref_14"]},{"type":"op","aoid":"BestFitSupportedLocales","refId":"sec-bestfitsupportedlocales"},{"type":"clause","id":"sec-bestfitsupportedlocales","title":"BestFitSupportedLocales ( availableLocales, requestedLocales )","titleHTML":"BestFitSupportedLocales ( <var>availableLocales</var>, <var>requestedLocales</var> )","number":"1.2.9","referencingIds":["_ref_13"]},{"type":"op","aoid":"SupportedLocales","refId":"sec-supportedlocales"},{"type":"clause","id":"sec-supportedlocales","title":"SupportedLocales ( availableLocales, requestedLocales, options )","titleHTML":"SupportedLocales ( <var>availableLocales</var>, <var>requestedLocales</var>, <var>options</var> )","number":"1.2.10"},{"type":"op","aoid":"GetOptionsObject","refId":"sec-getoptionsobject"},{"type":"clause","id":"sec-getoptionsobject","title":"GetOptionsObject ( options )","titleHTML":"GetOptionsObject ( <var>options</var> )","number":"1.2.11","referencingIds":["_ref_17"]},{"type":"op","aoid":"CoerceOptionsToObject","refId":"sec-coerceoptionstoobject"},{"type":"clause","id":"sec-coerceoptionstoobject","title":"CoerceOptionsToObject ( options )","titleHTML":"CoerceOptionsToObject ( <var>options</var> )","number":"1.2.12","referencingIds":["_ref_11"]},{"type":"op","aoid":"GetOption","refId":"sec-getoption"},{"type":"clause","id":"sec-getoption","title":"GetOption ( options, property, type, values, default )","titleHTML":"GetOption ( <var>options</var>, <var>property</var>, <var>type</var>, <var>values</var>, <var>default</var> )","number":"1.2.13","referencingIds":["_ref_12","_ref_15","_ref_16"]},{"type":"op","aoid":"GetBooleanOrStringNumberFormatOption","refId":"sec-getbooleanorstringnumberformatoption"},{"type":"clause","id":"sec-getbooleanorstringnumberformatoption","title":"GetBooleanOrStringNumberFormatOption ( options, property, stringValues, fallback )","titleHTML":"GetBooleanOrStringNumberFormatOption ( <var>options</var>, <var>property</var>, <var>stringValues</var>, <var>fallback</var> )","number":"1.2.14"},{"type":"op","aoid":"DefaultNumberOption","refId":"sec-defaultnumberoption"},{"type":"clause","id":"sec-defaultnumberoption","title":"DefaultNumberOption ( value, minimum, maximum, fallback )","titleHTML":"DefaultNumberOption ( <var>value</var>, <var>minimum</var>, <var>maximum</var>, <var>fallback</var> )","number":"1.2.15","referencingIds":["_ref_18"]},{"type":"op","aoid":"GetNumberOption","refId":"sec-getnumberoption"},{"type":"clause","id":"sec-getnumberoption","title":"GetNumberOption ( options, property, minimum, maximum, fallback )","titleHTML":"GetNumberOption ( <var>options</var>, <var>property</var>, <var>minimum</var>, <var>maximum</var>, <var>fallback</var> )","number":"1.2.16"},{"type":"op","aoid":"PartitionPattern","refId":"sec-partitionpattern"},{"type":"clause","id":"sec-partitionpattern","title":"PartitionPattern ( pattern )","titleHTML":"PartitionPattern ( <var>pattern</var> )","number":"1.2.17"},{"type":"clause","id":"sec-abstract-operations","titleHTML":"Abstract Operations","number":"1.2"},{"type":"clause","id":"locale-and-parameter-negotiation","titleHTML":"Locale and Parameter Negotiation","number":"1"}]}`);
+;let usesMultipage = false</script><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.0.1/styles/base16/solarized-light.min.css"><style>body {
   display: flex;
+  word-wrap: break-word;
   font-size: 18px;
   line-height: 1.5;
   font-family: Cambria, Palatino Linotype, Palatino, Liberation Serif, serif;
@@ -912,6 +1364,7 @@ document.addEventListener('DOMContentLoaded', installFindLocalReferences);
   flex-basis: 66%;
   box-sizing: border-box;
   overflow: hidden;
+  padding-bottom: 1em;
 }
 
 body.oldtoc {
@@ -919,8 +1372,8 @@ body.oldtoc {
 }
 
 a {
-    text-decoration: none;
-    color: #206ca7;
+  text-decoration: none;
+  color: #206ca7;
 }
 
 a:visited {
@@ -928,15 +1381,51 @@ a:visited {
 }
 
 a:hover {
-    text-decoration: underline;
-    color: #239dee;
+  text-decoration: underline;
+  color: #239dee;
 }
 
+a.e-user-code,
+span.e-user-code {
+  white-space: nowrap;
+}
+
+a.e-user-code::before,
+span.e-user-code::before {
+  display: none;
+  color: brown;
+  background-color: white;
+  border: 2pt solid brown;
+  padding: 0.3ex;
+  margin: 0 0.25em 0 0;
+  line-height: 1;
+  vertical-align: text-top;
+  text-transform: uppercase;
+  font-family: 'Comic Code', sans-serif;
+  font-weight: 900;
+  font-size: x-small;
+}
+
+a.e-user-code:hover::before,
+span.e-user-code:hover::before {
+  background-color: brown;
+  color: white;
+}
+
+html.show-ao-annotations a.e-user-code::before,
+html.show-ao-annotations span.e-user-code::before {
+  display: inline-block;
+}
+
+a.e-user-code::before,
+span.e-user-code::before {
+  content: 'UC';
+}
 
 code {
-    font-weight: bold;
-    font-family: Consolas, Monaco, monospace;
-    white-space: pre;
+  font-weight: bold;
+  font-family: Consolas, Monaco, monospace;
+  white-space: pre;
 }
 
 pre code {
@@ -950,13 +1439,13 @@ pre code.hljs {
 }
 
 ol.toc {
-    list-style: none;
-    padding-left: 0;
+  list-style: none;
+  padding-left: 0;
 }
 
 ol.toc ol.toc {
-    padding-left: 2ex;
-    list-style: none;
+  padding-left: 2ex;
+  list-style: none;
 }
 
 var {
@@ -965,8 +1454,40 @@ var {
   cursor: pointer;
 }
 
-var.referenced {
+var.referenced0 {
+  color: inherit;
   background-color: #ffff33;
+  box-shadow: 0 0 0 2px #ffff33;
+}
+var.referenced1 {
+  color: inherit;
+  background-color: #ff87a2;
+  box-shadow: 0 0 0 2px #ff87a2;
+}
+var.referenced2 {
+  color: inherit;
+  background-color: #96e885;
+  box-shadow: 0 0 0 2px #96e885;
+}
+var.referenced3 {
+  color: inherit;
+  background-color: #3eeed2;
+  box-shadow: 0 0 0 2px #3eeed2;
+}
+var.referenced4 {
+  color: inherit;
+  background-color: #eacfb6;
+  box-shadow: 0 0 0 2px #eacfb6;
+}
+var.referenced5 {
+  color: inherit;
+  background-color: #82ddff;
+  box-shadow: 0 0 0 2px #82ddff;
+}
+var.referenced6 {
+  color: inherit;
+  background-color: #ffbcf2;
+  box-shadow: 0 0 0 2px #ffbcf2;
 }
 
 emu-const {
@@ -1015,6 +1536,10 @@ emu-alg ol.nested-lots ol {
   list-style-type: lower-roman;
 }
 
+emu-alg [aria-hidden=true] {
+  font-size: 0;
+}
+
 emu-eqn {
   display: block;
   margin-left: 4em;
@@ -1030,29 +1555,32 @@ emu-eqn div:first-child {
 }
 
 emu-note {
-    margin: 1em 0;
-    color: #666;
-    border-left: 5px solid #ccc;
-    display: flex;
-    flex-direction: row;
+  margin: 1em 0;
+  display: flex;
+  flex-direction: row;
+  color: inherit;
+  border-left: 5px solid #52e052;
+  background: #e9fbe9;
+  padding: 10px 10px 10px 0;
 }
 
 emu-note > span.note {
-    flex-basis: 100px;
-    min-width: 100px;
-    flex-grow: 0;
-    flex-shrink: 1;
-    text-transform: uppercase;
-    padding-left: 5px;
+  flex-basis: 100px;
+  min-width: 100px;
+  flex-grow: 0;
+  flex-shrink: 1;
+  text-transform: uppercase;
+  padding-left: 5px;
 }
 
-emu-note[type=editor] {
+emu-note[type='editor'] {
   border-left-color: #faa;
 }
 
 emu-note > div.note-contents {
   flex-grow: 1;
   flex-shrink: 1;
+  overflow: auto;
 }
 
 emu-note > div.note-contents > p:first-of-type {
@@ -1063,9 +1591,9 @@ emu-note > div.note-contents > p:last-of-type {
   margin-bottom: 0;
 }
 
-emu-table td code {
+emu-table:not(.code) td code {
   white-space: normal;
-} 
+}
 
 emu-figure {
   display: block;
@@ -1090,99 +1618,120 @@ emu-table figure {
 }
 
 emu-production {
-    display: block;
+  display: block;
 }
 
-emu-grammar[type="example"] emu-production,
-emu-grammar[type="definition"] emu-production {
-    margin-top: 1em;
-    margin-bottom: 1em;
-    margin-left: 5ex;
+emu-grammar[type='example'] emu-production,
+emu-grammar[type='definition'] emu-production {
+  margin-top: 1em;
+  margin-bottom: 1em;
+  margin-left: 5ex;
 }
 
-emu-grammar.inline, emu-production.inline,
-emu-grammar.inline emu-production emu-rhs, emu-production.inline emu-rhs,
-emu-grammar[collapsed] emu-production emu-rhs, emu-production[collapsed] emu-rhs {
-    display: inline;
-    padding-left: 1ex;
-    margin-left: 0;
+emu-grammar.inline,
+emu-production.inline,
+emu-grammar.inline emu-production emu-rhs,
+emu-production.inline emu-rhs,
+emu-grammar[collapsed] emu-production emu-rhs {
+  display: inline;
+  padding-left: 1ex;
+  margin-left: 0;
 }
 
-emu-grammar[collapsed] emu-production, emu-production[collapsed] {
-    margin: 0;
+emu-production[collapsed] emu-rhs {
+  display: inline;
+  padding-left: 0.5ex;
+  margin-left: 0;
+}
+
+emu-grammar[collapsed] emu-production,
+emu-production[collapsed] {
+  margin: 0;
 }
 
 emu-constraints {
-    font-size: .75em;
-    margin-right: 1ex;
+  font-size: 0.75em;
+  margin-right: 0.5ex;
 }
 
 emu-gann {
-    margin-right: 1ex;
+  margin-right: 0.5ex;
 }
 
 emu-gann emu-t:last-child,
 emu-gann emu-gprose:last-child,
 emu-gann emu-nt:last-child {
-    margin-right: 0;
+  margin-right: 0;
 }
 
 emu-geq {
-    margin-left: 1ex;
-    font-weight: bold;
+  margin-left: 0.5ex;
+  font-weight: bold;
 }
 
 emu-oneof {
-    font-weight: bold;
-    margin-left: 1ex;
+  font-weight: bold;
+  margin-left: 0.5ex;
 }
 
 emu-nt {
-    display: inline-block;
-    font-style: italic;
-    white-space: nowrap;
-    text-indent: 0;
+  display: inline-block;
+  font-style: italic;
+  white-space: nowrap;
+  text-indent: 0;
 }
 
-emu-nt a, emu-nt a:visited {
+emu-nt a,
+emu-nt a:visited {
   color: #333;
 }
 
 emu-rhs emu-nt {
-    margin-right: 1ex;
+  margin-right: 0.5ex;
 }
 
 emu-t {
-    display: inline-block;
-    font-family: monospace;
-    font-weight: bold;
-    white-space: nowrap;
-    text-indent: 0;
+  display: inline-block;
+  font-family: monospace;
+  font-weight: bold;
+  white-space: nowrap;
+  text-indent: 0;
 }
 
 emu-production emu-t {
-    margin-right: 1ex;
+  margin-right: 0.5ex;
 }
 
 emu-rhs {
-    display: block;
-    padding-left: 75px;
-    text-indent: -25px;
+  display: block;
+  padding-left: 75px;
+  text-indent: -25px;
+}
+
+emu-production:not([collapsed]) emu-rhs {
+  border: 0.2ex dashed transparent;
+}
+
+emu-production:not([collapsed]) emu-rhs:hover {
+  border-color: #888;
+  background-color: #f0f0f0;
 }
 
 emu-mods {
-    font-size: .85em;
-    vertical-align: sub;
-    font-style: normal;
-    font-weight: normal;
+  font-size: 0.85em;
+  vertical-align: sub;
+  font-style: normal;
+  font-weight: normal;
 }
 
-emu-params, emu-opt {
+emu-params,
+emu-opt {
   margin-right: 1ex;
   font-family: monospace;
 }
 
-emu-params, emu-constraints {
+emu-params,
+emu-constraints {
   color: #2aa198;
 }
 
@@ -1191,12 +1740,12 @@ emu-opt {
 }
 
 emu-gprose {
-    font-size: 0.9em;
-    font-family: Helvetica, Arial, sans-serif;
+  font-size: 0.9em;
+  font-family: Helvetica, Arial, sans-serif;
 }
 
 emu-production emu-gprose {
-    margin-right: 1ex;
+  margin-right: 1ex;
 }
 
 h1.shortname {
@@ -1208,20 +1757,19 @@ h1.shortname {
 h1.version {
   color: #f60;
   font-size: 1.5em;
-  margin: 0;
 }
 
 h1.title {
-  margin-top: 0;
   color: #f60;
 }
 
-h1.first {
-  margin-top: 0;
-}
-
-h1, h2, h3, h4, h5, h6 {
-    position: relative;
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  position: relative;
 }
 
 h1 .secnum {
@@ -1233,142 +1781,267 @@ h1 span.title {
   order: 2;
 }
 
+h1 {
+  font-size: 2.67em;
+  margin-bottom: 0;
+  line-height: 1em;
+}
+h2 {
+  font-size: 2em;
+}
+h3 {
+  font-size: 1.56em;
+}
+h4 {
+  font-size: 1.25em;
+}
+h5 {
+  font-size: 1.11em;
+}
+h6 {
+  font-size: 1em;
+}
 
-h1 { font-size: 2.67em; margin-top: 2em; margin-bottom: 0; line-height: 1em;}
-h2 { font-size: 2em; }
-h3 { font-size: 1.56em; }
-h4 { font-size: 1.25em; }
-h5 { font-size: 1.11em; }
-h6 { font-size: 1em; }
+pre code.hljs {
+  background: transparent;
+}
 
-h1:hover span.utils {
+emu-clause[id],
+emu-annex[id],
+emu-intro[id] {
+  scroll-margin-top: 2ex;
+}
+
+emu-intro h1,
+emu-clause h1,
+emu-annex h1 {
+  font-size: 2em;
+}
+emu-intro h2,
+emu-clause h2,
+emu-annex h2 {
+  font-size: 1.56em;
+}
+emu-intro h3,
+emu-clause h3,
+emu-annex h3 {
+  font-size: 1.25em;
+}
+emu-intro h4,
+emu-clause h4,
+emu-annex h4 {
+  font-size: 1.11em;
+}
+emu-intro h5,
+emu-clause h5,
+emu-annex h5 {
+  font-size: 1em;
+}
+emu-intro h6,
+emu-clause h6,
+emu-annex h6 {
+  font-size: 0.9em;
+}
+emu-intro emu-intro h1,
+emu-clause emu-clause h1,
+emu-annex emu-annex h1 {
+  font-size: 1.56em;
+}
+emu-intro emu-intro h2,
+emu-clause emu-clause h2,
+emu-annex emu-annex h2 {
+  font-size: 1.25em;
+}
+emu-intro emu-intro h3,
+emu-clause emu-clause h3,
+emu-annex emu-annex h3 {
+  font-size: 1.11em;
+}
+emu-intro emu-intro h4,
+emu-clause emu-clause h4,
+emu-annex emu-annex h4 {
+  font-size: 1em;
+}
+emu-intro emu-intro h5,
+emu-clause emu-clause h5,
+emu-annex emu-annex h5 {
+  font-size: 0.9em;
+}
+emu-intro emu-intro emu-intro h1,
+emu-clause emu-clause emu-clause h1,
+emu-annex emu-annex emu-annex h1 {
+  font-size: 1.25em;
+}
+emu-intro emu-intro emu-intro h2,
+emu-clause emu-clause emu-clause h2,
+emu-annex emu-annex emu-annex h2 {
+  font-size: 1.11em;
+}
+emu-intro emu-intro emu-intro h3,
+emu-clause emu-clause emu-clause h3,
+emu-annex emu-annex emu-annex h3 {
+  font-size: 1em;
+}
+emu-intro emu-intro emu-intro h4,
+emu-clause emu-clause emu-clause h4,
+emu-annex emu-annex emu-annex h4 {
+  font-size: 0.9em;
+}
+emu-intro emu-intro emu-intro emu-intro h1,
+emu-clause emu-clause emu-clause emu-clause h1,
+emu-annex emu-annex emu-annex emu-annex h1 {
+  font-size: 1.11em;
+}
+emu-intro emu-intro emu-intro emu-intro h2,
+emu-clause emu-clause emu-clause emu-clause h2,
+emu-annex emu-annex emu-annex emu-annex h2 {
+  font-size: 1em;
+}
+emu-intro emu-intro emu-intro emu-intro h3,
+emu-clause emu-clause emu-clause emu-clause h3,
+emu-annex emu-annex emu-annex emu-annex h3 {
+  font-size: 0.9em;
+}
+emu-intro emu-intro emu-intro emu-intro emu-intro h1,
+emu-clause emu-clause emu-clause emu-clause emu-clause h1,
+emu-annex emu-annex emu-annex emu-annex emu-annex h1 {
+  font-size: 1em;
+}
+emu-intro emu-intro emu-intro emu-intro emu-intro h2,
+emu-clause emu-clause emu-clause emu-clause emu-clause h2,
+emu-annex emu-annex emu-annex emu-annex emu-annex h2 {
+  font-size: 0.9em;
+}
+emu-intro emu-intro emu-intro emu-intro emu-intro emu-intro h1,
+emu-clause emu-clause emu-clause emu-clause emu-clause emu-clause h1,
+emu-annex emu-annex emu-annex emu-annex emu-annex emu-annex h1 {
+  font-size: 0.9em;
+}
+
+emu-clause,
+emu-intro,
+emu-annex {
   display: block;
 }
 
-span.utils {
-  font-size: 18px;
-  line-height: 18px;
-  display: none;
-  position: absolute;
-  top: 100%;
-  left: 0;
-  right: 0;
-  font-weight: normal;
+/* these values are twice the font-size for the <h1> titles for clauses */
+emu-intro,
+emu-clause,
+emu-annex {
+  margin-top: 4em;
+}
+emu-intro emu-intro,
+emu-clause emu-clause,
+emu-annex emu-annex {
+  margin-top: 3.12em;
+}
+emu-intro emu-intro emu-intro,
+emu-clause emu-clause emu-clause,
+emu-annex emu-annex emu-annex {
+  margin-top: 2.5em;
+}
+emu-intro emu-intro emu-intro emu-intro,
+emu-clause emu-clause emu-clause emu-clause,
+emu-annex emu-annex emu-annex emu-annex {
+  margin-top: 2.22em;
+}
+emu-intro emu-intro emu-intro emu-intro emu-intro,
+emu-clause emu-clause emu-clause emu-clause emu-clause,
+emu-annex emu-annex emu-annex emu-annex emu-annex {
+  margin-top: 2em;
+}
+emu-intro emu-intro emu-intro emu-intro emu-intro emu-intro,
+emu-clause emu-clause emu-clause emu-clause emu-clause emu-clause,
+emu-annex emu-annex emu-annex emu-annex emu-annex emu-annex {
+  margin-top: 1.8em;
 }
 
-span.utils:before {
-    content: "⤷";
-    display: inline-block;
-    padding: 0 5px;
-}
-
-span.utils > * {
-  display: inline-block;
-  margin-right: 20px;
-}
-
-h1 span.utils span.anchor a,
-h2 span.utils span.anchor a,
-h3 span.utils span.anchor a,
-h4 span.utils span.anchor a,
-h5 span.utils span.anchor a,
-h6 span.utils span.anchor a {
-  text-decoration: none;
-  font-variant: small-caps;
-}
-
-h1 span.utils span.anchor a:hover,
-h2 span.utils span.anchor a:hover,
-h3 span.utils span.anchor a:hover,
-h4 span.utils span.anchor a:hover,
-h5 span.utils span.anchor a:hover,
-h6 span.utils span.anchor a:hover {
-  color: #333;
-}
-
-emu-intro h1, emu-clause h1, emu-annex h1 { font-size: 2em; }
-emu-intro h2, emu-clause h2, emu-annex h2 { font-size: 1.56em; }
-emu-intro h3, emu-clause h3, emu-annex h3 { font-size: 1.25em; }
-emu-intro h4, emu-clause h4, emu-annex h4 { font-size: 1.11em; }
-emu-intro h5, emu-clause h5, emu-annex h5 { font-size: 1em; }
-emu-intro h6, emu-clause h6, emu-annex h6 { font-size: 0.9em; }
-emu-intro emu-intro h1, emu-clause emu-clause h1, emu-annex emu-annex h1 { font-size: 1.56em; }
-emu-intro emu-intro h2, emu-clause emu-clause h2, emu-annex emu-annex h2 { font-size: 1.25em; }
-emu-intro emu-intro h3, emu-clause emu-clause h3, emu-annex emu-annex h3 { font-size: 1.11em; }
-emu-intro emu-intro h4, emu-clause emu-clause h4, emu-annex emu-annex h4 { font-size: 1em; }
-emu-intro emu-intro h5, emu-clause emu-clause h5, emu-annex emu-annex h5 { font-size: 0.9em; }
-emu-intro emu-intro emu-intro h1, emu-clause emu-clause emu-clause h1, emu-annex emu-annex emu-annex h1 { font-size: 1.25em; }
-emu-intro emu-intro emu-intro h2, emu-clause emu-clause emu-clause h2, emu-annex emu-annex emu-annex h2 { font-size: 1.11em; }
-emu-intro emu-intro emu-intro h3, emu-clause emu-clause emu-clause h3, emu-annex emu-annex emu-annex h3 { font-size: 1em; }
-emu-intro emu-intro emu-intro h4, emu-clause emu-clause emu-clause h4, emu-annex emu-annex emu-annex h4 { font-size: 0.9em; }
-emu-intro emu-intro emu-intro emu-intro h1, emu-clause emu-clause emu-clause emu-clause h1, emu-annex emu-annex emu-annex emu-annex h1 { font-size: 1.11em; }
-emu-intro emu-intro emu-intro emu-intro h2, emu-clause emu-clause emu-clause emu-clause h2, emu-annex emu-annex emu-annex emu-annex h2 { font-size: 1em; }
-emu-intro emu-intro emu-intro emu-intro h3, emu-clause emu-clause emu-clause emu-clause h3, emu-annex emu-annex emu-annex emu-annex h3 { font-size: 0.9em; }
-emu-intro emu-intro emu-intro emu-intro emu-intro h1, emu-clause emu-clause emu-clause emu-clause emu-clause h1, emu-annex emu-annex emu-annex emu-annex emu-annex h1 { font-size: 1em; }
-emu-intro emu-intro emu-intro emu-intro emu-intro h2, emu-clause emu-clause emu-clause emu-clause emu-clause h2, emu-annex emu-annex emu-annex emu-annex emu-annex h2 { font-size: 0.9em; }
-emu-intro emu-intro emu-intro emu-intro emu-intro emu-intro h1, emu-clause emu-clause emu-clause emu-clause emu-clause emu-clause h1, emu-annex emu-annex emu-annex emu-annex emu-annex emu-annex h1 { font-size: 0.9em }
-
-emu-clause, emu-intro, emu-annex {
-    display: block;
+#spec-container > emu-intro:first-of-type,
+#spec-container > emu-clause:first-of-type,
+#spec-container > emu-annex:first-of-type {
+  margin-top: 0;
 }
 
 /* Figures and tables */
-figure { display: block; margin: 1em 0 3em 0; }
-figure object { display: block; margin: 0 auto; }
-figure table.real-table { margin: 0 auto; }
+figure {
+  display: block;
+  margin: 1em 0 3em 0;
+}
+figure object {
+  display: block;
+  margin: 0 auto;
+}
+figure table.real-table {
+  margin: 0 auto;
+}
 figure figcaption {
-    display: block;
-    color: #555555;
-    font-weight: bold;
-    text-align: center;
+  display: block;
+  color: #555555;
+  font-weight: bold;
+  text-align: center;
 }
 
 emu-table table {
   margin: 0 auto;
 }
 
-emu-table table, table.real-table {
-    border-collapse: collapse;
+emu-table table,
+table.real-table {
+  border-collapse: collapse;
 }
 
-emu-table td, emu-table th, table.real-table td, table.real-table th {
-    border: 1px solid black;
-    padding: 0.4em;
-    vertical-align: baseline;
+emu-table td,
+emu-table th,
+table.real-table td,
+table.real-table th {
+  border: 1px solid black;
+  padding: 0.4em;
+  vertical-align: baseline;
 }
-emu-table th, emu-table thead td, table.real-table th {
-    background-color: #eeeeee;
+emu-table th,
+emu-table thead td,
+table.real-table th {
+  background-color: #eeeeee;
+}
+
+emu-table td {
+  background: #fff;
 }
 
 /* Note: the left content edges of table.lightweight-table >tbody >tr >td
    and div.display line up. */
 table.lightweight-table {
-    border-collapse: collapse;
-    margin: 0 0 0 1.5em;
+  border-collapse: collapse;
+  margin: 0 0 0 1.5em;
 }
-table.lightweight-table td, table.lightweight-table th {
-    border: none;
-    padding: 0 0.5em;
-    vertical-align: baseline;
+table.lightweight-table td,
+table.lightweight-table th {
+  border: none;
+  padding: 0 0.5em;
+  vertical-align: baseline;
 }
 
 /* diff styles */
 ins {
-    background-color: #e0f8e0;
-    text-decoration: none;
-    border-bottom: 1px solid #396;
+  background-color: #e0f8e0;
+  text-decoration: none;
+  border-bottom: 1px solid #396;
 }
 
 del {
-    background-color: #fee;
+  background-color: #fee;
 }
 
-ins.block, del.block,
-emu-production > ins, emu-production > del,
-emu-grammar > ins, emu-grammar > del {
+ins.block,
+del.block,
+emu-production > ins,
+emu-production > del,
+emu-grammar > ins,
+emu-grammar > del {
   display: block;
 }
-emu-rhs > ins, emu-rhs > del { 
+emu-rhs > ins,
+emu-rhs > del {
   display: inline;
 }
 
@@ -1405,7 +2078,7 @@ tr.del > td {
   -khtml-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
-  user-select: none;;
+  user-select: none;
 
   cursor: pointer;
 }
@@ -1413,7 +2086,8 @@ tr.del > td {
 #menu {
   display: flex;
   flex-direction: column;
-  width: 33%; height: 100vh;
+  width: 33%;
+  height: 100vh;
   max-width: 500px;
   box-sizing: border-box;
   background-color: #ddd;
@@ -1421,13 +2095,14 @@ tr.del > td {
   transition: opacity 0.1s linear;
   padding: 0 5px;
   position: fixed;
-  left: 0; top: 0;
+  left: 0;
+  top: 0;
   border-right: 2px solid #bbb;
 
   z-index: 2;
 }
 
-#menu-spacer {
+.menu-spacer {
   flex-basis: 33%;
   max-width: 500px;
   flex-grow: 0;
@@ -1482,7 +2157,8 @@ tr.del > td {
   padding: 0;
 }
 
-#menu-toc > ol , #menu-toc > ol ol {
+#menu-toc > ol,
+#menu-toc > ol ol {
   list-style-type: none;
   margin: 0;
   padding: 0;
@@ -1512,7 +2188,7 @@ tr.del > td {
   -khtml-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
-  user-select: none;;
+  user-select: none;
 
   cursor: pointer;
 }
@@ -1543,7 +2219,7 @@ tr.del > td {
   */
 }
 
-#menu-toc li.revealed-leaf> a {
+#menu-toc li.revealed-leaf > a {
   color: #206ca7;
   /*
   background-color: #222;
@@ -1579,6 +2255,34 @@ tr.del > td {
   font-size: 0.8em;
 }
 
+.menu-pane-header emu-opt,
+.menu-pane-header emu-t,
+.menu-pane-header emu-nt {
+  margin-right: 0px;
+  display: inline;
+  color: inherit;
+}
+
+.menu-pane-header emu-rhs {
+  display: inline;
+  padding-left: 0px;
+  text-indent: 0px;
+}
+
+.menu-pane-header emu-geq {
+  margin-left: 0px;
+}
+
+a.menu-pane-header-production {
+  color: inherit;
+}
+
+.menu-pane-header-production {
+  text-transform: none;
+  letter-spacing: 1.5px;
+  padding-left: 0.5em;
+}
+
 #menu-toc {
   display: flex;
   flex-direction: column;
@@ -1597,10 +2301,10 @@ tr.del > td {
   flex-grow: 0;
   flex-shrink: 0;
   width: 100%;
-  
+
   display: flex;
   flex-direction: column;
-  
+
   max-height: 300px;
 }
 
@@ -1625,43 +2329,42 @@ tr.del > td {
 }
 
 li.menu-search-result-clause:before {
-    content: 'clause';
-    width: 40px;
-    display: inline-block;
-    text-align: right;
-    padding-right: 1ex;
-    color: #666;
-    font-size: 75%;
+  content: 'clause';
+  width: 40px;
+  display: inline-block;
+  text-align: right;
+  padding-right: 1ex;
+  color: #666;
+  font-size: 75%;
 }
 li.menu-search-result-op:before {
-    content: 'op';
-    width: 40px;
-    display: inline-block;
-    text-align: right;
-    padding-right: 1ex;
-    color: #666;
-    font-size: 75%;
+  content: 'op';
+  width: 40px;
+  display: inline-block;
+  text-align: right;
+  padding-right: 1ex;
+  color: #666;
+  font-size: 75%;
 }
 
 li.menu-search-result-prod:before {
-    content: 'prod';
-    width: 40px;
-    display: inline-block;
-    text-align: right;
-    padding-right: 1ex;
-    color: #666;
-    font-size: 75%
+  content: 'prod';
+  width: 40px;
+  display: inline-block;
+  text-align: right;
+  padding-right: 1ex;
+  color: #666;
+  font-size: 75%;
 }
 
-
 li.menu-search-result-term:before {
-    content: 'term';
-    width: 40px;
-    display: inline-block;
-    text-align: right;
-    padding-right: 1ex;
-    color: #666;
-    font-size: 75%
+  content: 'term';
+  width: 40px;
+  display: inline-block;
+  text-align: right;
+  padding-right: 1ex;
+  color: #666;
+  font-size: 75%;
 }
 
 #menu-search-results ul {
@@ -1674,7 +2377,6 @@ li.menu-search-result-term:before {
   text-overflow: ellipsis;
 }
 
-
 #menu-trace-list {
   counter-reset: item;
   margin: 0 0 0 20px;
@@ -1686,19 +2388,19 @@ li.menu-search-result-term:before {
 }
 
 #menu-trace-list li .secnum:after {
-  content: " ";
+  content: ' ';
 }
 #menu-trace-list li:before {
-    content: counter(item) " ";
-    background-color: #222;
-    counter-increment: item;
-    color: #999;
-    width: 20px;
-    height: 20px;
-    line-height: 20px;
-    display: inline-block;
-    text-align: center;
-    margin: 2px 4px 2px 0;
+  content: counter(item) ' ';
+  background-color: #222;
+  counter-increment: item;
+  color: #999;
+  width: 20px;
+  height: 20px;
+  line-height: 20px;
+  display: inline-block;
+  text-align: center;
+  margin: 2px 4px 2px 0;
 }
 
 @media (max-width: 1000px) {
@@ -1740,24 +2442,29 @@ li.menu-search-result-term:before {
   }
 
   h1 .secnum:empty {
-    margin: 0; padding: 0;
+    margin: 0;
+    padding: 0;
   }
 }
 
-
 /* Toolbox */
-.toolbox {
-	position: absolute;
-	background: #ddd;
-	border: 1px solid #aaa;
+.toolbox-container {
+  position: absolute;
   display: none;
+  padding-bottom: 7px;
+}
+
+.toolbox-container.active {
+  display: inline-block;
+}
+
+.toolbox {
+  position: relative;
+  background: #ddd;
+  border: 1px solid #aaa;
   color: #eee;
   padding: 5px;
   border-radius: 3px;
-}
-
-.toolbox.active {
-  display: inline-block;
 }
 
 .toolbox a {
@@ -1769,28 +2476,29 @@ li.menu-search-result-term:before {
   text-decoration: underline;
 }
 
-.toolbox:after, .toolbox:before {
-	top: 100%;
-	left: 15px;
-	border: solid transparent;
-	content: " ";
-	height: 0;
-	width: 0;
-	position: absolute;
-	pointer-events: none;
+.toolbox:after,
+.toolbox:before {
+  top: 100%;
+  left: 15px;
+  border: solid transparent;
+  content: ' ';
+  height: 0;
+  width: 0;
+  position: absolute;
+  pointer-events: none;
 }
 
 .toolbox:after {
-	border-color: rgba(0, 0, 0, 0);
-	border-top-color: #ddd;
-	border-width: 10px;
-	margin-left: -10px;
+  border-color: rgba(0, 0, 0, 0);
+  border-top-color: #ddd;
+  border-width: 10px;
+  margin-left: -10px;
 }
 .toolbox:before {
-	border-color: rgba(204, 204, 204, 0);
-	border-top-color: #aaa;
-	border-width: 12px;
-	margin-left: -12px;
+  border-color: rgba(204, 204, 204, 0);
+  border-top-color: #aaa;
+  border-width: 12px;
+  margin-left: -12px;
 }
 
 #references-pane-container {
@@ -1807,11 +2515,6 @@ li.menu-search-result-term:before {
 #references-pane-table-container {
   overflow-x: hidden;
   overflow-y: auto;
-}
-
-#references-pane-spacer {
-  flex-basis: 33%;
-  max-width: 500px;
 }
 
 #references-pane {
@@ -1831,6 +2534,10 @@ li.menu-search-result-term:before {
   cursor: pointer;
 }
 
+#references-pane table tbody {
+  vertical-align: baseline;
+}
+
 #references-pane table tr td:first-child {
   text-align: right;
   padding-right: 5px;
@@ -1838,43 +2545,94 @@ li.menu-search-result-term:before {
 
 @media print {
   #menu-toggle {
-    display: none; 
+    display: none;
   }
 }
-</style></head><body><div id="menu-toggle">☰</div><div id="menu-spacer"></div><div id="menu"><div id="menu-search"><input type="text" id="menu-search-box" placeholder="Search..."><div id="menu-search-results" class="inactive"></div></div><div id="menu-pins"><div class="menu-pane-header">Pins</div><ul id="menu-pins-list"></ul></div><div class="menu-pane-header">Table of Contents</div><div id="menu-toc"><ol class="toc"><li><span class="item-toggle">◢</span><a href="#locale-and-parameter-negotiation" title="Locale and Parameter Negotiation"><span class="secnum">1</span> Locale and Parameter Negotiation</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-internal-slots" title="Internal slots of Service Constructors"><span class="secnum">1.1</span> Internal slots of Service Constructors</a></li><li><span class="item-toggle">◢</span><a href="#sec-abstract-operations" title="Abstract Operations"><span class="secnum">1.2</span> Abstract Operations</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-canonicalizelocalelist" title="CanonicalizeLocaleList ( locales )"><span class="secnum">1.2.1</span> CanonicalizeLocaleList ( <var>locales</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-bestavailablelocale" title="BestAvailableLocale ( availableLocales, locale )"><span class="secnum">1.2.2</span> BestAvailableLocale ( <var>availableLocales</var>, <var>locale</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-lookupmatcher" title="LookupMatcher ( availableLocales, requestedLocales )"><span class="secnum">1.2.3</span> LookupMatcher ( <var>availableLocales</var>, <var>requestedLocales</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-bestfitmatcher" title="BestFitMatcher ( availableLocales, requestedLocales )"><span class="secnum">1.2.4</span> BestFitMatcher ( <var>availableLocales</var>, <var>requestedLocales</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-unicode-extension-components" title="UnicodeExtensionComponents ( extension )"><span class="secnum">1.2.5</span> UnicodeExtensionComponents ( <var>extension</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-insert-unicode-extension-and-canonicalize" title="InsertUnicodeExtensionAndCanonicalize ( locale, extension )"><span class="secnum">1.2.6</span> InsertUnicodeExtensionAndCanonicalize ( <var>locale</var>, <var>extension</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-resolvelocale" title="ResolveLocale ( availableLocales, requestedLocales, options, relevantExtensionKeys, localeData )"><span class="secnum">1.2.7</span> ResolveLocale ( <var>availableLocales</var>, <var>requestedLocales</var>, <var>options</var>, <var>relevantExtensionKeys</var>, <var>localeData</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-lookupsupportedlocales" title="LookupSupportedLocales ( availableLocales, requestedLocales )"><span class="secnum">1.2.8</span> LookupSupportedLocales ( <var>availableLocales</var>, <var>requestedLocales</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-bestfitsupportedlocales" title="BestFitSupportedLocales ( availableLocales, requestedLocales )"><span class="secnum">1.2.9</span> BestFitSupportedLocales ( <var>availableLocales</var>, <var>requestedLocales</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-supportedlocales" title="SupportedLocales ( availableLocales, requestedLocales, options )"><span class="secnum">1.2.10</span> SupportedLocales ( <var>availableLocales</var>, <var>requestedLocales</var>, <var>options</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-getoptionsobject" title="GetOptionsObject ( options )"><span class="secnum">1.2.11</span> GetOptionsObject ( <var>options</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-coerceoptionstoobject" title="CoerceOptionsToObject ( options )"><span class="secnum">1.2.12</span> CoerceOptionsToObject ( <var>options</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-getoption" title="
-        GetOption (
-          options: an Object,
-          property: a property key,
-          type: boolean, number, or string,
-          values: empty or a List of ECMAScript language values,
-          default: required or an ECMAScript language value,
-        )
-      "><span class="secnum">1.2.13</span> 
-        GetOption (
-          <var>options</var>: an Object,
-          <var>property</var>: a property key,
-          <var>type</var>: <emu-const>boolean</emu-const>, <emu-const>number</emu-const>, or <emu-const>string</emu-const>,
-          <var>values</var>: <emu-const>empty</emu-const> or a List of ECMAScript language values,
-          <var>default</var>: <emu-const>required</emu-const> or an ECMAScript language value,
-        )
-      </a></li><li><span class="item-toggle-none"></span><a href="#sec-getstringorbooleanoption" title="GetStringOrBooleanOption ( options, property, values, trueValue, falsyValue, fallback )"><span class="secnum">1.2.14</span> GetStringOrBooleanOption ( <var>options</var>, <var>property</var>, <var>values</var>, <var>trueValue</var>, <var>falsyValue</var>, <var>fallback</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-defaultnumberoption" title="DefaultNumberOption ( value, minimum, maximum, fallback )"><span class="secnum">1.2.15</span> DefaultNumberOption ( <var>value</var>, <var>minimum</var>, <var>maximum</var>, <var>fallback</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-getnumberoption" title="GetNumberOption ( options, property, minimum, maximum, fallback )"><span class="secnum">1.2.16</span> GetNumberOption ( <var>options</var>, <var>property</var>, <var>minimum</var>, <var>maximum</var>, <var>fallback</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-partitionpattern" title="PartitionPattern ( pattern )"><span class="secnum">1.2.17</span> PartitionPattern ( <var>pattern</var> )</a></li></ol></li></ol></li></ol></div></div><div id="spec-container"><emu-clause id="locale-and-parameter-negotiation">
-  <h1 class="first"><span class="secnum">1</span> Locale and Parameter Negotiation</h1>
+
+[normative-optional],
+[legacy] {
+  border-left: 5px solid #ff6600;
+  padding: 0.5em;
+  display: block;
+  background: #ffeedd;
+}
+
+.clause-attributes-tag {
+  text-transform: uppercase;
+  color: #884400;
+}
+
+.clause-attributes-tag a {
+  color: #884400;
+}
+
+/* Shortcuts help dialog */
+
+#shortcuts-help {
+  position: fixed;
+  left: 5%;
+  margin: 0 auto;
+  right: 5%;
+  z-index: 10;
+  top: 10%;
+  top: calc(5vw + 5vh);
+  padding: 30px 90px;
+  max-width: 500px;
+  outline: solid 10000px rgba(255, 255, 255, 0.6);
+  border-radius: 5px;
+  border-width: 1px 1px 0 1px;
+  background-color: #ddd;
+  display: none;
+}
+
+#shortcuts-help.active {
+  display: block;
+}
+
+#shortcuts-help ul {
+  padding: 0;
+}
+
+#shortcuts-help li {
+  display: flex;
+  justify-content: space-between;
+}
+
+#shortcuts-help code {
+  padding: 3px 10px;
+  border-radius: 3px;
+  border-width: 1px 1px 0 1px;
+  border-color: #bbb;
+  background-color: #eee;
+  box-shadow: inset 0 -1px 0 #ccc;
+}
+</style></head><body><div id="shortcuts-help">
+<ul>
+  <li><span>Toggle shortcuts help</span><code>?</code></li>
+  <li><span>Toggle "can call user code" annotations</span><code>u</code></li>
+
+  <li><span>Jump to search box</span><code>/</code></li>
+</ul></div><div id="menu-toggle"><svg xmlns="http://www.w3.org/2000/svg" style="width:100%; height:100%; stroke:currentColor" viewBox="0 0 120 120">
+      <title>Menu</title>
+      <path stroke-width="10" stroke-linecap="round" d="M30,60 h60  M30,30 m0,5 h60  M30,90 m0,-5 h60"></path>
+    </svg></div><div id="menu-spacer" class="menu-spacer"></div><div id="menu"><div id="menu-search"><input type="text" id="menu-search-box" placeholder="Search..."><div id="menu-search-results" class="inactive"></div></div><div id="menu-pins"><div class="menu-pane-header">Pins</div><ul id="menu-pins-list"></ul></div><div class="menu-pane-header">Table of Contents</div><div id="menu-toc"><ol class="toc"><li><span class="item-toggle">◢</span><a href="#locale-and-parameter-negotiation" title="Locale and Parameter Negotiation"><span class="secnum">1</span> Locale and Parameter Negotiation</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-internal-slots" title="Internal slots of Service Constructors"><span class="secnum">1.1</span> Internal slots of Service Constructors</a></li><li><span class="item-toggle">◢</span><a href="#sec-abstract-operations" title="Abstract Operations"><span class="secnum">1.2</span> Abstract Operations</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-canonicalizelocalelist" title="CanonicalizeLocaleList ( locales )"><span class="secnum">1.2.1</span> CanonicalizeLocaleList ( <var>locales</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-bestavailablelocale" title="BestAvailableLocale ( availableLocales, locale )"><span class="secnum">1.2.2</span> BestAvailableLocale ( <var>availableLocales</var>, <var>locale</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-lookupmatcher" title="LookupMatcher ( availableLocales, requestedLocales )"><span class="secnum">1.2.3</span> LookupMatcher ( <var>availableLocales</var>, <var>requestedLocales</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-bestfitmatcher" title="BestFitMatcher ( availableLocales, requestedLocales )"><span class="secnum">1.2.4</span> BestFitMatcher ( <var>availableLocales</var>, <var>requestedLocales</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-unicode-extension-components" title="UnicodeExtensionComponents ( extension )"><span class="secnum">1.2.5</span> UnicodeExtensionComponents ( <var>extension</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-insert-unicode-extension-and-canonicalize" title="InsertUnicodeExtensionAndCanonicalize ( locale, extension )"><span class="secnum">1.2.6</span> InsertUnicodeExtensionAndCanonicalize ( <var>locale</var>, <var>extension</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-resolvelocale" title="ResolveLocale ( availableLocales, requestedLocales, options, relevantExtensionKeys, localeData )"><span class="secnum">1.2.7</span> ResolveLocale ( <var>availableLocales</var>, <var>requestedLocales</var>, <var>options</var>, <var>relevantExtensionKeys</var>, <var>localeData</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-lookupsupportedlocales" title="LookupSupportedLocales ( availableLocales, requestedLocales )"><span class="secnum">1.2.8</span> LookupSupportedLocales ( <var>availableLocales</var>, <var>requestedLocales</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-bestfitsupportedlocales" title="BestFitSupportedLocales ( availableLocales, requestedLocales )"><span class="secnum">1.2.9</span> BestFitSupportedLocales ( <var>availableLocales</var>, <var>requestedLocales</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-supportedlocales" title="SupportedLocales ( availableLocales, requestedLocales, options )"><span class="secnum">1.2.10</span> SupportedLocales ( <var>availableLocales</var>, <var>requestedLocales</var>, <var>options</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-getoptionsobject" title="GetOptionsObject ( options )"><span class="secnum">1.2.11</span> GetOptionsObject ( <var>options</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-coerceoptionstoobject" title="CoerceOptionsToObject ( options )"><span class="secnum">1.2.12</span> CoerceOptionsToObject ( <var>options</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-getoption" title="GetOption ( options, property, type, values, default )"><span class="secnum">1.2.13</span> GetOption ( <var>options</var>, <var>property</var>, <var>type</var>, <var>values</var>, <var>default</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-getbooleanorstringnumberformatoption" title="GetBooleanOrStringNumberFormatOption ( options, property, stringValues, fallback )"><span class="secnum">1.2.14</span> GetBooleanOrStringNumberFormatOption ( <var>options</var>, <var>property</var>, <var>stringValues</var>, <var>fallback</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-defaultnumberoption" title="DefaultNumberOption ( value, minimum, maximum, fallback )"><span class="secnum">1.2.15</span> DefaultNumberOption ( <var>value</var>, <var>minimum</var>, <var>maximum</var>, <var>fallback</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-getnumberoption" title="GetNumberOption ( options, property, minimum, maximum, fallback )"><span class="secnum">1.2.16</span> GetNumberOption ( <var>options</var>, <var>property</var>, <var>minimum</var>, <var>maximum</var>, <var>fallback</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-partitionpattern" title="PartitionPattern ( pattern )"><span class="secnum">1.2.17</span> PartitionPattern ( <var>pattern</var> )</a></li></ol></li></ol></li></ol></div></div><div id="spec-container"><emu-clause id="locale-and-parameter-negotiation">
+  <h1><span class="secnum">1</span> Locale and Parameter Negotiation</h1>
 
   <p>
-    <emu-xref href="#service-constructor">Service constructors</emu-xref> use a common pattern to negotiate the requests represented by their <var>locales</var> and <var>options</var> arguments against the actual capabilities of their implementations. That common behaviour is explained here in terms of internal slots describing the capabilities and <emu-xref href="#sec-algorithm-conventions-abstract-operations"><a href="https://tc39.es/ecma262/#sec-algorithm-conventions-abstract-operations">abstract operations</a></emu-xref> using these internal slots.
+    <emu-xref href="#service-constructor">Service constructors</emu-xref> use a common pattern to negotiate the requests represented by their <var>locales</var> and <var>options</var> arguments against the actual capabilities of their implementations. That common behaviour is explained here in terms of internal slots describing the capabilities and abstract operations using these internal slots.
   </p>
 
   <emu-clause id="sec-internal-slots">
     <h1><span class="secnum">1.1</span> Internal slots of Service Constructors</h1>
 
     <p>
-      Each service <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> has the following internal slots:
+      Each service constructor has the following internal slots:
     </p>
 
     <ul>
-      <li>[[AvailableLocales]] is a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> that contains structurally valid (<emu-xref href="#sec-isstructurallyvalidlanguagetag"></emu-xref>) and canonicalized (<emu-xref href="#sec-canonicalizeunicodelocaleid"></emu-xref>) language tags identifying the locales for which the implementation provides the functionality of the constructed objects. Language tags on the list must not have a Unicode locale extension sequence. The list must include the value returned by the DefaultLocale abstract operation (<emu-xref href="#sec-defaultlocale"></emu-xref>), and must not include duplicates. Implementations must include in [[AvailableLocales]] locales that can serve as fallbacks in the algorithm used to resolve locales (see <emu-xref href="#sec-resolvelocale" id="_ref_0"><a href="#sec-resolvelocale">1.2.7</a></emu-xref>). For example, implementations that provide a <emu-val>"de-DE"</emu-val> locale must include a <emu-val>"de"</emu-val> locale that can serve as a fallback for requests such as <emu-val>"de-AT"</emu-val> and <emu-val>"de-CH"</emu-val>. For locales that include a script subtag in addition to language and region, the corresponding locale without a script subtag must also be supported; that is, if an implementation recognizes <emu-val>"zh-Hant-TW"</emu-val>, it is also expected to recognize <emu-val>"zh-TW"</emu-val>. The ordering of the locales within [[AvailableLocales]] is irrelevant.</li>
-      <li>[[RelevantExtensionKeys]] is a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> of keys of the language tag extensions defined in Unicode Technical Standard #35 that are relevant for the functionality of the constructed objects.</li>
-      <li>[[SortLocaleData]] and [[SearchLocaleData]] (for Intl.Collator) and [[LocaleData]] (for every other service <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref>) are records that have fields for each locale contained in [[AvailableLocales]]. The value of each of these fields must be a record that has fields for each key contained in [[RelevantExtensionKeys]]. The value of each of these fields must be a non-empty list of those values defined in Unicode Technical Standard #35 for the given key that are supported by the implementation for the given locale, with the first element providing the default value.</li>
+      <li>[[AvailableLocales]] is a List that contains structurally valid (<emu-xref href="#sec-isstructurallyvalidlanguagetag"></emu-xref>) and canonicalized (<emu-xref href="#sec-canonicalizeunicodelocaleid"></emu-xref>) language tags identifying the locales for which the implementation provides the functionality of the constructed objects. Language tags on the list must not have a Unicode locale extension sequence. The list must include the value returned by the DefaultLocale abstract operation (<emu-xref href="#sec-defaultlocale"></emu-xref>), and must not include duplicates. Implementations must include in [[AvailableLocales]] locales that can serve as fallbacks in the algorithm used to resolve locales (see <emu-xref href="#sec-resolvelocale" id="_ref_0"><a href="#sec-resolvelocale">1.2.7</a></emu-xref>). For example, implementations that provide a <emu-val>"de-DE"</emu-val> locale must include a <emu-val>"de"</emu-val> locale that can serve as a fallback for requests such as <emu-val>"de-AT"</emu-val> and <emu-val>"de-CH"</emu-val>. For locales that include a script subtag in addition to language and region, the corresponding locale without a script subtag must also be supported; that is, if an implementation recognizes <emu-val>"zh-Hant-TW"</emu-val>, it is also expected to recognize <emu-val>"zh-TW"</emu-val>. The ordering of the locales within [[AvailableLocales]] is irrelevant.</li>
+      <li>[[RelevantExtensionKeys]] is a List of keys of the language tag extensions defined in Unicode Technical Standard #35 that are relevant for the functionality of the constructed objects.</li>
+      <li>[[SortLocaleData]] and [[SearchLocaleData]] (for Intl.Collator) and [[LocaleData]] (for every other service constructor) are records that have fields for each locale contained in [[AvailableLocales]]. The value of each of these fields must be a record that has fields for each key contained in [[RelevantExtensionKeys]]. The value of each of these fields must be a non-empty list of those values defined in Unicode Technical Standard #35 for the given key that are supported by the implementation for the given locale, with the first element providing the default value.</li>
     </ul>
 
     <emu-note><span class="note">Note</span><div class="note-contents">
@@ -1888,7 +2646,7 @@ li.menu-search-result-term:before {
     <h1><span class="secnum">1.2</span> Abstract Operations</h1>
 
     <p>
-      Where the following <emu-xref href="#sec-algorithm-conventions-abstract-operations"><a href="https://tc39.es/ecma262/#sec-algorithm-conventions-abstract-operations">abstract operations</a></emu-xref> take an <var>availableLocales</var> argument, it must be an [[AvailableLocales]] <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> as specified in <emu-xref href="#sec-internal-slots" id="_ref_1"><a href="#sec-internal-slots">1.1</a></emu-xref>.
+      Where the following abstract operations take an <var>availableLocales</var> argument, it must be an [[AvailableLocales]] List as specified in <emu-xref href="#sec-internal-slots" id="_ref_1"><a href="#sec-internal-slots">1.1</a></emu-xref>.
     </p>
 
     <emu-clause id="sec-canonicalizelocalelist" aoid="CanonicalizeLocaleList">
@@ -1898,14 +2656,14 @@ li.menu-search-result-term:before {
         The abstract operation CanonicalizeLocaleList takes the following steps:
       </p>
 
-      <emu-alg><ol><li>If <var>locales</var> is <emu-val>undefined</emu-val>, then<ol><li>Return a new empty <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref>.</li></ol></li><li>Let <var>seen</var> be a new empty <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref>.</li><li>If <emu-xref aoid="Type" id="_ref_2"><a href="https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>locales</var>) is String or <emu-xref aoid="Type" id="_ref_3"><a href="https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>locales</var>) is Object and <var>locales</var> has an [[InitializedLocale]] internal slot, then<ol><li>Let <var>O</var> be <emu-xref aoid="CreateArrayFromList" id="_ref_4"><a href="https://tc39.es/ecma262/#sec-createarrayfromlist">CreateArrayFromList</a></emu-xref>(« <var>locales</var> »).</li></ol></li><li>Else,<ol><li>Let <var>O</var> be ?&nbsp;<emu-xref aoid="ToObject" id="_ref_5"><a href="https://tc39.es/ecma262/#sec-toobject">ToObject</a></emu-xref>(<var>locales</var>).</li></ol></li><li>Let <var>len</var> be ?&nbsp;<emu-xref aoid="ToLength" id="_ref_6"><a href="https://tc39.es/ecma262/#sec-tolength">ToLength</a></emu-xref>(? <emu-xref aoid="Get" id="_ref_7"><a href="https://tc39.es/ecma262/#sec-get-o-p">Get</a></emu-xref>(<var>O</var>, <emu-val>"length"</emu-val>)).</li><li>Let <var>k</var> be 0.</li><li>Repeat, while <var>k</var> &lt; <var>len</var>,<ol><li>Let <var>Pk</var> be !&nbsp;<emu-xref aoid="ToString" id="_ref_8"><a href="https://tc39.es/ecma262/#sec-tostring">ToString</a></emu-xref>(<var>k</var>).</li><li>Let <var>kPresent</var> be ?&nbsp;<emu-xref aoid="HasProperty" id="_ref_9"><a href="https://tc39.es/ecma262/#sec-hasproperty">HasProperty</a></emu-xref>(<var>O</var>, <var>Pk</var>).</li><li>If <var>kPresent</var> is <emu-val>true</emu-val>, then<ol><li>Let <var>kValue</var> be ?&nbsp;<emu-xref aoid="Get" id="_ref_10"><a href="https://tc39.es/ecma262/#sec-get-o-p">Get</a></emu-xref>(<var>O</var>, <var>Pk</var>).</li><li>If <emu-xref aoid="Type" id="_ref_11"><a href="https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>kValue</var>) is not String or Object, throw a <emu-val>TypeError</emu-val> exception.</li><li>If <emu-xref aoid="Type" id="_ref_12"><a href="https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>kValue</var>) is Object and <var>kValue</var> has an [[InitializedLocale]] internal slot, then<ol><li>Let <var>tag</var> be <var>kValue</var>.[[Locale]].</li></ol></li><li>Else,<ol><li>Let <var>tag</var> be ?&nbsp;<emu-xref aoid="ToString" id="_ref_13"><a href="https://tc39.es/ecma262/#sec-tostring">ToString</a></emu-xref>(<var>kValue</var>).</li></ol></li><li>If !&nbsp;IsStructurallyValidLanguageTag(<var>tag</var>) is <emu-val>false</emu-val>, throw a <emu-val>RangeError</emu-val> exception.</li><li>Let <var>canonicalizedTag</var> be !&nbsp;CanonicalizeUnicodeLocaleId(<var>tag</var>).</li><li>If <var>canonicalizedTag</var> is not an element of <var>seen</var>, append <var>canonicalizedTag</var> as the last element of <var>seen</var>.</li></ol></li><li>Increase <var>k</var> by 1.</li></ol></li><li>Return <var>seen</var>.</li></ol></emu-alg>
+      <emu-alg><ol><li>If <var>locales</var> is <emu-val>undefined</emu-val>, then<ol><li>Return a new empty List.</li></ol></li><li>Let <var>seen</var> be a new empty List.</li><li>If Type(<var>locales</var>) is String or Type(<var>locales</var>) is Object and <var>locales</var> has an [[InitializedLocale]] internal slot, then<ol><li>Let <var>O</var> be CreateArrayFromList(« <var>locales</var> »).</li></ol></li><li>Else,<ol><li>Let <var>O</var> be ?&nbsp;ToObject(<var>locales</var>).</li></ol></li><li>Let <var>len</var> be ?&nbsp;ToLength(? Get(<var>O</var>, <emu-val>"length"</emu-val>)).</li><li>Let <var>k</var> be 0.</li><li>Repeat, while <var>k</var> &lt; <var>len</var>,<ol><li>Let <var>Pk</var> be !&nbsp;ToString(<var>k</var>).</li><li>Let <var>kPresent</var> be ?&nbsp;HasProperty(<var>O</var>, <var>Pk</var>).</li><li>If <var>kPresent</var> is <emu-val>true</emu-val>, then<ol><li>Let <var>kValue</var> be ?&nbsp;Get(<var>O</var>, <var>Pk</var>).</li><li>If Type(<var>kValue</var>) is not String or Object, throw a <emu-val>TypeError</emu-val> exception.</li><li>If Type(<var>kValue</var>) is Object and <var>kValue</var> has an [[InitializedLocale]] internal slot, then<ol><li>Let <var>tag</var> be <var>kValue</var>.[[Locale]].</li></ol></li><li>Else,<ol><li>Let <var>tag</var> be ?&nbsp;ToString(<var>kValue</var>).</li></ol></li><li>If !&nbsp;IsStructurallyValidLanguageTag(<var>tag</var>) is <emu-val>false</emu-val>, throw a <emu-val>RangeError</emu-val> exception.</li><li>Let <var>canonicalizedTag</var> be !&nbsp;CanonicalizeUnicodeLocaleId(<var>tag</var>).</li><li>If <var>canonicalizedTag</var> is not an element of <var>seen</var>, append <var>canonicalizedTag</var> as the last element of <var>seen</var>.</li></ol></li><li>Increase <var>k</var> by 1.</li></ol></li><li>Return <var>seen</var>.</li></ol></emu-alg>
 
       <emu-note><span class="note">Note 1</span><div class="note-contents">
-        Non-normative summary: The abstract operation interprets the <var>locales</var> argument as an array and copies its elements into a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref>, validating the elements as structurally valid language tags and canonicalizing them, and omitting duplicates.
+        Non-normative summary: The abstract operation interprets the <var>locales</var> argument as an array and copies its elements into a List, validating the elements as structurally valid language tags and canonicalizing them, and omitting duplicates.
       </div></emu-note>
 
       <emu-note><span class="note">Note 2</span><div class="note-contents">
-        Requiring <var>kValue</var> to be a String or Object means that the <emu-xref href="#number-value"><a href="https://tc39.es/ecma262/#number-value">Number value</a></emu-xref> <emu-val>NaN</emu-val> will not be interpreted as the language tag <emu-val>"nan"</emu-val>, which stands for Min Nan Chinese.
+        Requiring <var>kValue</var> to be a String or Object means that the Number value <emu-val>NaN</emu-val> will not be interpreted as the language tag <emu-val>"nan"</emu-val>, which stands for Min Nan Chinese.
       </div></emu-note>
     </emu-clause>
 
@@ -1916,17 +2674,17 @@ li.menu-search-result-term:before {
         The BestAvailableLocale abstract operation compares the provided argument <var>locale</var>, which must be a String value with a structurally valid and canonicalized Unicode BCP 47 locale identifier, against the locales in <var>availableLocales</var> and returns either the longest non-empty prefix of <var>locale</var> that is an element of <var>availableLocales</var>, or <emu-val>undefined</emu-val> if there is no such element. It uses the fallback mechanism of RFC 4647, section 3.4. The following steps are taken:
       </p>
 
-      <emu-alg><ol><li>Let <var>candidate</var> be <var>locale</var>.</li><li>Repeat,<ol><li>If <var>availableLocales</var> contains an element equal to <var>candidate</var>, return <var>candidate</var>.</li><li>Let <var>pos</var> be the character index of the last occurrence of <emu-val>"-"</emu-val> (U+002D) within <var>candidate</var>. If that character does not occur, return <emu-val>undefined</emu-val>.</li><li>If <var>pos</var> ≥ 2 and the character <emu-val>"-"</emu-val> occurs at index <var>pos</var> - 2 of candidate, decrease <var>pos</var> by 2.</li><li>Let <var>candidate</var> be the substring of <var>candidate</var> from position 0, inclusive, to position <var>pos</var>, exclusive.</li></ol></li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>candidate</var> be <var>locale</var>.</li><li>Repeat,<ol><li>If <var>availableLocales</var> contains <del>an element equal to</del> <var>candidate</var>, return <var>candidate</var>.</li><li>Let <var>pos</var> be the character index of the last occurrence of <emu-val>"-"</emu-val> (U+002D) within <var>candidate</var>. If that character does not occur, return <emu-val>undefined</emu-val>.</li><li>If <var>pos</var> ≥ 2 and the character <emu-val>"-"</emu-val> occurs at index <var>pos</var> - 2 of candidate, decrease <var>pos</var> by 2.</li><li>Let <var>candidate</var> be the substring of <var>candidate</var> from position 0, inclusive, to position <var>pos</var>, exclusive.</li></ol></li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-lookupmatcher" aoid="LookupMatcher">
       <h1><span class="secnum">1.2.3</span> LookupMatcher ( <var>availableLocales</var>, <var>requestedLocales</var> )</h1>
 
       <p>
-        The LookupMatcher abstract operation compares <var>requestedLocales</var>, which must be a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> as returned by <emu-xref aoid="CanonicalizeLocaleList" id="_ref_14"><a href="#sec-canonicalizelocalelist">CanonicalizeLocaleList</a></emu-xref>, against the locales in <var>availableLocales</var> and determines the best available language to meet the request. The following steps are taken:
+        The LookupMatcher abstract operation compares <var>requestedLocales</var>, which must be a List as returned by <emu-xref aoid="CanonicalizeLocaleList" id="_ref_2"><a href="#sec-canonicalizelocalelist">CanonicalizeLocaleList</a></emu-xref>, against the locales in <var>availableLocales</var> and determines the best available language to meet the request. The following steps are taken:
       </p>
 
-      <emu-alg><ol><li>Let <var>result</var> be a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref>.</li><li>For each element <var>locale</var> of <var>requestedLocales</var>, do<ol><li>Let <var>noExtensionsLocale</var> be the String value that is <var>locale</var> with any Unicode locale extension sequences removed.</li><li>Let <var>availableLocale</var> be !&nbsp;<emu-xref aoid="BestAvailableLocale" id="_ref_15"><a href="#sec-bestavailablelocale">BestAvailableLocale</a></emu-xref>(<var>availableLocales</var>, <var>noExtensionsLocale</var>).</li><li>If <var>availableLocale</var> is not <emu-val>undefined</emu-val>, then<ol><li>Set <var>result</var>.[[locale]] to <var>availableLocale</var>.</li><li>If <var>locale</var> and <var>noExtensionsLocale</var> are not the same String value, then<ol><li>Let <var>extension</var> be the String value consisting of the substring of the Unicode locale extension sequence within <var>locale</var>.</li><li>Set <var>result</var>.[[extension]] to <var>extension</var>.</li></ol></li><li>Return <var>result</var>.</li></ol></li></ol></li><li>Let <var>defLocale</var> be !&nbsp;DefaultLocale().</li><li>Set <var>result</var>.[[locale]] to <var>defLocale</var>.</li><li>Return <var>result</var>.</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>result</var> be a new Record.</li><li>For each element <var>locale</var> of <var>requestedLocales</var>, do<ol><li>Let <var>noExtensionsLocale</var> be the String value that is <var>locale</var> with any Unicode locale extension sequences removed.</li><li>Let <var>availableLocale</var> be !&nbsp;<emu-xref aoid="BestAvailableLocale" id="_ref_3"><a href="#sec-bestavailablelocale">BestAvailableLocale</a></emu-xref>(<var>availableLocales</var>, <var>noExtensionsLocale</var>).</li><li>If <var>availableLocale</var> is not <emu-val>undefined</emu-val>, then<ol><li>Set <var>result</var>.[[locale]] to <var>availableLocale</var>.</li><li>If <var>locale</var> and <var>noExtensionsLocale</var> are not the same String value, then<ol><li>Let <var>extension</var> be the String value consisting of the substring of the Unicode locale extension sequence within <var>locale</var>.</li><li>Set <var>result</var>.[[extension]] to <var>extension</var>.</li></ol></li><li>Return <var>result</var>.</li></ol></li></ol></li><li>Let <var>defLocale</var> be !&nbsp;DefaultLocale().</li><li>Set <var>result</var>.[[locale]] to <var>defLocale</var>.</li><li>Return <var>result</var>.</li></ol></emu-alg>
 
       <emu-note><span class="note">Note</span><div class="note-contents">
         The algorithm is based on the Lookup algorithm described in RFC 4647 section 3.4, but options specified through Unicode locale extension sequences are ignored in the lookup. Information about such subsequences is returned separately. The abstract operation returns a record with a [[locale]] field, whose value is the language tag of the selected locale, which must be an element of <var>availableLocales</var>. If the language tag of the request locale that led to the selected locale contained a Unicode locale extension sequence, then the returned record also contains an [[extension]] field whose value is the substring of the Unicode locale extension sequence within the request locale language tag.
@@ -1937,17 +2695,17 @@ li.menu-search-result-term:before {
       <h1><span class="secnum">1.2.4</span> BestFitMatcher ( <var>availableLocales</var>, <var>requestedLocales</var> )</h1>
 
       <p>
-        The BestFitMatcher abstract operation compares <var>requestedLocales</var>, which must be a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> as returned by <emu-xref aoid="CanonicalizeLocaleList" id="_ref_16"><a href="#sec-canonicalizelocalelist">CanonicalizeLocaleList</a></emu-xref>, against the locales in <var>availableLocales</var> and determines the best available language to meet the request. The algorithm is implementation dependent, but should produce results that a typical user of the requested locales would perceive as at least as good as those produced by the <emu-xref aoid="LookupMatcher" id="_ref_17"><a href="#sec-lookupmatcher">LookupMatcher</a></emu-xref> abstract operation. Options specified through Unicode locale extension sequences must be ignored by the algorithm. Information about such subsequences is returned separately. The abstract operation returns a record with a [[locale]] field, whose value is the language tag of the selected locale, which must be an element of <var>availableLocales</var>. If the language tag of the request locale that led to the selected locale contained a Unicode locale extension sequence, then the returned record also contains an [[extension]] field whose value is the substring of the Unicode locale extension sequence within the request locale language tag.
+        The BestFitMatcher abstract operation compares <var>requestedLocales</var>, which must be a List as returned by <emu-xref aoid="CanonicalizeLocaleList" id="_ref_4"><a href="#sec-canonicalizelocalelist">CanonicalizeLocaleList</a></emu-xref>, against the locales in <var>availableLocales</var> and determines the best available language to meet the request. The algorithm is implementation dependent, but should produce results that a typical user of the requested locales would perceive as at least as good as those produced by the <emu-xref aoid="LookupMatcher" id="_ref_5"><a href="#sec-lookupmatcher">LookupMatcher</a></emu-xref> abstract operation. Options specified through Unicode locale extension sequences must be ignored by the algorithm. Information about such subsequences is returned separately. The abstract operation returns a record with a [[locale]] field, whose value is the language tag of the selected locale, which must be an element of <var>availableLocales</var>. If the language tag of the request locale that led to the selected locale contained a Unicode locale extension sequence, then the returned record also contains an [[extension]] field whose value is the substring of the Unicode locale extension sequence within the request locale language tag.
       </p>
     </emu-clause>
 
     <emu-clause id="sec-unicode-extension-components" aoid="UnicodeExtensionComponents">
       <h1><span class="secnum">1.2.5</span> UnicodeExtensionComponents ( <var>extension</var> )</h1>
       <p>
-        The UnicodeExtensionComponents abstract operation returns the attributes and keywords from <var>extension</var>, which must be a String value whose contents are a Unicode locale extension sequence. If an attribute or a <emu-xref href="#sec-keywords-and-reserved-words"><a href="https://tc39.es/ecma262/#sec-keywords-and-reserved-words">keyword</a></emu-xref> occurs multiple times in <var>extension</var>, only the first occurence is returned. The following steps are taken:
+        The UnicodeExtensionComponents abstract operation returns the attributes and keywords from <var>extension</var>, which must be a String value whose contents are a Unicode locale extension sequence. If an attribute or a keyword occurs multiple times in <var>extension</var>, only the first occurence is returned. The following steps are taken:
       </p>
 
-      <emu-alg><ol><li>Let <var>attributes</var> be a new empty <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref>.</li><li>Let <var>keywords</var> be a new empty <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref>.</li><li>Let <var>keyword</var> be <emu-val>undefined</emu-val>.</li><li>Let <var>size</var> be the length of <var>extension</var>.</li><li>Let <var>k</var> be 3.</li><li>Repeat, while <var>k</var> &lt; <var>size</var>,<ol><li>Let <var>e</var> be StringIndexOf(<var>extension</var>, <emu-val>"-"</emu-val>, <var>k</var>).</li><li>If <var>e</var> = -1, let <var>len</var> be <var>size</var> - <var>k</var>; else let <var>len</var> be <var>e</var> - <var>k</var>.</li><li>Let <var>subtag</var> be the String value equal to the substring of <var>extension</var> consisting of the code units at indices <var>k</var> (inclusive) through <var>k</var> + <var>len</var> (exclusive).</li><li>If <var>keyword</var> is <emu-val>undefined</emu-val> and <var>len</var> ≠ 2, then<ol><li>If <var>subtag</var> is not an element of <var>attributes</var>, then<ol><li>Append <var>subtag</var> to <var>attributes</var>.</li></ol></li></ol></li><li>Else if <var>len</var> = 2, then<ol><li>If <var>keyword</var> is not <emu-val>undefined</emu-val> and <var>keywords</var> does not contain an element whose [[Key]] is the same as <var>keyword</var>.[[Key]], then<ol><li>Append <var>keyword</var> to <var>keywords</var>.</li></ol></li><li>Set <var>keyword</var> to the <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Key]]: <var>subtag</var>, [[Value]]: <emu-val>""</emu-val> }.</li></ol></li><li>Else,<ol><li>If <var>keyword</var>.[[Value]] is the empty String, then<ol><li>Set <var>keyword</var>.[[Value]] to <var>subtag</var>.</li></ol></li><li>Else,<ol><li>Set <var>keyword</var>.[[Value]] to the <emu-xref href="#sec-ecmascript-language-types-string-type"><a href="https://tc39.es/ecma262/#sec-ecmascript-language-types-string-type">string-concatenation</a></emu-xref> of <var>keyword</var>.[[Value]], <emu-val>"-"</emu-val>, and <var>subtag</var>.</li></ol></li></ol></li><li>Let <var>k</var> be <var>k</var> + <var>len</var> + 1.</li></ol></li><li>If <var>keyword</var> is not <emu-val>undefined</emu-val> and <var>keywords</var> does not contain an element whose [[Key]] is the same as <var>keyword</var>.[[Key]], then<ol><li>Append <var>keyword</var> to <var>keywords</var>.</li></ol></li><li>Return the <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Attributes]]: <var>attributes</var>, [[Keywords]]: <var>keywords</var> }.</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>attributes</var> be a new empty List.</li><li>Let <var>keywords</var> be a new empty List.</li><li>Let <var>keyword</var> be <emu-val>undefined</emu-val>.</li><li>Let <var>size</var> be the length of <var>extension</var>.</li><li>Let <var>k</var> be 3.</li><li>Repeat, while <var>k</var> &lt; <var>size</var>,<ol><li>Let <var>e</var> be StringIndexOf(<var>extension</var>, <emu-val>"-"</emu-val>, <var>k</var>).</li><li>If <var>e</var> = -1, let <var>len</var> be <var>size</var> - <var>k</var>; else let <var>len</var> be <var>e</var> - <var>k</var>.</li><li>Let <var>subtag</var> be the String value equal to the substring of <var>extension</var> consisting of the code units at indices <var>k</var> (inclusive) through <var>k</var> + <var>len</var> (exclusive).</li><li>If <var>keyword</var> is <emu-val>undefined</emu-val> and <var>len</var> ≠ 2, then<ol><li>If <var>subtag</var> is not an element of <var>attributes</var>, then<ol><li>Append <var>subtag</var> to <var>attributes</var>.</li></ol></li></ol></li><li>Else if <var>len</var> = 2, then<ol><li>If <var>keyword</var> is not <emu-val>undefined</emu-val> and <var>keywords</var> does not contain an element whose [[Key]] is the same as <var>keyword</var>.[[Key]], then<ol><li>Append <var>keyword</var> to <var>keywords</var>.</li></ol></li><li>Set <var>keyword</var> to the Record { [[Key]]: <var>subtag</var>, [[Value]]: <emu-val>""</emu-val> }.</li></ol></li><li>Else,<ol><li>If <var>keyword</var>.[[Value]] is the empty String, then<ol><li>Set <var>keyword</var>.[[Value]] to <var>subtag</var>.</li></ol></li><li>Else,<ol><li>Set <var>keyword</var>.[[Value]] to the string-concatenation of <var>keyword</var>.[[Value]], <emu-val>"-"</emu-val>, and <var>subtag</var>.</li></ol></li></ol></li><li>Let <var>k</var> be <var>k</var> + <var>len</var> + 1.</li></ol></li><li>If <var>keyword</var> is not <emu-val>undefined</emu-val> and <var>keywords</var> does not contain an element whose [[Key]] is the same as <var>keyword</var>.[[Key]], then<ol><li>Append <var>keyword</var> to <var>keywords</var>.</li></ol></li><li>Return the Record { [[Attributes]]: <var>attributes</var>, [[Keywords]]: <var>keywords</var> }.</li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-insert-unicode-extension-and-canonicalize" aoid="InsertUnicodeExtensionAndCanonicalize">
@@ -1959,21 +2717,21 @@ li.menu-search-result-term:before {
         The following algorithm refers to <a href="https://www.unicode.org/reports/tr35/#Identifiers">UTS 35's Unicode Language and Locale Identifiers grammar</a>.
       </p>
 
-      <emu-alg><ol><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>locale</var> matches the <code>unicode_locale_id</code> production.</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>locale</var> does not contain a Unicode locale extension sequence.</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>extension</var> is a Unicode locale extension sequence.</li><li>Let <var>privateIndex</var> be StringIndexOf(<var>locale</var>, <emu-val>"-x-"</emu-val>, 0).</li><li>If <var>privateIndex</var> = -1, then<ol><li>Let <var>locale</var> be the <emu-xref href="#sec-ecmascript-language-types-string-type"><a href="https://tc39.es/ecma262/#sec-ecmascript-language-types-string-type">string-concatenation</a></emu-xref> of <var>locale</var> and <var>extension</var>.</li></ol></li><li>Else,<ol><li>Let <var>preExtension</var> be the substring of <var>locale</var> from position 0, inclusive, to position <var>privateIndex</var>, exclusive.</li><li>Let <var>postExtension</var> be the substring of <var>locale</var> from position <var>privateIndex</var> to the end of the string.</li><li>Let <var>locale</var> be the <emu-xref href="#sec-ecmascript-language-types-string-type"><a href="https://tc39.es/ecma262/#sec-ecmascript-language-types-string-type">string-concatenation</a></emu-xref> of <var>preExtension</var>, <var>extension</var>, and <var>postExtension</var>.</li></ol></li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: !&nbsp;IsStructurallyValidLanguageTag(<var>locale</var>) is <emu-val>true</emu-val>.</li><li>Return !&nbsp;CanonicalizeUnicodeLocaleId(<var>locale</var>).</li></ol></emu-alg>
+      <emu-alg><ol><li>Assert: <var>locale</var> matches the <code>unicode_locale_id</code> production.</li><li>Assert: <var>locale</var> does not contain a Unicode locale extension sequence.</li><li>Assert: <var>extension</var> is a Unicode locale extension sequence.</li><li>Let <var>privateIndex</var> be StringIndexOf(<var>locale</var>, <emu-val>"-x-"</emu-val>, 0).</li><li>If <var>privateIndex</var> = -1, then<ol><li>Let <var>locale</var> be the string-concatenation of <var>locale</var> and <var>extension</var>.</li></ol></li><li>Else,<ol><li>Let <var>preExtension</var> be the substring of <var>locale</var> from position 0, inclusive, to position <var>privateIndex</var>, exclusive.</li><li>Let <var>postExtension</var> be the substring of <var>locale</var> from position <var>privateIndex</var> to the end of the string.</li><li>Let <var>locale</var> be the string-concatenation of <var>preExtension</var>, <var>extension</var>, and <var>postExtension</var>.</li></ol></li><li>Assert: !&nbsp;IsStructurallyValidLanguageTag(<var>locale</var>) is <emu-val>true</emu-val>.</li><li>Return !&nbsp;CanonicalizeUnicodeLocaleId(<var>locale</var>).</li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-resolvelocale" aoid="ResolveLocale">
       <h1><span class="secnum">1.2.7</span> ResolveLocale ( <var>availableLocales</var>, <var>requestedLocales</var>, <var>options</var>, <var>relevantExtensionKeys</var>, <var>localeData</var> )</h1>
 
       <p>
-        The ResolveLocale abstract operation compares a BCP 47 language priority list <var>requestedLocales</var> against the locales in <var>availableLocales</var> and determines the best available language to meet the request. <var>availableLocales</var>, <var>requestedLocales</var>, and <var>relevantExtensionKeys</var> must be provided as <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> values, <var>options</var> and <var>localeData</var> as Records.
+        The ResolveLocale abstract operation compares a BCP 47 language priority list <var>requestedLocales</var> against the locales in <var>availableLocales</var> and determines the best available language to meet the request. <var>availableLocales</var>, <var>requestedLocales</var>, and <var>relevantExtensionKeys</var> must be provided as List values, <var>options</var> and <var>localeData</var> as Records.
       </p>
 
       <p>
         The following steps are taken:
       </p>
 
-      <emu-alg><ol><li>Let <var>matcher</var> be <var>options</var>.[[localeMatcher]].</li><li>If <var>matcher</var> is <emu-val>"lookup"</emu-val>, then<ol><li>Let <var>r</var> be !&nbsp;<emu-xref aoid="LookupMatcher" id="_ref_18"><a href="#sec-lookupmatcher">LookupMatcher</a></emu-xref>(<var>availableLocales</var>, <var>requestedLocales</var>).</li></ol></li><li>Else,<ol><li>Let <var>r</var> be !&nbsp;<emu-xref aoid="BestFitMatcher" id="_ref_19"><a href="#sec-bestfitmatcher">BestFitMatcher</a></emu-xref>(<var>availableLocales</var>, <var>requestedLocales</var>).</li></ol></li><li>Let <var>foundLocale</var> be <var>r</var>.[[locale]].</li><li>Let <var>result</var> be a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref>.</li><li>Set <var>result</var>.[[dataLocale]] to <var>foundLocale</var>.</li><li>If <var>r</var> has an [[extension]] field, then<ol><li>Let <var>components</var> be !&nbsp;<emu-xref aoid="UnicodeExtensionComponents" id="_ref_20"><a href="#sec-unicode-extension-components">UnicodeExtensionComponents</a></emu-xref>(<var>r</var>.[[extension]]).</li><li>Let <var>keywords</var> be <var>components</var>.[[Keywords]].</li></ol></li><li>Let <var>supportedExtension</var> be <emu-val>"-u"</emu-val>.</li><li>For each element <var>key</var> of <var>relevantExtensionKeys</var>, do<ol><li>Let <var>foundLocaleData</var> be <var>localeData</var>.[[&lt;<var>foundLocale</var>&gt;]].</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <emu-xref aoid="Type" id="_ref_21"><a href="https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>foundLocaleData</var>) is <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref>.</li><li>Let <var>keyLocaleData</var> be <var>foundLocaleData</var>.[[&lt;<var>key</var>&gt;]].</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <emu-xref aoid="Type" id="_ref_22"><a href="https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>keyLocaleData</var>) is <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref>.</li><li>Let <var>value</var> be <var>keyLocaleData</var>[0].</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <emu-xref aoid="Type" id="_ref_23"><a href="https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>value</var>) is either String or Null.</li><li>Let <var>supportedExtensionAddition</var> be <emu-val>""</emu-val>.</li><li>If <var>r</var> has an [[extension]] field, then<ol><li>If <var>keywords</var> contains an element whose [[Key]] is the same as <var>key</var>, then<ol><li>Let <var>entry</var> be the element of <var>keywords</var> whose [[Key]] is the same as <var>key</var>.</li><li>Let <var>requestedValue</var> be <var>entry</var>.[[Value]].</li><li>If <var>requestedValue</var> is not the empty String, then<ol><li>If <var>keyLocaleData</var> contains <var>requestedValue</var>, then<ol><li>Let <var>value</var> be <var>requestedValue</var>.</li><li>Let <var>supportedExtensionAddition</var> be the <emu-xref href="#sec-ecmascript-language-types-string-type"><a href="https://tc39.es/ecma262/#sec-ecmascript-language-types-string-type">string-concatenation</a></emu-xref> of <emu-val>"-"</emu-val>, <var>key</var>, <emu-val>"-"</emu-val>, and <var>value</var>.</li></ol></li></ol></li><li>Else if <var>keyLocaleData</var> contains <emu-val>"true"</emu-val>, then<ol><li>Let <var>value</var> be <emu-val>"true"</emu-val>.</li><li>Let <var>supportedExtensionAddition</var> be the <emu-xref href="#sec-ecmascript-language-types-string-type"><a href="https://tc39.es/ecma262/#sec-ecmascript-language-types-string-type">string-concatenation</a></emu-xref> of <emu-val>"-"</emu-val> and <var>key</var>.</li></ol></li></ol></li></ol></li><li>If <var>options</var> has a field [[&lt;<var>key</var>&gt;]], then<ol><li>Let <var>optionsValue</var> be <var>options</var>.[[&lt;<var>key</var>&gt;]].</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <emu-xref aoid="Type" id="_ref_24"><a href="https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>optionsValue</var>) is either String, Undefined, or Null.</li><li>If <emu-xref aoid="Type" id="_ref_25"><a href="https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>optionsValue</var>) is String, then<ol><li>Let <var>optionsValue</var> be the string <var>optionsValue</var> after performing the algorithm steps to transform Unicode extension values to canonical syntax per <a href="https://unicode.org/reports/tr35/#Canonical_Unicode_Locale_Identifiers">Unicode Technical Standard #35 LDML § 3.2.1 Canonical Unicode Locale Identifiers</a>, treating <var>key</var> as <code>ukey</code> and <var>optionsValue</var> as <code>uvalue</code> productions.</li><li>Let <var>optionsValue</var> be the string <var>optionsValue</var> after performing the algorithm steps to replace Unicode extension values with their canonical form per <a href="https://unicode.org/reports/tr35/#Canonical_Unicode_Locale_Identifiers">Unicode Technical Standard #35 LDML § 3.2.1 Canonical Unicode Locale Identifiers</a>, treating <var>key</var> as <code>ukey</code> and <var>optionsValue</var> as <code>uvalue</code> productions.</li><li>If <var>optionsValue</var> is the empty String, then<ol><li>Let <var>optionsValue</var> be <emu-val>"true"</emu-val>.</li></ol></li></ol></li><li>If <var>keyLocaleData</var> contains <var>optionsValue</var>, then<ol><li>If <emu-xref aoid="SameValue" id="_ref_26"><a href="https://tc39.es/ecma262/#sec-samevalue">SameValue</a></emu-xref>(<var>optionsValue</var>, <var>value</var>) is <emu-val>false</emu-val>, then<ol><li>Let <var>value</var> be <var>optionsValue</var>.</li><li>Let <var>supportedExtensionAddition</var> be <emu-val>""</emu-val>.</li></ol></li></ol></li></ol></li><li>Set <var>result</var>.[[&lt;<var>key</var>&gt;]] to <var>value</var>.</li><li>Append <var>supportedExtensionAddition</var> to <var>supportedExtension</var>.</li></ol></li><li>If the number of elements in <var>supportedExtension</var> is greater than 2, then<ol><li>Let <var>foundLocale</var> be <emu-xref aoid="InsertUnicodeExtensionAndCanonicalize" id="_ref_27"><a href="#sec-insert-unicode-extension-and-canonicalize">InsertUnicodeExtensionAndCanonicalize</a></emu-xref>(<var>foundLocale</var>, <var>supportedExtension</var>).</li></ol></li><li>Set <var>result</var>.[[locale]] to <var>foundLocale</var>.</li><li>Return <var>result</var>.</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>matcher</var> be <var>options</var>.[[localeMatcher]].</li><li>If <var>matcher</var> is <emu-val>"lookup"</emu-val>, then<ol><li>Let <var>r</var> be !&nbsp;<emu-xref aoid="LookupMatcher" id="_ref_6"><a href="#sec-lookupmatcher">LookupMatcher</a></emu-xref>(<var>availableLocales</var>, <var>requestedLocales</var>).</li></ol></li><li>Else,<ol><li>Let <var>r</var> be !&nbsp;<emu-xref aoid="BestFitMatcher" id="_ref_7"><a href="#sec-bestfitmatcher">BestFitMatcher</a></emu-xref>(<var>availableLocales</var>, <var>requestedLocales</var>).</li></ol></li><li>Let <var>foundLocale</var> be <var>r</var>.[[locale]].</li><li>Let <var>result</var> be a new Record.</li><li>Set <var>result</var>.[[dataLocale]] to <var>foundLocale</var>.</li><li>If <var>r</var> has an [[extension]] field, then<ol><li>Let <var>components</var> be !&nbsp;<emu-xref aoid="UnicodeExtensionComponents" id="_ref_8"><a href="#sec-unicode-extension-components">UnicodeExtensionComponents</a></emu-xref>(<var>r</var>.[[extension]]).</li><li>Let <var>keywords</var> be <var>components</var>.[[Keywords]].</li></ol></li><li>Let <var>supportedExtension</var> be <emu-val>"-u"</emu-val>.</li><li>For each element <var>key</var> of <var>relevantExtensionKeys</var>, do<ol><li>Let <var>foundLocaleData</var> be <var>localeData</var>.[[&lt;<var>foundLocale</var>&gt;]].</li><li>Assert: Type(<var>foundLocaleData</var>) is Record.</li><li>Let <var>keyLocaleData</var> be <var>foundLocaleData</var>.[[&lt;<var>key</var>&gt;]].</li><li>Assert: Type(<var>keyLocaleData</var>) is List.</li><li>Let <var>value</var> be <var>keyLocaleData</var>[0].</li><li>Assert: Type(<var>value</var>) is either String or Null.</li><li>Let <var>supportedExtensionAddition</var> be <emu-val>""</emu-val>.</li><li>If <var>r</var> has an [[extension]] field, then<ol><li>If <var>keywords</var> contains an element whose [[Key]] is the same as <var>key</var>, then<ol><li>Let <var>entry</var> be the element of <var>keywords</var> whose [[Key]] is the same as <var>key</var>.</li><li>Let <var>requestedValue</var> be <var>entry</var>.[[Value]].</li><li>If <var>requestedValue</var> is not the empty String, then<ol><li>If <var>keyLocaleData</var> contains <var>requestedValue</var>, then<ol><li>Let <var>value</var> be <var>requestedValue</var>.</li><li>Let <var>supportedExtensionAddition</var> be the string-concatenation of <emu-val>"-"</emu-val>, <var>key</var>, <emu-val>"-"</emu-val>, and <var>value</var>.</li></ol></li></ol></li><li>Else if <var>keyLocaleData</var> contains <emu-val>"true"</emu-val>, then<ol><li>Let <var>value</var> be <emu-val>"true"</emu-val>.</li><li>Let <var>supportedExtensionAddition</var> be the string-concatenation of <emu-val>"-"</emu-val> and <var>key</var>.</li></ol></li></ol></li></ol></li><li>If <var>options</var> has a field [[&lt;<var>key</var>&gt;]], then<ol><li>Let <var>optionsValue</var> be <var>options</var>.[[&lt;<var>key</var>&gt;]].</li><li>Assert: Type(<var>optionsValue</var>) is either String, Undefined, or Null.</li><li>If Type(<var>optionsValue</var>) is String, then<ol><li>Let <var>optionsValue</var> be the string <var>optionsValue</var> after performing the algorithm steps to transform Unicode extension values to canonical syntax per <a href="https://unicode.org/reports/tr35/#Canonical_Unicode_Locale_Identifiers">Unicode Technical Standard #35 LDML § 3.2.1 Canonical Unicode Locale Identifiers</a>, treating <var>key</var> as <code>ukey</code> and <var>optionsValue</var> as <code>uvalue</code> productions.</li><li>Let <var>optionsValue</var> be the string <var>optionsValue</var> after performing the algorithm steps to replace Unicode extension values with their canonical form per <a href="https://unicode.org/reports/tr35/#Canonical_Unicode_Locale_Identifiers">Unicode Technical Standard #35 LDML § 3.2.1 Canonical Unicode Locale Identifiers</a>, treating <var>key</var> as <code>ukey</code> and <var>optionsValue</var> as <code>uvalue</code> productions.</li><li>If <var>optionsValue</var> is the empty String, then<ol><li>Let <var>optionsValue</var> be <emu-val>"true"</emu-val>.</li></ol></li></ol></li><li>If <var>keyLocaleData</var> contains <var>optionsValue</var>, then<ol><li>If SameValue(<var>optionsValue</var>, <var>value</var>) is <emu-val>false</emu-val>, then<ol><li>Let <var>value</var> be <var>optionsValue</var>.</li><li>Let <var>supportedExtensionAddition</var> be <emu-val>""</emu-val>.</li></ol></li></ol></li></ol></li><li>Set <var>result</var>.[[&lt;<var>key</var>&gt;]] to <var>value</var>.</li><li>Append <var>supportedExtensionAddition</var> to <var>supportedExtension</var>.</li></ol></li><li>If the number of elements in <var>supportedExtension</var> is greater than 2, then<ol><li>Let <var>foundLocale</var> be <emu-xref aoid="InsertUnicodeExtensionAndCanonicalize" id="_ref_9"><a href="#sec-insert-unicode-extension-and-canonicalize">InsertUnicodeExtensionAndCanonicalize</a></emu-xref>(<var>foundLocale</var>, <var>supportedExtension</var>).</li></ol></li><li>Set <var>result</var>.[[locale]] to <var>foundLocale</var>.</li><li>Return <var>result</var>.</li></ol></emu-alg>
 
       <emu-note><span class="note">Note</span><div class="note-contents">
         Non-normative summary: Two algorithms are available to match the locales: the Lookup algorithm described in RFC 4647 section 3.4, and an implementation dependent best-fit algorithm. Independent of the locale matching algorithm, options specified through Unicode locale extension sequences are negotiated separately, taking the caller's relevant extension keys and locale data as well as client-provided options into consideration. The abstract operation returns a record with a [[locale]] field whose value is the language tag of the selected locale, and fields for each key in <var>relevantExtensionKeys</var> providing the selected value for that key.
@@ -1987,7 +2745,7 @@ li.menu-search-result-term:before {
         The LookupSupportedLocales abstract operation returns the subset of the provided BCP 47 language priority list <var>requestedLocales</var> for which <var>availableLocales</var> has a matching locale when using the BCP 47 Lookup algorithm. Locales appear in the same order in the returned list as in <var>requestedLocales</var>. The following steps are taken:
       </p>
 
-      <emu-alg><ol><li>Let <var>subset</var> be a new empty <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref>.</li><li>For each element <var>locale</var> of <var>requestedLocales</var>, do<ol><li>Let <var>noExtensionsLocale</var> be the String value that is <var>locale</var> with any Unicode locale extension sequences removed.</li><li>Let <var>availableLocale</var> be !&nbsp;<emu-xref aoid="BestAvailableLocale" id="_ref_28"><a href="#sec-bestavailablelocale">BestAvailableLocale</a></emu-xref>(<var>availableLocales</var>, <var>noExtensionsLocale</var>).</li><li>If <var>availableLocale</var> is not <emu-val>undefined</emu-val>, append <var>locale</var> to the end of <var>subset</var>.</li></ol></li><li>Return <var>subset</var>.</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>subset</var> be a new empty List.</li><li>For each element <var>locale</var> of <var>requestedLocales</var>, do<ol><li>Let <var>noExtensionsLocale</var> be the String value that is <var>locale</var> with any Unicode locale extension sequences removed.</li><li>Let <var>availableLocale</var> be !&nbsp;<emu-xref aoid="BestAvailableLocale" id="_ref_10"><a href="#sec-bestavailablelocale">BestAvailableLocale</a></emu-xref>(<var>availableLocales</var>, <var>noExtensionsLocale</var>).</li><li>If <var>availableLocale</var> is not <emu-val>undefined</emu-val>, append <var>locale</var> to the end of <var>subset</var>.</li></ol></li><li>Return <var>subset</var>.</li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-bestfitsupportedlocales" aoid="BestFitSupportedLocales">
@@ -2005,53 +2763,38 @@ li.menu-search-result-term:before {
         The SupportedLocales abstract operation returns the subset of the provided BCP 47 language priority list <var>requestedLocales</var> for which <var>availableLocales</var> has a matching locale. Two algorithms are available to match the locales: the Lookup algorithm described in RFC 4647 section 3.4, and an implementation dependent best-fit algorithm. Locales appear in the same order in the returned list as in <var>requestedLocales</var>. The following steps are taken:
       </p>
 
-      <emu-alg><ol><li>Set <var>options</var> to ?&nbsp;<emu-xref aoid="CoerceOptionsToObject" id="_ref_29"><a href="#sec-coerceoptionstoobject">CoerceOptionsToObject</a></emu-xref>(<var>options</var>).</li><li>Let <var>matcher</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"localeMatcher"</emu-val>, <emu-const>string</emu-const>, « <emu-val>"lookup"</emu-val>, <emu-val>"best fit"</emu-val> », <emu-val>"best fit"</emu-val>).</li><li>If <var>matcher</var> is <emu-val>"best fit"</emu-val>, then<ol><li>Let <var>supportedLocales</var> be <emu-xref aoid="BestFitSupportedLocales" id="_ref_30"><a href="#sec-bestfitsupportedlocales">BestFitSupportedLocales</a></emu-xref>(<var>availableLocales</var>, <var>requestedLocales</var>).</li></ol></li><li>Else,<ol><li>Let <var>supportedLocales</var> be <emu-xref aoid="LookupSupportedLocales" id="_ref_31"><a href="#sec-lookupsupportedlocales">LookupSupportedLocales</a></emu-xref>(<var>availableLocales</var>, <var>requestedLocales</var>).</li></ol></li><li>Return <emu-xref aoid="CreateArrayFromList" id="_ref_32"><a href="https://tc39.es/ecma262/#sec-createarrayfromlist">CreateArrayFromList</a></emu-xref>(<var>supportedLocales</var>).</li></ol></emu-alg>
+      <emu-alg><ol><li>Set <var>options</var> to ?&nbsp;<emu-xref aoid="CoerceOptionsToObject" id="_ref_11"><a href="#sec-coerceoptionstoobject">CoerceOptionsToObject</a></emu-xref>(<var>options</var>).</li><li>Let <var>matcher</var> be ?&nbsp;<emu-xref aoid="GetOption" id="_ref_12"><a href="#sec-getoption">GetOption</a></emu-xref>(<var>options</var>, <emu-val>"localeMatcher"</emu-val>, <emu-const>string</emu-const>, « <emu-val>"lookup"</emu-val>, <emu-val>"best fit"</emu-val> », <emu-val>"best fit"</emu-val>).</li><li>If <var>matcher</var> is <emu-val>"best fit"</emu-val>, then<ol><li>Let <var>supportedLocales</var> be <emu-xref aoid="BestFitSupportedLocales" id="_ref_13"><a href="#sec-bestfitsupportedlocales">BestFitSupportedLocales</a></emu-xref>(<var>availableLocales</var>, <var>requestedLocales</var>).</li></ol></li><li>Else,<ol><li>Let <var>supportedLocales</var> be <emu-xref aoid="LookupSupportedLocales" id="_ref_14"><a href="#sec-lookupsupportedlocales">LookupSupportedLocales</a></emu-xref>(<var>availableLocales</var>, <var>requestedLocales</var>).</li></ol></li><li>Return CreateArrayFromList(<var>supportedLocales</var>).</li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-getoptionsobject" aoid="GetOptionsObject">
       <h1><span class="secnum">1.2.11</span> GetOptionsObject ( <var>options</var> )</h1>
       <p>
-        The abstract operation GetOptionsObject returns an Object suitable for use with GetOption, either <var>options</var> itself or a default empty Object.
+        The abstract operation GetOptionsObject returns an Object suitable for use with <emu-xref aoid="GetOption" id="_ref_15"><a href="#sec-getoption">GetOption</a></emu-xref>, either <var>options</var> itself or a default empty Object.
         It throws a TypeError if <var>options</var> is not undefined and not an Object.
       </p>
-      <emu-alg><ol><li>If <var>options</var> is <emu-val>undefined</emu-val>, then<ol><li>Return OrdinaryObjectCreate(<emu-val>null</emu-val>).</li></ol></li><li>If <emu-xref aoid="Type" id="_ref_33"><a href="https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>options</var>) is Object, then<ol><li>Return <var>options</var>.</li></ol></li><li>Throw a <emu-val>TypeError</emu-val> exception.</li></ol></emu-alg>
+      <emu-alg><ol><li>If <var>options</var> is <emu-val>undefined</emu-val>, then<ol><li>Return OrdinaryObjectCreate(<emu-val>null</emu-val>).</li></ol></li><li>If Type(<var>options</var>) is Object, then<ol><li>Return <var>options</var>.</li></ol></li><li>Throw a <emu-val>TypeError</emu-val> exception.</li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-coerceoptionstoobject" aoid="CoerceOptionsToObject">
       <h1><span class="secnum">1.2.12</span> CoerceOptionsToObject ( <var>options</var> )</h1>
       <p>
-        The abstract operation CoerceOptionsToObject coerces <var>options</var> into an Object suitable for use with GetOption, defaulting to an empty Object.
-        Because it coerces non-null primitive values into objects, its use is discouraged for new functionality in favour of <emu-xref aoid="GetOptionsObject" id="_ref_34"><a href="#sec-getoptionsobject">GetOptionsObject</a></emu-xref>.
+        The abstract operation CoerceOptionsToObject coerces <var>options</var> into an Object suitable for use with <emu-xref aoid="GetOption" id="_ref_16"><a href="#sec-getoption">GetOption</a></emu-xref>, defaulting to an empty Object.
+        Because it coerces non-null primitive values into objects, its use is discouraged for new functionality in favour of <emu-xref aoid="GetOptionsObject" id="_ref_17"><a href="#sec-getoptionsobject">GetOptionsObject</a></emu-xref>.
       </p>
-      <emu-alg><ol><li>If <var>options</var> is <emu-val>undefined</emu-val>, then<ol><li>Return OrdinaryObjectCreate(<emu-val>null</emu-val>).</li></ol></li><li>Return ?&nbsp;<emu-xref aoid="ToObject" id="_ref_35"><a href="https://tc39.es/ecma262/#sec-toobject">ToObject</a></emu-xref>(<var>options</var>).</li></ol></emu-alg>
+      <emu-alg><ol><li>If <var>options</var> is <emu-val>undefined</emu-val>, then<ol><li>Return OrdinaryObjectCreate(<emu-val>null</emu-val>).</li></ol></li><li>Return ?&nbsp;ToObject(<var>options</var>).</li></ol></emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-getoption" type="abstract operation">
-      <h1><span class="secnum">1.2.13</span> 
-        GetOption (
-          <var>options</var>: an Object,
-          <var>property</var>: a property key,
-          <var>type</var>: <emu-const>boolean</emu-const>, <emu-const>number</emu-const>, or <emu-const>string</emu-const>,
-          <var>values</var>: <emu-const>empty</emu-const> or a List of ECMAScript language values,
-          <var>default</var>: <emu-const>required</emu-const> or an ECMAScript language value,
-        )
-      </h1>
-      <dl class="header">
-        <dt>description</dt>
-        <dd>It extracts the value of the specified property of <var>options</var>, converts it to the required <var>type</var>, checks whether it is allowed by <var>values</var> if <var>values</var> is not <emu-const>empty</emu-const>, and substitutes <var>default</var> if the value is <emu-val>undefined</emu-val>.</dd>
-      </dl>
-      <emu-alg><ol><li>Let <var>value</var> be ?&nbsp;<emu-xref aoid="Get" id="_ref_36"><a href="https://tc39.es/ecma262/#sec-get-o-p">Get</a></emu-xref>(<var>options</var>, <var>property</var>).</li><li>If <var>value</var> is <emu-val>undefined</emu-val>, then<ol><li>If <var>default</var> is <emu-const>required</emu-const>, throw a <emu-val>RangeError</emu-val> exception.</li><li>Return <var>default</var>.</li></ol></li><li>If <var>type</var> is <emu-const>boolean</emu-const>, then<ol><li>Set <var>value</var> to <emu-xref aoid="ToBoolean" id="_ref_37"><a href="https://tc39.es/ecma262/#sec-toboolean">ToBoolean</a></emu-xref>(<var>value</var>).</li></ol></li><li>Else if <var>type</var> is <emu-const>number</emu-const>, then<ol><li>Set <var>value</var> to ?&nbsp;<emu-xref aoid="ToNumber" id="_ref_38"><a href="https://tc39.es/ecma262/#sec-tonumber">ToNumber</a></emu-xref>(<var>value</var>).</li><li>If <var>value</var> is <emu-val>NaN</emu-val>, throw a <emu-val>RangeError</emu-val> exception.</li></ol></li><li>Else,<ol><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>type</var> is <emu-const>string</emu-const>.</li><li>Set <var>value</var> to ?&nbsp;<emu-xref aoid="ToString" id="_ref_39"><a href="https://tc39.es/ecma262/#sec-tostring">ToString</a></emu-xref>(<var>value</var>).</li></ol></li><li>If <var>values</var> is not <emu-const>empty</emu-const> and <var>values</var> does not contain an element equal to <var>value</var>, throw a <emu-val>RangeError</emu-val> exception.</li><li>Return <var>value</var>.</li></ol></emu-alg>
+    <emu-clause id="sec-getoption" type="abstract operation" aoid="GetOption">
+      <h1><span class="secnum">1.2.13</span> GetOption ( <var>options</var>, <var>property</var>, <var>type</var>, <var>values</var>, <var>default</var> )</h1>
+      <p>The abstract operation GetOption takes arguments <var>options</var> (an Object), <var>property</var> (a property key), <var>type</var> (<emu-const>boolean</emu-const>, <emu-const>number</emu-const>, or <emu-const>string</emu-const>), <var>values</var> (<emu-const>empty</emu-const> or a List of ECMAScript language values), and <var>default</var> (<emu-const>required</emu-const> or an ECMAScript language value). It extracts the value of the specified property of <var>options</var>, converts it to the required <var>type</var>, checks whether it is allowed by <var>values</var> if <var>values</var> is not <emu-const>empty</emu-const>, and substitutes <var>default</var> if the value is <emu-val>undefined</emu-val>. It performs the following steps when called:</p>
+      <emu-alg><ol><li>Let <var>value</var> be ?&nbsp;Get(<var>options</var>, <var>property</var>).</li><li>If <var>value</var> is <emu-val>undefined</emu-val>, then<ol><li>If <var>default</var> is <emu-const>required</emu-const>, throw a <emu-val>RangeError</emu-val> exception.</li><li>Return <var>default</var>.</li></ol></li><li>If <var>type</var> is <emu-const>boolean</emu-const>, then<ol><li>Set <var>value</var> to ToBoolean(<var>value</var>).</li></ol></li><li>Else if <var>type</var> is <emu-const>number</emu-const>, then<ol><li>Set <var>value</var> to ?&nbsp;ToNumber(<var>value</var>).</li><li>If <var>value</var> is <emu-val>NaN</emu-val>, throw a <emu-val>RangeError</emu-val> exception.</li></ol></li><li>Else,<ol><li>Assert: <var>type</var> is <emu-const>string</emu-const>.</li><li>Set <var>value</var> to ?&nbsp;ToString(<var>value</var>).</li></ol></li><li>If <var>values</var> is not <emu-const>empty</emu-const> and <var>values</var> does not contain <del>an element equal to</del> <var>value</var>, throw a <emu-val>RangeError</emu-val> exception.</li><li>Return <var>value</var>.</li></ol></emu-alg>
     </emu-clause>
 
     <ins class="block">
-    <emu-clause id="sec-getstringorbooleanoption" aoid="GetStringOrBooleanOption">
-      <h1><span class="secnum">1.2.14</span> GetStringOrBooleanOption ( <var>options</var>, <var>property</var>, <var>values</var>, <var>trueValue</var>, <var>falsyValue</var>, <var>fallback</var> )</h1>
-
-      <p>
-        The abstract operation GetStringOrBooleanOption extracts the value of the property named <var>property</var> from the provided <var>options</var> object. It returns either <var>trueValue</var>, <var>falsyValue</var>, <var>fallback</var>, or one of the elements of the <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> <var>values</var>. The following steps are taken:
-      </p>
-
-     <emu-alg><ol><li>Let <var>value</var> be ?&nbsp;<emu-xref aoid="Get" id="_ref_40"><a href="https://tc39.es/ecma262/#sec-get-o-p">Get</a></emu-xref>(<var>options</var>, <var>property</var>).</li><li>If <var>value</var> is <emu-val>undefined</emu-val>, return <var>fallback</var>.</li><li>If <var>value</var> is <emu-val>true</emu-val>, return <var>trueValue</var>.</li><li>Let <var>valueBoolean</var> be <emu-xref aoid="ToBoolean" id="_ref_41"><a href="https://tc39.es/ecma262/#sec-toboolean">ToBoolean</a></emu-xref>(<var>value</var>).</li><li>If <var>valueBoolean</var> is <emu-val>false</emu-val>, return <var>falsyValue</var>.</li><li>Let <var>value</var> be ?&nbsp;<emu-xref aoid="ToString" id="_ref_42"><a href="https://tc39.es/ecma262/#sec-tostring">ToString</a></emu-xref>(<var>value</var>).</li><li>NOTE: For historical reasons, the strings <emu-val>"true"</emu-val> and <emu-val>"false"</emu-val> are treated the same as the <var>fallback</var> value.</li><li>If <var>value</var> is <emu-val>"true"</emu-val> or <emu-val>"false"</emu-val>, return <var>fallback</var>.</li><li>If <var>values</var> does not contain an element equal to <var>value</var>, throw a <emu-val>RangeError</emu-val> exception.</li><li>Return <var>value</var>.</li></ol></emu-alg>
+    <emu-clause id="sec-getbooleanorstringnumberformatoption" type="abstract operation" aoid="GetBooleanOrStringNumberFormatOption">
+      <h1><span class="secnum">1.2.14</span> GetBooleanOrStringNumberFormatOption ( <var>options</var>, <var>property</var>, <var>stringValues</var>, <var>fallback</var> )</h1>
+      <p>The abstract operation GetBooleanOrStringNumberFormatOption takes arguments <var>options</var> (an Object), <var>property</var> (a property key), <var>stringValues</var> (a List of Strings), and <var>fallback</var> (an ECMAScript language value) and returns either a normal completion containing either a Boolean, String, or <var>fallback</var>, or a throw completion. It extracts the value of the property named <var>property</var> from the provided <var>options</var> object. It returns <var>fallback</var> if that value is <emu-val>undefined</emu-val>, <emu-val>true</emu-val> if that value is <emu-val>true</emu-val>, <emu-val>false</emu-val> if that value coerces to <emu-val>false</emu-val>, and otherwise coerces it to a String and returns the result if it is allowed by <var>stringValues</var>. It performs the following steps when called:</p>
+      <emu-alg><ol><li>Let <var>value</var> be ?&nbsp;Get(<var>options</var>, <var>property</var>).</li><li>If <var>value</var> is <emu-val>undefined</emu-val>, return <var>fallback</var>.</li><li>If <var>value</var> is <emu-val>true</emu-val>, return <emu-val>true</emu-val>.</li><li>If ToBoolean(<var>value</var>) is <emu-val>false</emu-val>, return <emu-val>false</emu-val>.</li><li>Let <var>value</var> be ?&nbsp;ToString(<var>value</var>).</li><li>If <var>stringValues</var> does not contain <var>value</var>, throw a <emu-val>RangeError</emu-val> exception.</li><li>Return <var>value</var>.</li></ol></emu-alg>
     </emu-clause>
     </ins>
 
@@ -2059,20 +2802,20 @@ li.menu-search-result-term:before {
       <h1><span class="secnum">1.2.15</span> DefaultNumberOption ( <var>value</var>, <var>minimum</var>, <var>maximum</var>, <var>fallback</var> )</h1>
 
       <p>
-        The abstract operation DefaultNumberOption converts <var>value</var> to a <emu-xref href="#number-value"><a href="https://tc39.es/ecma262/#number-value">Number value</a></emu-xref>, checks whether it is in the allowed range, and fills in a <var>fallback</var> value if necessary.
+        The abstract operation DefaultNumberOption converts <var>value</var> to a Number value, checks whether it is in the allowed range, and fills in a <var>fallback</var> value if necessary.
       </p>
 
-      <emu-alg><ol><li>If <var>value</var> is <emu-val>undefined</emu-val>, return <var>fallback</var>.</li><li>Set <var>value</var> to ?&nbsp;<emu-xref aoid="ToNumber" id="_ref_43"><a href="https://tc39.es/ecma262/#sec-tonumber">ToNumber</a></emu-xref>(<var>value</var>).</li><li>If <var>value</var> is <emu-val>NaN</emu-val> or less than <var>minimum</var> or greater than <var>maximum</var>, throw a <emu-val>RangeError</emu-val> exception.</li><li>Return <emu-xref aoid="floor"><a href="https://tc39.es/ecma262/#eqn-floor">floor</a></emu-xref>(<var>value</var>).</li></ol></emu-alg>
+      <emu-alg><ol><li>If <var>value</var> is <emu-val>undefined</emu-val>, return <var>fallback</var>.</li><li>Set <var>value</var> to ?&nbsp;ToNumber(<var>value</var>).</li><li>If <var>value</var> is <emu-val>NaN</emu-val> or less than <var>minimum</var> or greater than <var>maximum</var>, throw a <emu-val>RangeError</emu-val> exception.</li><li>Return floor(<var>value</var>).</li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-getnumberoption" aoid="GetNumberOption">
       <h1><span class="secnum">1.2.16</span> GetNumberOption ( <var>options</var>, <var>property</var>, <var>minimum</var>, <var>maximum</var>, <var>fallback</var> )</h1>
 
       <p>
-        The abstract operation GetNumberOption extracts the value of the property named <var>property</var> from the provided <var>options</var> object, converts it to a <emu-xref href="#number-value"><a href="https://tc39.es/ecma262/#number-value">Number value</a></emu-xref>, checks whether it is in the allowed range, and fills in a <var>fallback</var> value if necessary.
+        The abstract operation GetNumberOption extracts the value of the property named <var>property</var> from the provided <var>options</var> object, converts it to a Number value, checks whether it is in the allowed range, and fills in a <var>fallback</var> value if necessary.
       </p>
 
-      <emu-alg><ol><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <emu-xref aoid="Type" id="_ref_44"><a href="https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>options</var>) is Object.</li><li>Let <var>value</var> be ?&nbsp;<emu-xref aoid="Get" id="_ref_45"><a href="https://tc39.es/ecma262/#sec-get-o-p">Get</a></emu-xref>(<var>options</var>, <var>property</var>).</li><li>Return ?&nbsp;<emu-xref aoid="DefaultNumberOption" id="_ref_46"><a href="#sec-defaultnumberoption">DefaultNumberOption</a></emu-xref>(<var>value</var>, <var>minimum</var>, <var>maximum</var>, <var>fallback</var>).</li></ol></emu-alg>
+      <emu-alg><ol><li>Assert: Type(<var>options</var>) is Object.</li><li>Let <var>value</var> be ?&nbsp;Get(<var>options</var>, <var>property</var>).</li><li>Return ?&nbsp;<emu-xref aoid="DefaultNumberOption" id="_ref_18"><a href="#sec-defaultnumberoption">DefaultNumberOption</a></emu-xref>(<var>value</var>, <var>minimum</var>, <var>maximum</var>, <var>fallback</var>).</li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-partitionpattern" aoid="PartitionPattern">
@@ -2086,7 +2829,7 @@ li.menu-search-result-term:before {
         The following steps are taken:
       </p>
 
-      <emu-alg><ol><li>Let <var>result</var> be a new empty <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref>.</li><li>Let <var>beginIndex</var> be StringIndexOf(<var>pattern</var>, <emu-val>"{"</emu-val>, 0).</li><li>Let <var>endIndex</var> be 0.</li><li>Let <var>nextIndex</var> be 0.</li><li>Let <var>length</var> be the number of code units in <var>pattern</var>.</li><li>Repeat, while <var>beginIndex</var> is an <emu-xref href="#integer-index"><a href="https://tc39.es/ecma262/#integer-index">integer index</a></emu-xref> into <var>pattern</var>,<ol><li>Set <var>endIndex</var> to StringIndexOf(<var>pattern</var>, <emu-val>"}"</emu-val>, <var>beginIndex</var>).</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>endIndex</var> is greater than <var>beginIndex</var>.</li><li>If <var>beginIndex</var> is greater than <var>nextIndex</var>, then<ol><li>Let <var>literal</var> be a substring of <var>pattern</var> from position <var>nextIndex</var>, inclusive, to position <var>beginIndex</var>, exclusive.</li><li>Append a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]]: <emu-val>"literal"</emu-val>, [[Value]]: <var>literal</var> } as the last element of the list <var>result</var>.</li></ol></li><li>Let <var>p</var> be the substring of <var>pattern</var> from position <var>beginIndex</var>, exclusive, to position <var>endIndex</var>, exclusive.</li><li>Append a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]]: <var>p</var>, [[Value]]: <emu-val>undefined</emu-val> } as the last element of the list <var>result</var>.</li><li>Set <var>nextIndex</var> to <var>endIndex</var> + 1.</li><li>Set <var>beginIndex</var> to StringIndexOf(<var>pattern</var>, <emu-val>"{"</emu-val>, <var>nextIndex</var>).</li></ol></li><li>If <var>nextIndex</var> is less than <var>length</var>, then<ol><li>Let <var>literal</var> be the substring of <var>pattern</var> from position <var>nextIndex</var>, inclusive, to position <var>length</var>, exclusive.</li><li>Append a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]]: <emu-val>"literal"</emu-val>, [[Value]]: <var>literal</var> } as the last element of the list <var>result</var>.</li></ol></li><li>Return <var>result</var>.</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>result</var> be a new empty List.</li><li>Let <var>beginIndex</var> be StringIndexOf(<var>pattern</var>, <emu-val>"{"</emu-val>, 0).</li><li>Let <var>endIndex</var> be 0.</li><li>Let <var>nextIndex</var> be 0.</li><li>Let <var>length</var> be the number of code units in <var>pattern</var>.</li><li>Repeat, while <var>beginIndex</var> is an integer index into <var>pattern</var>,<ol><li>Set <var>endIndex</var> to StringIndexOf(<var>pattern</var>, <emu-val>"}"</emu-val>, <var>beginIndex</var>).</li><li>Assert: <var>endIndex</var> is greater than <var>beginIndex</var>.</li><li>If <var>beginIndex</var> is greater than <var>nextIndex</var>, then<ol><li>Let <var>literal</var> be a substring of <var>pattern</var> from position <var>nextIndex</var>, inclusive, to position <var>beginIndex</var>, exclusive.</li><li>Append a new Record { [[Type]]: <emu-val>"literal"</emu-val>, [[Value]]: <var>literal</var> } as the last element of the list <var>result</var>.</li></ol></li><li>Let <var>p</var> be the substring of <var>pattern</var> from position <var>beginIndex</var>, exclusive, to position <var>endIndex</var>, exclusive.</li><li>Append a new Record { [[Type]]: <var>p</var>, [[Value]]: <emu-val>undefined</emu-val> } as the last element of the list <var>result</var>.</li><li>Set <var>nextIndex</var> to <var>endIndex</var> + 1.</li><li>Set <var>beginIndex</var> to StringIndexOf(<var>pattern</var>, <emu-val>"{"</emu-val>, <var>nextIndex</var>).</li></ol></li><li>If <var>nextIndex</var> is less than <var>length</var>, then<ol><li>Let <var>literal</var> be the substring of <var>pattern</var> from position <var>nextIndex</var>, inclusive, to position <var>length</var>, exclusive.</li><li>Append a new Record { [[Type]]: <emu-val>"literal"</emu-val>, [[Value]]: <var>literal</var> } as the last element of the list <var>result</var>.</li></ol></li><li>Return <var>result</var>.</li></ol></emu-alg>
     </emu-clause>
   </emu-clause>
 </emu-clause></div></body>

--- a/out/negotiation/proposed.html
+++ b/out/negotiation/proposed.html
@@ -1,6 +1,88 @@
 <!doctype html>
-<head><meta charset="utf-8"><script type="application/json" id="menu-search-biblio">[{"type":"clause","id":"sec-internal-slots","aoid":null,"title":"Internal slots of Service Constructors","titleHTML":"Internal slots of Service Constructors","number":"1.1","namespace":"<no location>","location":"","referencingIds":["_ref_1"],"key":"Internal slots of Service Constructors"},{"type":"op","aoid":"CanonicalizeLocaleList","refId":"sec-canonicalizelocalelist","location":"","referencingIds":[],"key":"CanonicalizeLocaleList"},{"type":"clause","id":"sec-canonicalizelocalelist","aoid":"CanonicalizeLocaleList","title":"CanonicalizeLocaleList ( locales )","titleHTML":"CanonicalizeLocaleList ( <var>locales</var> )","number":"1.2.1","namespace":"<no location>","location":"","referencingIds":["_ref_14","_ref_16"],"key":"CanonicalizeLocaleList ( locales )"},{"type":"op","aoid":"BestAvailableLocale","refId":"sec-bestavailablelocale","location":"","referencingIds":[],"key":"BestAvailableLocale"},{"type":"clause","id":"sec-bestavailablelocale","aoid":"BestAvailableLocale","title":"BestAvailableLocale ( availableLocales, locale )","titleHTML":"BestAvailableLocale ( <var>availableLocales</var>, <var>locale</var> )","number":"1.2.2","namespace":"<no location>","location":"","referencingIds":["_ref_15","_ref_28"],"key":"BestAvailableLocale ( availableLocales, locale )"},{"type":"op","aoid":"LookupMatcher","refId":"sec-lookupmatcher","location":"","referencingIds":[],"key":"LookupMatcher"},{"type":"clause","id":"sec-lookupmatcher","aoid":"LookupMatcher","title":"LookupMatcher ( availableLocales, requestedLocales )","titleHTML":"LookupMatcher ( <var>availableLocales</var>, <var>requestedLocales</var> )","number":"1.2.3","namespace":"<no location>","location":"","referencingIds":["_ref_17","_ref_18"],"key":"LookupMatcher ( availableLocales, requestedLocales )"},{"type":"op","aoid":"BestFitMatcher","refId":"sec-bestfitmatcher","location":"","referencingIds":[],"key":"BestFitMatcher"},{"type":"clause","id":"sec-bestfitmatcher","aoid":"BestFitMatcher","title":"BestFitMatcher ( availableLocales, requestedLocales )","titleHTML":"BestFitMatcher ( <var>availableLocales</var>, <var>requestedLocales</var> )","number":"1.2.4","namespace":"<no location>","location":"","referencingIds":["_ref_19"],"key":"BestFitMatcher ( availableLocales, requestedLocales )"},{"type":"op","aoid":"UnicodeExtensionComponents","refId":"sec-unicode-extension-components","location":"","referencingIds":[],"key":"UnicodeExtensionComponents"},{"type":"clause","id":"sec-unicode-extension-components","aoid":"UnicodeExtensionComponents","title":"UnicodeExtensionComponents ( extension )","titleHTML":"UnicodeExtensionComponents ( <var>extension</var> )","number":"1.2.5","namespace":"<no location>","location":"","referencingIds":["_ref_20"],"key":"UnicodeExtensionComponents ( extension )"},{"type":"op","aoid":"InsertUnicodeExtensionAndCanonicalize","refId":"sec-insert-unicode-extension-and-canonicalize","location":"","referencingIds":[],"key":"InsertUnicodeExtensionAndCanonicalize"},{"type":"clause","id":"sec-insert-unicode-extension-and-canonicalize","aoid":"InsertUnicodeExtensionAndCanonicalize","title":"InsertUnicodeExtensionAndCanonicalize ( locale, extension )","titleHTML":"InsertUnicodeExtensionAndCanonicalize ( <var>locale</var>, <var>extension</var> )","number":"1.2.6","namespace":"<no location>","location":"","referencingIds":["_ref_27"],"key":"InsertUnicodeExtensionAndCanonicalize ( locale, extension )"},{"type":"op","aoid":"ResolveLocale","refId":"sec-resolvelocale","location":"","referencingIds":[],"key":"ResolveLocale"},{"type":"clause","id":"sec-resolvelocale","aoid":"ResolveLocale","title":"ResolveLocale ( availableLocales, requestedLocales, options, relevantExtensionKeys, localeData )","titleHTML":"ResolveLocale ( <var>availableLocales</var>, <var>requestedLocales</var>, <var>options</var>, <var>relevantExtensionKeys</var>, <var>localeData</var> )","number":"1.2.7","namespace":"<no location>","location":"","referencingIds":["_ref_0"],"key":"ResolveLocale ( availableLocales, requestedLocales, options, relevantExtensionKeys, localeData )"},{"type":"op","aoid":"LookupSupportedLocales","refId":"sec-lookupsupportedlocales","location":"","referencingIds":[],"key":"LookupSupportedLocales"},{"type":"clause","id":"sec-lookupsupportedlocales","aoid":"LookupSupportedLocales","title":"LookupSupportedLocales ( availableLocales, requestedLocales )","titleHTML":"LookupSupportedLocales ( <var>availableLocales</var>, <var>requestedLocales</var> )","number":"1.2.8","namespace":"<no location>","location":"","referencingIds":["_ref_31"],"key":"LookupSupportedLocales ( availableLocales, requestedLocales )"},{"type":"op","aoid":"BestFitSupportedLocales","refId":"sec-bestfitsupportedlocales","location":"","referencingIds":[],"key":"BestFitSupportedLocales"},{"type":"clause","id":"sec-bestfitsupportedlocales","aoid":"BestFitSupportedLocales","title":"BestFitSupportedLocales ( availableLocales, requestedLocales )","titleHTML":"BestFitSupportedLocales ( <var>availableLocales</var>, <var>requestedLocales</var> )","number":"1.2.9","namespace":"<no location>","location":"","referencingIds":["_ref_30"],"key":"BestFitSupportedLocales ( availableLocales, requestedLocales )"},{"type":"op","aoid":"SupportedLocales","refId":"sec-supportedlocales","location":"","referencingIds":[],"key":"SupportedLocales"},{"type":"clause","id":"sec-supportedlocales","aoid":"SupportedLocales","title":"SupportedLocales ( availableLocales, requestedLocales, options )","titleHTML":"SupportedLocales ( <var>availableLocales</var>, <var>requestedLocales</var>, <var>options</var> )","number":"1.2.10","namespace":"<no location>","location":"","referencingIds":[],"key":"SupportedLocales ( availableLocales, requestedLocales, options )"},{"type":"op","aoid":"GetOptionsObject","refId":"sec-getoptionsobject","location":"","referencingIds":[],"key":"GetOptionsObject"},{"type":"clause","id":"sec-getoptionsobject","aoid":"GetOptionsObject","title":"GetOptionsObject ( options )","titleHTML":"GetOptionsObject ( <var>options</var> )","number":"1.2.11","namespace":"<no location>","location":"","referencingIds":["_ref_34"],"key":"GetOptionsObject ( options )"},{"type":"op","aoid":"CoerceOptionsToObject","refId":"sec-coerceoptionstoobject","location":"","referencingIds":[],"key":"CoerceOptionsToObject"},{"type":"clause","id":"sec-coerceoptionstoobject","aoid":"CoerceOptionsToObject","title":"CoerceOptionsToObject ( options )","titleHTML":"CoerceOptionsToObject ( <var>options</var> )","number":"1.2.12","namespace":"<no location>","location":"","referencingIds":["_ref_29"],"key":"CoerceOptionsToObject ( options )"},{"type":"clause","id":"sec-getoption","aoid":null,"title":"\n        GetOption (\n          options: an Object,\n          property: a property key,\n          type: boolean, number, or string,\n          values: empty or a List of ECMAScript language values,\n          default: required or an ECMAScript language value,\n        )\n      ","titleHTML":"\n        GetOption (\n          <var>options</var>: an Object,\n          <var>property</var>: a property key,\n          <var>type</var>: <emu-const>boolean</emu-const>, <emu-const>number</emu-const>, or <emu-const>string</emu-const>,\n          <var>values</var>: <emu-const>empty</emu-const> or a List of ECMAScript language values,\n          <var>default</var>: <emu-const>required</emu-const> or an ECMAScript language value,\n        )\n      ","number":"1.2.13","namespace":"<no location>","location":"","referencingIds":[],"key":"\n        GetOption (\n          options: an Object,\n          property: a property key,\n          type: boolean, number, or string,\n          values: empty or a List of ECMAScript language values,\n          default: required or an ECMAScript language value,\n        )\n      "},{"type":"op","aoid":"GetStringOrBooleanOption","refId":"sec-getstringorbooleanoption","location":"","referencingIds":[],"key":"GetStringOrBooleanOption"},{"type":"clause","id":"sec-getstringorbooleanoption","aoid":"GetStringOrBooleanOption","title":"GetStringOrBooleanOption ( options, property, values, trueValue, falsyValue, fallback )","titleHTML":"GetStringOrBooleanOption ( <var>options</var>, <var>property</var>, <var>values</var>, <var>trueValue</var>, <var>falsyValue</var>, <var>fallback</var> )","number":"1.2.14","namespace":"<no location>","location":"","referencingIds":[],"key":"GetStringOrBooleanOption ( options, property, values, trueValue, falsyValue, fallback )"},{"type":"op","aoid":"DefaultNumberOption","refId":"sec-defaultnumberoption","location":"","referencingIds":[],"key":"DefaultNumberOption"},{"type":"clause","id":"sec-defaultnumberoption","aoid":"DefaultNumberOption","title":"DefaultNumberOption ( value, minimum, maximum, fallback )","titleHTML":"DefaultNumberOption ( <var>value</var>, <var>minimum</var>, <var>maximum</var>, <var>fallback</var> )","number":"1.2.15","namespace":"<no location>","location":"","referencingIds":["_ref_46"],"key":"DefaultNumberOption ( value, minimum, maximum, fallback )"},{"type":"op","aoid":"GetNumberOption","refId":"sec-getnumberoption","location":"","referencingIds":[],"key":"GetNumberOption"},{"type":"clause","id":"sec-getnumberoption","aoid":"GetNumberOption","title":"GetNumberOption ( options, property, minimum, maximum, fallback )","titleHTML":"GetNumberOption ( <var>options</var>, <var>property</var>, <var>minimum</var>, <var>maximum</var>, <var>fallback</var> )","number":"1.2.16","namespace":"<no location>","location":"","referencingIds":[],"key":"GetNumberOption ( options, property, minimum, maximum, fallback )"},{"type":"op","aoid":"PartitionPattern","refId":"sec-partitionpattern","location":"","referencingIds":[],"key":"PartitionPattern"},{"type":"clause","id":"sec-partitionpattern","aoid":"PartitionPattern","title":"PartitionPattern ( pattern )","titleHTML":"PartitionPattern ( <var>pattern</var> )","number":"1.2.17","namespace":"<no location>","location":"","referencingIds":[],"key":"PartitionPattern ( pattern )"},{"type":"clause","id":"sec-abstract-operations","aoid":null,"title":"Abstract Operations","titleHTML":"Abstract Operations","number":"1.2","namespace":"<no location>","location":"","referencingIds":[],"key":"Abstract Operations"},{"type":"clause","id":"locale-and-parameter-negotiation","aoid":null,"title":"Locale and Parameter Negotiation","titleHTML":"Locale and Parameter Negotiation","number":"1","namespace":"<no location>","location":"","referencingIds":[],"key":"Locale and Parameter Negotiation"}]</script><script>"use strict";
+<head><meta charset="utf-8"><script>'use strict';
+let sdoBox = {
+  init() {
+    this.$alternativeId = null;
+    this.$outer = document.createElement('div');
+    this.$outer.classList.add('toolbox-container');
+    this.$container = document.createElement('div');
+    this.$container.classList.add('toolbox');
+    this.$displayLink = document.createElement('a');
+    this.$displayLink.setAttribute('href', '#');
+    this.$displayLink.textContent = 'Syntax-Directed Operations';
+    this.$displayLink.addEventListener('click', e => {
+      e.preventDefault();
+      e.stopPropagation();
+      referencePane.showSDOs(sdoMap[this.$alternativeId] || {}, this.$alternativeId);
+    });
+    this.$container.appendChild(this.$displayLink);
+    this.$outer.appendChild(this.$container);
+    document.body.appendChild(this.$outer);
+  },
 
+  activate(el) {
+    clearTimeout(this.deactiveTimeout);
+    Toolbox.deactivate();
+    this.$alternativeId = el.id;
+    let numSdos = Object.keys(sdoMap[this.$alternativeId] || {}).length;
+    this.$displayLink.textContent = 'Syntax-Directed Operations (' + numSdos + ')';
+    this.$outer.classList.add('active');
+    let top = el.offsetTop - this.$outer.offsetHeight;
+    let left = el.offsetLeft + 50 - 10; // 50px = padding-left(=75px) + text-indent(=-25px)
+    this.$outer.setAttribute('style', 'left: ' + left + 'px; top: ' + top + 'px');
+    if (top < document.body.scrollTop) {
+      this.$container.scrollIntoView();
+    }
+  },
+
+  deactivate() {
+    clearTimeout(this.deactiveTimeout);
+    this.$outer.classList.remove('active');
+  },
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+  if (typeof sdoMap == 'undefined') {
+    console.error('could not find sdo map');
+    return;
+  }
+  sdoBox.init();
+
+  let insideTooltip = false;
+  sdoBox.$outer.addEventListener('pointerenter', () => {
+    insideTooltip = true;
+  });
+  sdoBox.$outer.addEventListener('pointerleave', () => {
+    insideTooltip = false;
+    sdoBox.deactivate();
+  });
+
+  sdoBox.deactiveTimeout = null;
+  [].forEach.call(document.querySelectorAll('emu-grammar[type=definition] emu-rhs'), node => {
+    node.addEventListener('pointerenter', function () {
+      sdoBox.activate(this);
+    });
+
+    node.addEventListener('pointerleave', () => {
+      sdoBox.deactiveTimeout = setTimeout(() => {
+        if (!insideTooltip) {
+          sdoBox.deactivate();
+        }
+      }, 500);
+    });
+  });
+
+  document.addEventListener(
+    'keydown',
+    debounce(e => {
+      if (e.code === 'Escape') {
+        sdoBox.deactivate();
+      }
+    })
+  );
+});
+
+'use strict';
 function Search(menu) {
   this.menu = menu;
   this.$search = document.getElementById('menu-search');
@@ -11,8 +93,14 @@ function Search(menu) {
 
   document.addEventListener('keydown', this.documentKeydown.bind(this));
 
-  this.$searchBox.addEventListener('keydown', debounce(this.searchBoxKeydown.bind(this), { stopPropagation: true }));
-  this.$searchBox.addEventListener('keyup', debounce(this.searchBoxKeyup.bind(this), { stopPropagation: true }));
+  this.$searchBox.addEventListener(
+    'keydown',
+    debounce(this.searchBoxKeydown.bind(this), { stopPropagation: true })
+  );
+  this.$searchBox.addEventListener(
+    'keyup',
+    debounce(this.searchBoxKeyup.bind(this), { stopPropagation: true })
+  );
 
   // Perform an initial search if the box is not empty.
   if (this.$searchBox.value) {
@@ -21,26 +109,34 @@ function Search(menu) {
 }
 
 Search.prototype.loadBiblio = function () {
-  var $biblio = document.getElementById('menu-search-biblio');
-  if (!$biblio) {
-    this.biblio = [];
+  if (typeof biblio === 'undefined') {
+    console.error('could not find biblio');
+    this.biblio = { refToClause: {}, entries: [] };
   } else {
-    this.biblio = JSON.parse($biblio.textContent);
-    this.biblio.clauses = this.biblio.filter(function (e) { return e.type === 'clause' });
-    this.biblio.byId = this.biblio.reduce(function (map, entry) {
+    this.biblio = biblio;
+    this.biblio.clauses = this.biblio.entries.filter(e => e.type === 'clause');
+    this.biblio.byId = this.biblio.entries.reduce((map, entry) => {
       map[entry.id] = entry;
       return map;
     }, {});
+    let refParentClause = Object.create(null);
+    this.biblio.refParentClause = refParentClause;
+    let refsByClause = this.biblio.refsByClause;
+    Object.keys(refsByClause).forEach(clause => {
+      refsByClause[clause].forEach(ref => {
+        refParentClause[ref] = clause;
+      });
+    });
   }
-}
+};
 
 Search.prototype.documentKeydown = function (e) {
-  if (e.keyCode === 191) {
+  if (e.key === '/') {
     e.preventDefault();
     e.stopPropagation();
     this.triggerSearch();
   }
-}
+};
 
 Search.prototype.searchBoxKeydown = function (e) {
   e.stopPropagation();
@@ -51,7 +147,7 @@ Search.prototype.searchBoxKeydown = function (e) {
     e.preventDefault();
     this.selectResult();
   }
-}
+};
 
 Search.prototype.searchBoxKeyup = function (e) {
   if (e.keyCode === 13 || e.keyCode === 9) {
@@ -59,10 +155,9 @@ Search.prototype.searchBoxKeyup = function (e) {
   }
 
   this.search(e.target.value);
-}
+};
 
-
-Search.prototype.triggerSearch = function (e) {
+Search.prototype.triggerSearch = function () {
   if (this.menu.isVisible()) {
     this._closeAfterSearch = false;
   } else {
@@ -72,14 +167,14 @@ Search.prototype.triggerSearch = function (e) {
 
   this.$searchBox.focus();
   this.$searchBox.select();
-}
+};
 // bit 12 - Set if the result starts with searchString
 // bits 8-11: 8 - number of chunks multiplied by 2 if cases match, otherwise 1.
 // bits 1-7: 127 - length of the entry
 // General scheme: prefer case sensitive matches with fewer chunks, and otherwise
 // prefer shorter matches.
-function relevance(result, searchString) {
-  var relevance = 0;
+function relevance(result) {
+  let relevance = 0;
 
   relevance = Math.max(0, 8 - result.match.chunks) << 7;
 
@@ -88,10 +183,10 @@ function relevance(result, searchString) {
   }
 
   if (result.match.prefix) {
-    relevance += 2048
+    relevance += 2048;
   }
 
-  relevance += Math.max(0, 255 - result.entry.key.length);
+  relevance += Math.max(0, 255 - result.key.length);
 
   return relevance;
 }
@@ -110,36 +205,34 @@ Search.prototype.search = function (searchString) {
     return;
   }
 
-  var results;
+  let results;
 
-  if (/^[\d\.]*$/.test(searchString)) {
-    results = this.biblio.clauses.filter(function (clause) {
-      return clause.number.substring(0, searchString.length) === searchString;
-    }).map(function (clause) {
-      return { entry: clause };
-    });
+  if (/^[\d.]*$/.test(searchString)) {
+    results = this.biblio.clauses
+      .filter(clause => clause.number.substring(0, searchString.length) === searchString)
+      .map(clause => ({ key: getKey(clause), entry: clause }));
   } else {
     results = [];
 
-    for (var i = 0; i < this.biblio.length; i++) {
-      var entry = this.biblio[i];
-      if (!entry.key) {
+    for (let i = 0; i < this.biblio.entries.length; i++) {
+      let entry = this.biblio.entries[i];
+      let key = getKey(entry);
+      if (!key) {
         // biblio entries without a key aren't searchable
         continue;
       }
 
-      var match = fuzzysearch(searchString, entry.key);
+      let match = fuzzysearch(searchString, key);
       if (match) {
-        results.push({ entry: entry, match: match });
+        results.push({ key, entry, match });
       }
     }
 
-    results.forEach(function (result) {
+    results.forEach(result => {
       result.relevance = relevance(result, searchString);
     });
 
-    results = results.sort(function (a, b) { return b.relevance - a.relevance });
-
+    results = results.sort((a, b) => b.relevance - a.relevance);
   }
 
   if (results.length > 50) {
@@ -147,17 +240,17 @@ Search.prototype.search = function (searchString) {
   }
 
   this.displayResults(results);
-}
+};
 Search.prototype.hideSearch = function () {
   this.$search.classList.remove('active');
-}
+};
 
 Search.prototype.showSearch = function () {
   this.$search.classList.add('active');
-}
+};
 
 Search.prototype.selectResult = function () {
-  var $first = this.$searchResults.querySelector('li:first-child a');
+  let $first = this.$searchResults.querySelector('li:first-child a');
 
   if ($first) {
     document.location = $first.getAttribute('href');
@@ -171,53 +264,79 @@ Search.prototype.selectResult = function () {
   if (this._closeAfterSearch) {
     this.menu.hide();
   }
-}
+};
 
 Search.prototype.displayResults = function (results) {
   if (results.length > 0) {
     this.$searchResults.classList.remove('no-results');
 
-    var html = '<ul>';
+    let html = '<ul>';
 
-    results.forEach(function (result) {
-      var entry = result.entry;
-      var id = entry.id;
-      var cssClass = '';
-      var text = '';
+    results.forEach(result => {
+      let key = result.key;
+      let entry = result.entry;
+      let id = entry.id;
+      let cssClass = '';
+      let text = '';
 
       if (entry.type === 'clause') {
-        var number = entry.number ? entry.number + ' ' : '';
-        text = number + entry.key;
+        let number = entry.number ? entry.number + ' ' : '';
+        text = number + key;
         cssClass = 'clause';
         id = entry.id;
       } else if (entry.type === 'production') {
-        text = entry.key;
+        text = key;
         cssClass = 'prod';
         id = entry.id;
       } else if (entry.type === 'op') {
-        text = entry.key;
+        text = key;
         cssClass = 'op';
         id = entry.id || entry.refId;
       } else if (entry.type === 'term') {
-        text = entry.key;
+        text = key;
         cssClass = 'term';
         id = entry.id || entry.refId;
       }
 
       if (text) {
-        html += '<li class=menu-search-result-' + cssClass + '><a href="#' + id + '">' + text + '</a></li>';
+        // prettier-ignore
+        html += `<li class=menu-search-result-${cssClass}><a href="${makeLinkToId(id)}">${text}</a></li>`;
       }
     });
 
-    html += '</ul>'
+    html += '</ul>';
 
     this.$searchResults.innerHTML = html;
   } else {
     this.$searchResults.innerHTML = '';
     this.$searchResults.classList.add('no-results');
   }
-}
+};
 
+function getKey(item) {
+  if (item.key) {
+    return item.key;
+  }
+  switch (item.type) {
+    case 'clause':
+      return item.title || item.titleHTML;
+    case 'production':
+      return item.name;
+    case 'op':
+      return item.aoid;
+    case 'term':
+      return item.term;
+    case 'table':
+    case 'figure':
+    case 'example':
+    case 'note':
+      return item.caption;
+    case 'step':
+      return item.id;
+    default:
+      throw new Error("Can't get key for " + item.type);
+  }
+}
 
 function Menu() {
   this.$toggle = document.getElementById('menu-toggle');
@@ -229,7 +348,7 @@ function Menu() {
   this.$specContainer = document.getElementById('spec-container');
   this.search = new Search(this);
 
-  this._pinnedIds = {}; 
+  this._pinnedIds = {};
   this.loadPinEntries();
 
   // toggle menu
@@ -239,23 +358,23 @@ function Menu() {
   document.addEventListener('keydown', this.documentKeydown.bind(this));
 
   // toc expansion
-  var tocItems = this.$menu.querySelectorAll('#menu-toc li');
-  for (var i = 0; i < tocItems.length; i++) {
-    var $item = tocItems[i];
-    $item.addEventListener('click', function($item, event) {
+  let tocItems = this.$menu.querySelectorAll('#menu-toc li');
+  for (let i = 0; i < tocItems.length; i++) {
+    let $item = tocItems[i];
+    $item.addEventListener('click', event => {
       $item.classList.toggle('active');
       event.stopPropagation();
-    }.bind(null, $item));
+    });
   }
 
   // close toc on toc item selection
-  var tocLinks = this.$menu.querySelectorAll('#menu-toc li > a');
-  for (var i = 0; i < tocLinks.length; i++) {
-    var $link = tocLinks[i];
-    $link.addEventListener('click', function(event) {
+  let tocLinks = this.$menu.querySelectorAll('#menu-toc li > a');
+  for (let i = 0; i < tocLinks.length; i++) {
+    let $link = tocLinks[i];
+    $link.addEventListener('click', event => {
       this.toggle();
       event.stopPropagation();
-    }.bind(this));
+    });
   }
 
   // update active clause on scroll
@@ -263,14 +382,13 @@ function Menu() {
   this.updateActiveClause();
 
   // prevent menu scrolling from scrolling the body
-  this.$toc.addEventListener('wheel', function (e) {
-    var target = e.currentTarget;
-    var offTop = e.deltaY < 0 && target.scrollTop === 0;
+  this.$toc.addEventListener('wheel', e => {
+    let target = e.currentTarget;
+    let offTop = e.deltaY < 0 && target.scrollTop === 0;
     if (offTop) {
       e.preventDefault();
     }
-    var offBottom = e.deltaY > 0
-                    && target.offsetHeight + target.scrollTop >= target.scrollHeight;
+    let offBottom = e.deltaY > 0 && target.offsetHeight + target.scrollTop >= target.scrollHeight;
 
     if (offBottom) {
       e.preventDefault();
@@ -285,62 +403,66 @@ Menu.prototype.documentKeydown = function (e) {
   } else if (e.keyCode > 48 && e.keyCode < 58) {
     this.selectPin(e.keyCode - 49);
   }
-}
+};
 
 Menu.prototype.updateActiveClause = function () {
-  this.setActiveClause(findActiveClause(this.$specContainer))
-}
+  this.setActiveClause(findActiveClause(this.$specContainer));
+};
 
 Menu.prototype.setActiveClause = function (clause) {
   this.$activeClause = clause;
   this.revealInToc(this.$activeClause);
-}
+};
 
 Menu.prototype.revealInToc = function (path) {
-  var current = this.$toc.querySelectorAll('li.revealed');
-  for (var i = 0; i < current.length; i++) {
+  let current = this.$toc.querySelectorAll('li.revealed');
+  for (let i = 0; i < current.length; i++) {
     current[i].classList.remove('revealed');
     current[i].classList.remove('revealed-leaf');
   }
 
-  var current = this.$toc;
-  var index = 0;
-  while (index < path.length) {
-    var children = current.children;
-    for (var i = 0; i < children.length; i++) {
-      if ('#' + path[index].id === children[i].children[1].getAttribute('href') ) {
+  current = this.$toc;
+  let index = 0;
+  outer: while (index < path.length) {
+    let children = current.children;
+    for (let i = 0; i < children.length; i++) {
+      if ('#' + path[index].id === children[i].children[1].hash) {
         children[i].classList.add('revealed');
         if (index === path.length - 1) {
           children[i].classList.add('revealed-leaf');
-          var rect = children[i].getBoundingClientRect();
+          let rect = children[i].getBoundingClientRect();
           // this.$toc.getBoundingClientRect().top;
-          var tocRect = this.$toc.getBoundingClientRect();
+          let tocRect = this.$toc.getBoundingClientRect();
           if (rect.top + 10 > tocRect.bottom) {
-            this.$toc.scrollTop = this.$toc.scrollTop + (rect.top - tocRect.bottom) + (rect.bottom - rect.top);
+            this.$toc.scrollTop =
+              this.$toc.scrollTop + (rect.top - tocRect.bottom) + (rect.bottom - rect.top);
           } else if (rect.top < tocRect.top) {
             this.$toc.scrollTop = this.$toc.scrollTop - (tocRect.top - rect.top);
           }
         }
         current = children[i].querySelector('ol');
         index++;
-        break;
+        continue outer;
       }
     }
-
+    console.log('could not find location in table of contents', path);
+    break;
   }
-}
+};
 
 function findActiveClause(root, path) {
-  var clauses = new ClauseWalker(root);
-  var $clause;
-  var path = path || [];
+  let clauses = getChildClauses(root);
+  path = path || [];
 
-  while ($clause = clauses.nextNode()) {
-    var rect = $clause.getBoundingClientRect();
-    var $header = $clause.querySelector("h1");
-    var marginTop = parseInt(getComputedStyle($header)["margin-top"]);
+  for (let $clause of clauses) {
+    let rect = $clause.getBoundingClientRect();
+    let $header = $clause.querySelector('h1');
+    let marginTop = Math.max(
+      parseInt(getComputedStyle($clause)['margin-top']),
+      parseInt(getComputedStyle($header)['margin-top'])
+    );
 
-    if ((rect.top - marginTop) <= 0 && rect.bottom > 0) {
+    if (rect.top - marginTop <= 1 && rect.bottom > 0) {
       return findActiveClause($clause, path.concat($clause)) || path;
     }
   }
@@ -348,57 +470,49 @@ function findActiveClause(root, path) {
   return path;
 }
 
-function ClauseWalker(root) {
-  var previous;
-  var treeWalker = document.createTreeWalker(
-    root,
-    NodeFilter.SHOW_ELEMENT,
-    {
-      acceptNode: function (node) {
-        if (previous === node.parentNode) {
-          return NodeFilter.FILTER_REJECT;
-        } else {
-          previous = node;
-        }
-        if (node.nodeName === 'EMU-CLAUSE' || node.nodeName === 'EMU-INTRO' || node.nodeName === 'EMU-ANNEX') {
-          return NodeFilter.FILTER_ACCEPT;
-        } else {
-          return NodeFilter.FILTER_SKIP;
-        }
-      }
-    },
-    false
-    );
+function* getChildClauses(root) {
+  for (let el of root.children) {
+    switch (el.nodeName) {
+      // descend into <emu-import>
+      case 'EMU-IMPORT':
+        yield* getChildClauses(el);
+        break;
 
-  return treeWalker;
+      // accept <emu-clause>, <emu-intro>, and <emu-annex>
+      case 'EMU-CLAUSE':
+      case 'EMU-INTRO':
+      case 'EMU-ANNEX':
+        yield el;
+    }
+  }
 }
 
 Menu.prototype.toggle = function () {
   this.$menu.classList.toggle('active');
-}
+};
 
 Menu.prototype.show = function () {
   this.$menu.classList.add('active');
-}
+};
 
 Menu.prototype.hide = function () {
   this.$menu.classList.remove('active');
-}
+};
 
-Menu.prototype.isVisible = function() {
+Menu.prototype.isVisible = function () {
   return this.$menu.classList.contains('active');
-}
+};
 
 Menu.prototype.showPins = function () {
   this.$pins.classList.add('active');
-}
+};
 
 Menu.prototype.hidePins = function () {
   this.$pins.classList.remove('active');
-}
+};
 
 Menu.prototype.addPinEntry = function (id) {
-  var entry = this.search.biblio.byId[id];
+  let entry = this.search.biblio.byId[id];
   if (!entry) {
     // id was deleted after pin (or something) so remove it
     delete this._pinnedIds[id];
@@ -407,15 +521,16 @@ Menu.prototype.addPinEntry = function (id) {
   }
 
   if (entry.type === 'clause') {
-    var prefix;
+    let prefix;
     if (entry.number) {
       prefix = entry.number + ' ';
     } else {
       prefix = '';
     }
-    this.$pinList.innerHTML += '<li><a href="#' + entry.id + '">' + prefix + entry.titleHTML + '</a></li>';
+    // prettier-ignore
+    this.$pinList.innerHTML += `<li><a href="${makeLinkToId(entry.id)}">${prefix}${entry.titleHTML}</a></li>`;
   } else {
-    this.$pinList.innerHTML += '<li><a href="#' + entry.id + '">' + entry.key + '</a></li>';
+    this.$pinList.innerHTML += `<li><a href="${makeLinkToId(entry.id)}">${getKey(entry)}</a></li>`;
   }
 
   if (Object.keys(this._pinnedIds).length === 0) {
@@ -423,10 +538,10 @@ Menu.prototype.addPinEntry = function (id) {
   }
   this._pinnedIds[id] = true;
   this.persistPinEntries();
-}
+};
 
 Menu.prototype.removePinEntry = function (id) {
-  var item = this.$pinList.querySelector('a[href="#' + id + '"]').parentNode;
+  let item = this.$pinList.querySelector(`a[href="${makeLinkToId(id)}"]`).parentNode;
   this.$pinList.removeChild(item);
   delete this._pinnedIds[id];
   if (Object.keys(this._pinnedIds).length === 0) {
@@ -434,7 +549,7 @@ Menu.prototype.removePinEntry = function (id) {
   }
 
   this.persistPinEntries();
-}
+};
 
 Menu.prototype.persistPinEntries = function () {
   try {
@@ -444,7 +559,7 @@ Menu.prototype.persistPinEntries = function () {
   }
 
   localStorage.pinEntries = JSON.stringify(Object.keys(this._pinnedIds));
-}
+};
 
 Menu.prototype.loadPinEntries = function () {
   try {
@@ -453,13 +568,13 @@ Menu.prototype.loadPinEntries = function () {
     return;
   }
 
-  var pinsString = window.localStorage.pinEntries;
+  let pinsString = window.localStorage.pinEntries;
   if (!pinsString) return;
-  var pins = JSON.parse(pinsString);
-  for(var i = 0; i < pins.length; i++) {
+  let pins = JSON.parse(pinsString);
+  for (let i = 0; i < pins.length; i++) {
     this.addPinEntry(pins[i]);
   }
-}
+};
 
 Menu.prototype.togglePinEntry = function (id) {
   if (!id) {
@@ -471,62 +586,49 @@ Menu.prototype.togglePinEntry = function (id) {
   } else {
     this.addPinEntry(id);
   }
-}
+};
 
 Menu.prototype.selectPin = function (num) {
   document.location = this.$pinList.children[num].children[0].href;
-}
+};
 
-var menu;
-function init() {
-  menu = new Menu();
-  var $container = document.getElementById('spec-container');
-  $container.addEventListener('mouseover', debounce(function (e) {
-    Toolbox.activateIfMouseOver(e);
-  }));
-  document.addEventListener('keydown', debounce(function (e) {
-    if (e.code === "Escape" && Toolbox.active) {
-      Toolbox.deactivate();
-    }
-  }));
-}
+let menu;
 
 document.addEventListener('DOMContentLoaded', init);
 
 function debounce(fn, opts) {
   opts = opts || {};
-  var timeout;
-  return function(e) {
+  let timeout;
+  return function (e) {
     if (opts.stopPropagation) {
       e.stopPropagation();
     }
-    var args = arguments;
+    let args = arguments;
     if (timeout) {
       clearTimeout(timeout);
     }
-    timeout = setTimeout(function() {
+    timeout = setTimeout(() => {
       timeout = null;
       fn.apply(this, args);
-    }.bind(this), 150);
-  }
+    }, 150);
+  };
 }
 
-var CLAUSE_NODES = ['EMU-CLAUSE', 'EMU-INTRO', 'EMU-ANNEX'];
-function findLocalReferences ($elem) {
-  var name = $elem.innerHTML;
-  var references = [];
-
-  var parentClause = $elem.parentNode;
+let CLAUSE_NODES = ['EMU-CLAUSE', 'EMU-INTRO', 'EMU-ANNEX'];
+function findContainer($elem) {
+  let parentClause = $elem.parentNode;
   while (parentClause && CLAUSE_NODES.indexOf(parentClause.nodeName) === -1) {
     parentClause = parentClause.parentNode;
   }
+  return parentClause;
+}
 
-  if(!parentClause) return;
+function findLocalReferences(parentClause, name) {
+  let vars = parentClause.querySelectorAll('var');
+  let references = [];
 
-  var vars = parentClause.querySelectorAll('var');
-
-  for (var i = 0; i < vars.length; i++) {
-    var $var = vars[i];
+  for (let i = 0; i < vars.length; i++) {
+    let $var = vars[i];
 
     if ($var.innerHTML === name) {
       references.push($var);
@@ -536,21 +638,38 @@ function findLocalReferences ($elem) {
   return references;
 }
 
+let REFERENCED_CLASSES = Array.from({ length: 7 }, (x, i) => `referenced${i}`);
+function chooseHighlightIndex(parentClause) {
+  let counts = REFERENCED_CLASSES.map($class => parentClause.getElementsByClassName($class).length);
+  // Find the earliest index with the lowest count.
+  let minCount = Infinity;
+  let index = null;
+  for (let i = 0; i < counts.length; i++) {
+    if (counts[i] < minCount) {
+      minCount = counts[i];
+      index = i;
+    }
+  }
+  return index;
+}
+
 function toggleFindLocalReferences($elem) {
-  var references = findLocalReferences($elem);
+  let parentClause = findContainer($elem);
+  let references = findLocalReferences(parentClause, $elem.innerHTML);
   if ($elem.classList.contains('referenced')) {
-    references.forEach(function ($reference) {
-      $reference.classList.remove('referenced');
+    references.forEach($reference => {
+      $reference.classList.remove('referenced', ...REFERENCED_CLASSES);
     });
   } else {
-    references.forEach(function ($reference) {
-      $reference.classList.add('referenced');
+    let index = chooseHighlightIndex(parentClause);
+    references.forEach($reference => {
+      $reference.classList.add('referenced', `referenced${index}`);
     });
   }
 }
 
-function installFindLocalReferences () {
-  document.addEventListener('click', function (e) {
+function installFindLocalReferences() {
+  document.addEventListener('click', e => {
     if (e.target.nodeName === 'VAR') {
       toggleFindLocalReferences(e.target);
     }
@@ -558,9 +677,6 @@ function installFindLocalReferences () {
 }
 
 document.addEventListener('DOMContentLoaded', installFindLocalReferences);
-
-
-
 
 // The following license applies to the fuzzysearch function
 // The MIT License (MIT)
@@ -582,11 +698,11 @@ document.addEventListener('DOMContentLoaded', installFindLocalReferences);
 // COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-function fuzzysearch (searchString, haystack, caseInsensitive) {
-  var tlen = haystack.length;
-  var qlen = searchString.length;
-  var chunks = 1;
-  var finding = false;
+function fuzzysearch(searchString, haystack, caseInsensitive) {
+  let tlen = haystack.length;
+  let qlen = searchString.length;
+  let chunks = 1;
+  let finding = false;
 
   if (qlen > tlen) {
     return false;
@@ -602,10 +718,11 @@ function fuzzysearch (searchString, haystack, caseInsensitive) {
     }
   }
 
-  outer: for (var i = 0, j = 0; i < qlen; i++) {
-    var nch = searchString[i];
+  let j = 0;
+  outer: for (let i = 0; i < qlen; i++) {
+    let nch = searchString[i];
     while (j < tlen) {
-      var targetChar = haystack[j++];
+      let targetChar = haystack[j++];
       if (targetChar === nch) {
         finding = true;
         continue outer;
@@ -616,113 +733,24 @@ function fuzzysearch (searchString, haystack, caseInsensitive) {
       }
     }
 
-    if (caseInsensitive) { return false; }
+    if (caseInsensitive) {
+      return false;
+    }
 
     return fuzzysearch(searchString.toLowerCase(), haystack.toLowerCase(), true);
   }
 
-  return { caseMatch: !caseInsensitive, chunks: chunks, prefix: j <= qlen };
+  return { caseMatch: !caseInsensitive, chunks, prefix: j <= qlen };
 }
 
-var Toolbox = {
-  init: function () {
-    this.$container = document.createElement('div');
-    this.$container.classList.add('toolbox');
-    this.$permalink = document.createElement('a');
-    this.$permalink.textContent = 'Permalink';
-    this.$pinLink = document.createElement('a');
-    this.$pinLink.textContent = 'Pin';
-    this.$pinLink.setAttribute('href', '#');
-    this.$pinLink.addEventListener('click', function (e) {
-      e.preventDefault();
-      e.stopPropagation();
-      menu.togglePinEntry(this.entry.id);
-    }.bind(this));
-
-    this.$refsLink = document.createElement('a');
-    this.$refsLink.setAttribute('href', '#');
-    this.$refsLink.addEventListener('click', function (e) {
-      e.preventDefault();
-      e.stopPropagation();
-      referencePane.showReferencesFor(this.entry);
-    }.bind(this));
-    this.$container.appendChild(this.$permalink);
-    this.$container.appendChild(this.$pinLink);
-    this.$container.appendChild(this.$refsLink);
-    document.body.appendChild(this.$container);
-  },
-
-  activate: function (el, entry, target) {
-    if (el === this._activeEl) return;
-    this.active = true;
-    this.entry = entry;
-    this.$container.classList.add('active');
-    this.top = el.offsetTop - this.$container.offsetHeight - 10;
-    this.left = el.offsetLeft;
-    this.$container.setAttribute('style', 'left: ' + this.left + 'px; top: ' + this.top + 'px');
-    this.updatePermalink();
-    this.updateReferences();
-    this._activeEl = el;
-    if (this.top < document.body.scrollTop && el === target) {
-      // don't scroll unless it's a small thing (< 200px)
-      this.$container.scrollIntoView();
-    }
-  },
-
-  updatePermalink: function () {
-    this.$permalink.setAttribute('href', '#' + this.entry.id);
-  },
-
-  updateReferences: function () {
-    this.$refsLink.textContent = 'References (' + this.entry.referencingIds.length + ')';
-  },
-
-  activateIfMouseOver: function (e) {
-    var ref = this.findReferenceUnder(e.target);
-    if (ref && (!this.active || e.pageY > this._activeEl.offsetTop)) {
-      var entry = menu.search.biblio.byId[ref.id];
-      this.activate(ref.element, entry, e.target);
-    } else if (this.active && ((e.pageY < this.top) || e.pageY > (this._activeEl.offsetTop + this._activeEl.offsetHeight))) {
-      this.deactivate();
-    }
-  },
-
-  findReferenceUnder: function (el) {
-    while (el) {
-      var parent = el.parentNode;
-      if (el.nodeName === 'H1' && parent.nodeName.match(/EMU-CLAUSE|EMU-ANNEX|EMU-INTRO/) && parent.id) {
-        return { element: el, id: parent.id };
-      } else if (el.nodeName.match(/EMU-(?!CLAUSE|XREF|ANNEX|INTRO)|DFN/) &&
-                el.id && el.id[0] !== '_') {
-        if (el.nodeName === 'EMU-FIGURE' || el.nodeName === 'EMU-TABLE' || el.nodeName === 'EMU-EXAMPLE') {
-          // return the figcaption element
-          return { element: el.children[0].children[0], id: el.id };
-        } else if (el.nodeName === 'EMU-PRODUCTION') {
-          // return the LHS non-terminal element
-          return { element: el.children[0], id: el.id };
-        } else {
-          return { element: el, id: el.id };
-        }
-      }
-      el = parent;
-    }
-  },
-
-  deactivate: function () {
-    this.$container.classList.remove('active');
-    this._activeEl = null;
-    this.activeElBounds = null;
-    this.active = false;
-  }
-}
-
-var referencePane = {
-  init: function() {
+let referencePane = {
+  init() {
     this.$container = document.createElement('div');
     this.$container.setAttribute('id', 'references-pane-container');
 
-    var $spacer = document.createElement('div');
+    let $spacer = document.createElement('div');
     $spacer.setAttribute('id', 'references-pane-spacer');
+    $spacer.classList.add('menu-spacer');
 
     this.$pane = document.createElement('div');
     this.$pane.setAttribute('id', 'references-pane');
@@ -732,18 +760,19 @@ var referencePane = {
 
     this.$header = document.createElement('div');
     this.$header.classList.add('menu-pane-header');
-    this.$header.textContent = 'References to ';
+    this.$headerText = document.createElement('span');
+    this.$header.appendChild(this.$headerText);
     this.$headerRefId = document.createElement('a');
     this.$header.appendChild(this.$headerRefId);
     this.$closeButton = document.createElement('span');
     this.$closeButton.setAttribute('id', 'references-pane-close');
-    this.$closeButton.addEventListener('click', function (e) {
+    this.$closeButton.addEventListener('click', () => {
       this.deactivate();
-    }.bind(this));
+    });
     this.$header.appendChild(this.$closeButton);
 
     this.$pane.appendChild(this.$header);
-    var tableContainer = document.createElement('div');
+    let tableContainer = document.createElement('div');
     tableContainer.setAttribute('id', 'references-pane-table-container');
 
     this.$table = document.createElement('table');
@@ -757,70 +786,238 @@ var referencePane = {
     menu.$specContainer.appendChild(this.$container);
   },
 
-  activate: function () {
+  activate() {
     this.$container.classList.add('active');
   },
 
-  deactivate: function () {
+  deactivate() {
     this.$container.classList.remove('active');
+    this.state = null;
   },
 
   showReferencesFor(entry) {
     this.activate();
-    var newBody = document.createElement('tbody');
-    var previousId;
-    var previousCell;
-    var dupCount = 0;
+    this.state = { type: 'ref', id: entry.id };
+    this.$headerText.textContent = 'References to ';
+    let newBody = document.createElement('tbody');
+    let previousId;
+    let previousCell;
+    let dupCount = 0;
     this.$headerRefId.textContent = '#' + entry.id;
-    this.$headerRefId.setAttribute('href', '#' + entry.id);
-    entry.referencingIds.map(function (id) {
-      var target = document.getElementById(id);
-      var cid = findParentClauseId(target);
-      var clause = menu.search.biblio.byId[cid];
-      return { id: id, clause: clause }
-    }).sort(function (a, b) {
-      return sortByClauseNumber(a.clause, b.clause);
-    }).forEach(function (record, i) {
-      if (previousId === record.clause.id) {
-        previousCell.innerHTML += ' (<a href="#' + record.id + '">' + (dupCount + 2) + '</a>)';
-        dupCount++;
-      } else {
-        var row = newBody.insertRow();
-        var cell = row.insertCell();
-        cell.innerHTML = record.clause.number;
-        cell = row.insertCell();
-        cell.innerHTML = '<a href="#' + record.id + '">' + record.clause.titleHTML + '</a>';
-        previousCell = cell;
-        previousId = record.clause.id;
-        dupCount = 0;
-      }
-    }, this);
+    this.$headerRefId.setAttribute('href', makeLinkToId(entry.id));
+    this.$headerRefId.style.display = 'inline';
+    (entry.referencingIds || [])
+      .map(id => {
+        let cid = menu.search.biblio.refParentClause[id];
+        let clause = menu.search.biblio.byId[cid];
+        if (clause == null) {
+          throw new Error('could not find clause for id ' + cid);
+        }
+        return { id, clause };
+      })
+      .sort((a, b) => sortByClauseNumber(a.clause, b.clause))
+      .forEach(record => {
+        if (previousId === record.clause.id) {
+          previousCell.innerHTML += ` (<a href="${makeLinkToId(record.id)}">${dupCount + 2}</a>)`;
+          dupCount++;
+        } else {
+          let row = newBody.insertRow();
+          let cell = row.insertCell();
+          cell.innerHTML = record.clause.number;
+          cell = row.insertCell();
+          cell.innerHTML = `<a href="${makeLinkToId(record.id)}">${record.clause.titleHTML}</a>`;
+          previousCell = cell;
+          previousId = record.clause.id;
+          dupCount = 0;
+        }
+      }, this);
     this.$table.removeChild(this.$tableBody);
     this.$tableBody = newBody;
     this.$table.appendChild(this.$tableBody);
-  }
-}
-function findParentClauseId(node) {
-  while (node && node.nodeName !== 'EMU-CLAUSE' && node.nodeName !== 'EMU-INTRO' && node.nodeName !== 'EMU-ANNEX') {
-    node = node.parentNode;
-  }
-  if (!node) return null;
-  return node.getAttribute('id');
-}
+  },
 
-function sortByClauseNumber(c1, c2) {
-  var c1c = c1.number.split('.');
-  var c2c = c2.number.split('.');
+  showSDOs(sdos, alternativeId) {
+    let rhs = document.getElementById(alternativeId);
+    let parentName = rhs.parentNode.getAttribute('name');
+    let colons = rhs.parentNode.querySelector('emu-geq');
+    rhs = rhs.cloneNode(true);
+    rhs.querySelectorAll('emu-params,emu-constraints').forEach(e => {
+      e.remove();
+    });
+    rhs.querySelectorAll('[id]').forEach(e => {
+      e.removeAttribute('id');
+    });
+    rhs.querySelectorAll('a').forEach(e => {
+      e.parentNode.replaceChild(document.createTextNode(e.textContent), e);
+    });
 
-  for (var i = 0; i < c1c.length; i++) {
+    // prettier-ignore
+    this.$headerText.innerHTML = `Syntax-Directed Operations for<br><a href="${makeLinkToId(alternativeId)}" class="menu-pane-header-production"><emu-nt>${parentName}</emu-nt> ${colons.outerHTML} </a>`;
+    this.$headerText.querySelector('a').append(rhs);
+    this.showSDOsBody(sdos, alternativeId);
+  },
+
+  showSDOsBody(sdos, alternativeId) {
+    this.activate();
+    this.state = { type: 'sdo', id: alternativeId, html: this.$headerText.innerHTML };
+    this.$headerRefId.style.display = 'none';
+    let newBody = document.createElement('tbody');
+    Object.keys(sdos).forEach(sdoName => {
+      let pair = sdos[sdoName];
+      let clause = pair.clause;
+      let ids = pair.ids;
+      let first = ids[0];
+      let row = newBody.insertRow();
+      let cell = row.insertCell();
+      cell.innerHTML = clause;
+      cell = row.insertCell();
+      let html = '<a href="' + makeLinkToId(first) + '">' + sdoName + '</a>';
+      for (let i = 1; i < ids.length; ++i) {
+        html += ' (<a href="' + makeLinkToId(ids[i]) + '">' + (i + 1) + '</a>)';
+      }
+      cell.innerHTML = html;
+    });
+    this.$table.removeChild(this.$tableBody);
+    this.$tableBody = newBody;
+    this.$table.appendChild(this.$tableBody);
+  },
+};
+
+let Toolbox = {
+  init() {
+    this.$outer = document.createElement('div');
+    this.$outer.classList.add('toolbox-container');
+    this.$container = document.createElement('div');
+    this.$container.classList.add('toolbox');
+    this.$outer.appendChild(this.$container);
+    this.$permalink = document.createElement('a');
+    this.$permalink.textContent = 'Permalink';
+    this.$pinLink = document.createElement('a');
+    this.$pinLink.textContent = 'Pin';
+    this.$pinLink.setAttribute('href', '#');
+    this.$pinLink.addEventListener('click', e => {
+      e.preventDefault();
+      e.stopPropagation();
+      menu.togglePinEntry(this.entry.id);
+      this.$pinLink.textContent = menu._pinnedIds[this.entry.id] ? 'Unpin' : 'Pin';
+    });
+
+    this.$refsLink = document.createElement('a');
+    this.$refsLink.setAttribute('href', '#');
+    this.$refsLink.addEventListener('click', e => {
+      e.preventDefault();
+      e.stopPropagation();
+      referencePane.showReferencesFor(this.entry);
+    });
+    this.$container.appendChild(this.$permalink);
+    this.$container.appendChild(this.$pinLink);
+    this.$container.appendChild(this.$refsLink);
+    document.body.appendChild(this.$outer);
+  },
+
+  activate(el, entry, target) {
+    if (el === this._activeEl) return;
+    sdoBox.deactivate();
+    this.active = true;
+    this.entry = entry;
+    this.$pinLink.textContent = menu._pinnedIds[entry.id] ? 'Unpin' : 'Pin';
+    this.$outer.classList.add('active');
+    this.top = el.offsetTop - this.$outer.offsetHeight;
+    this.left = el.offsetLeft - 10;
+    this.$outer.setAttribute('style', 'left: ' + this.left + 'px; top: ' + this.top + 'px');
+    this.updatePermalink();
+    this.updateReferences();
+    this._activeEl = el;
+    if (this.top < document.body.scrollTop && el === target) {
+      // don't scroll unless it's a small thing (< 200px)
+      this.$outer.scrollIntoView();
+    }
+  },
+
+  updatePermalink() {
+    this.$permalink.setAttribute('href', makeLinkToId(this.entry.id));
+  },
+
+  updateReferences() {
+    this.$refsLink.textContent = `References (${(this.entry.referencingIds || []).length})`;
+  },
+
+  activateIfMouseOver(e) {
+    let ref = this.findReferenceUnder(e.target);
+    if (ref && (!this.active || e.pageY > this._activeEl.offsetTop)) {
+      let entry = menu.search.biblio.byId[ref.id];
+      this.activate(ref.element, entry, e.target);
+    } else if (
+      this.active &&
+      (e.pageY < this.top || e.pageY > this._activeEl.offsetTop + this._activeEl.offsetHeight)
+    ) {
+      this.deactivate();
+    }
+  },
+
+  findReferenceUnder(el) {
+    while (el) {
+      let parent = el.parentNode;
+      if (el.nodeName === 'EMU-RHS' || el.nodeName === 'EMU-PRODUCTION') {
+        return null;
+      }
+      if (
+        el.nodeName === 'H1' &&
+        parent.nodeName.match(/EMU-CLAUSE|EMU-ANNEX|EMU-INTRO/) &&
+        parent.id
+      ) {
+        return { element: el, id: parent.id };
+      } else if (el.nodeName === 'EMU-NT') {
+        if (
+          parent.nodeName === 'EMU-PRODUCTION' &&
+          parent.id &&
+          parent.id[0] !== '_' &&
+          parent.firstElementChild === el
+        ) {
+          // return the LHS non-terminal element
+          return { element: el, id: parent.id };
+        }
+        return null;
+      } else if (
+        el.nodeName.match(/EMU-(?!CLAUSE|XREF|ANNEX|INTRO)|DFN/) &&
+        el.id &&
+        el.id[0] !== '_'
+      ) {
+        if (
+          el.nodeName === 'EMU-FIGURE' ||
+          el.nodeName === 'EMU-TABLE' ||
+          el.nodeName === 'EMU-EXAMPLE'
+        ) {
+          // return the figcaption element
+          return { element: el.children[0].children[0], id: el.id };
+        } else {
+          return { element: el, id: el.id };
+        }
+      }
+      el = parent;
+    }
+  },
+
+  deactivate() {
+    this.$outer.classList.remove('active');
+    this._activeEl = null;
+    this.active = false;
+  },
+};
+
+function sortByClauseNumber(clause1, clause2) {
+  let c1c = clause1.number.split('.');
+  let c2c = clause2.number.split('.');
+
+  for (let i = 0; i < c1c.length; i++) {
     if (i >= c2c.length) {
       return 1;
     }
 
-    var c1 = c1c[i];
-    var c2 = c2c[i];
-    var c1cn = Number(c1);
-    var c2cn = Number(c2);
+    let c1 = c1c[i];
+    let c2 = c2c[i];
+    let c1cn = Number(c1);
+    let c2cn = Number(c2);
 
     if (Number.isNaN(c1cn) && Number.isNaN(c2cn)) {
       if (c1 > c2) {
@@ -832,7 +1029,7 @@ function sortByClauseNumber(c1, c2) {
       return -1;
     } else if (Number.isNaN(c1cn) && !Number.isNaN(c2cn)) {
       return 1;
-    } else if(c1cn > c2cn) {
+    } else if (c1cn > c2cn) {
       return 1;
     } else if (c1cn < c2cn) {
       return -1;
@@ -845,59 +1042,314 @@ function sortByClauseNumber(c1, c2) {
   return -1;
 }
 
-document.addEventListener('DOMContentLoaded', function () {
+function makeLinkToId(id) {
+  let hash = '#' + id;
+  if (typeof idToSection === 'undefined' || !idToSection[id]) {
+    return hash;
+  }
+  let targetSec = idToSection[id];
+  return (targetSec === 'index' ? './' : targetSec + '.html') + hash;
+}
+
+function doShortcut(e) {
+  if (!(e.target instanceof HTMLElement)) {
+    return;
+  }
+  let target = e.target;
+  let name = target.nodeName.toLowerCase();
+  if (name === 'textarea' || name === 'input' || name === 'select' || target.isContentEditable) {
+    return;
+  }
+  if (e.altKey || e.ctrlKey || e.metaKey) {
+    return;
+  }
+  if (e.key === 'm' && usesMultipage) {
+    let pathParts = location.pathname.split('/');
+    let hash = location.hash;
+    if (pathParts[pathParts.length - 2] === 'multipage') {
+      if (hash === '') {
+        let sectionName = pathParts[pathParts.length - 1];
+        if (sectionName.endsWith('.html')) {
+          sectionName = sectionName.slice(0, -5);
+        }
+        if (idToSection['sec-' + sectionName] !== undefined) {
+          hash = '#sec-' + sectionName;
+        }
+      }
+      location = pathParts.slice(0, -2).join('/') + '/' + hash;
+    } else {
+      location = 'multipage/' + hash;
+    }
+  } else if (e.key === 'u') {
+    document.documentElement.classList.toggle('show-ao-annotations');
+  } else if (e.key === '?') {
+    document.getElementById('shortcuts-help').classList.toggle('active');
+  }
+}
+
+function init() {
+  menu = new Menu();
+  let $container = document.getElementById('spec-container');
+  $container.addEventListener(
+    'mouseover',
+    debounce(e => {
+      Toolbox.activateIfMouseOver(e);
+    })
+  );
+  document.addEventListener(
+    'keydown',
+    debounce(e => {
+      if (e.code === 'Escape') {
+        if (Toolbox.active) {
+          Toolbox.deactivate();
+        }
+        document.getElementById('shortcuts-help').classList.remove('active');
+      }
+    })
+  );
+}
+
+document.addEventListener('keypress', doShortcut);
+
+document.addEventListener('DOMContentLoaded', () => {
   Toolbox.init();
   referencePane.init();
-})
-var CLAUSE_NODES = ['EMU-CLAUSE', 'EMU-INTRO', 'EMU-ANNEX'];
-function findLocalReferences ($elem) {
-  var name = $elem.innerHTML;
-  var references = [];
+});
 
-  var parentClause = $elem.parentNode;
-  while (parentClause && CLAUSE_NODES.indexOf(parentClause.nodeName) === -1) {
-    parentClause = parentClause.parentNode;
+// preserve state during navigation
+
+function getTocPath(li) {
+  let path = [];
+  let pointer = li;
+  while (true) {
+    let parent = pointer.parentElement;
+    if (parent == null) {
+      return null;
+    }
+    let index = [].indexOf.call(parent.children, pointer);
+    if (index == -1) {
+      return null;
+    }
+    path.unshift(index);
+    pointer = parent.parentElement;
+    if (pointer == null) {
+      return null;
+    }
+    if (pointer.id === 'menu-toc') {
+      break;
+    }
+    if (pointer.tagName !== 'LI') {
+      return null;
+    }
   }
+  return path;
+}
 
-  if(!parentClause) return;
+function activateTocPath(path) {
+  try {
+    let pointer = document.getElementById('menu-toc');
+    for (let index of path) {
+      pointer = pointer.querySelector('ol').children[index];
+    }
+    pointer.classList.add('active');
+  } catch (e) {
+    // pass
+  }
+}
 
-  var vars = parentClause.querySelectorAll('var');
+function getActiveTocPaths() {
+  return [...menu.$menu.querySelectorAll('.active')].map(getTocPath).filter(p => p != null);
+}
 
-  for (var i = 0; i < vars.length; i++) {
-    var $var = vars[i];
-
-    if ($var.innerHTML === name) {
-      references.push($var);
+function loadStateFromSessionStorage() {
+  if (!window.sessionStorage || typeof menu === 'undefined' || window.navigating) {
+    return;
+  }
+  if (sessionStorage.referencePaneState != null) {
+    let state = JSON.parse(sessionStorage.referencePaneState);
+    if (state != null) {
+      if (state.type === 'ref') {
+        let entry = menu.search.biblio.byId[state.id];
+        if (entry != null) {
+          referencePane.showReferencesFor(entry);
+        }
+      } else if (state.type === 'sdo') {
+        let sdos = sdoMap[state.id];
+        if (sdos != null) {
+          referencePane.$headerText.innerHTML = state.html;
+          referencePane.showSDOsBody(sdos, state.id);
+        }
+      }
+      delete sessionStorage.referencePaneState;
     }
   }
 
-  return references;
-}
+  if (sessionStorage.activeTocPaths != null) {
+    document
+      .getElementById('menu-toc')
+      .querySelectorAll('.active')
+      .forEach(e => {
+        e.classList.remove('active');
+      });
+    let active = JSON.parse(sessionStorage.activeTocPaths);
+    active.forEach(activateTocPath);
+    delete sessionStorage.activeTocPaths;
+  }
 
-function toggleFindLocalReferences($elem) {
-  var references = findLocalReferences($elem);
-  if ($elem.classList.contains('referenced')) {
-    references.forEach(function ($reference) {
-      $reference.classList.remove('referenced');
-    });
-  } else {
-    references.forEach(function ($reference) {
-      $reference.classList.add('referenced');
-    });
+  if (sessionStorage.searchValue != null) {
+    let value = JSON.parse(sessionStorage.searchValue);
+    menu.search.$searchBox.value = value;
+    menu.search.search(value);
+    delete sessionStorage.searchValue;
+  }
+
+  if (sessionStorage.tocScroll != null) {
+    let tocScroll = JSON.parse(sessionStorage.tocScroll);
+    menu.$toc.scrollTop = tocScroll;
+    delete sessionStorage.tocScroll;
   }
 }
 
-function installFindLocalReferences () {
-  document.addEventListener('click', function (e) {
-    if (e.target.nodeName === 'VAR') {
-      toggleFindLocalReferences(e.target);
+document.addEventListener('DOMContentLoaded', loadStateFromSessionStorage);
+
+window.addEventListener('pageshow', loadStateFromSessionStorage);
+
+window.addEventListener('beforeunload', () => {
+  if (!window.sessionStorage || typeof menu === 'undefined') {
+    return;
+  }
+  sessionStorage.referencePaneState = JSON.stringify(referencePane.state || null);
+  sessionStorage.activeTocPaths = JSON.stringify(getActiveTocPaths());
+  sessionStorage.searchValue = JSON.stringify(menu.search.$searchBox.value);
+  sessionStorage.tocScroll = JSON.stringify(menu.$toc.scrollTop);
+});
+
+'use strict';
+
+// Manually prefix algorithm step list items with hidden counter representations
+// corresponding with their markers so they get selected and copied with content.
+// We read list-style-type to avoid divergence with the style sheet, but
+// for efficiency assume that all lists at the same nesting depth use the same
+// style (except for those associated with replacement steps).
+// We also precompute some initial items for each supported style type.
+// https://w3c.github.io/csswg-drafts/css-counter-styles/
+
+const lowerLetters = Array.from({ length: 26 }, (_, i) =>
+  String.fromCharCode('a'.charCodeAt(0) + i)
+);
+// Implement the lower-alpha 'alphabetic' algorithm,
+// adjusting for indexing from 0 rather than 1.
+// https://w3c.github.io/csswg-drafts/css-counter-styles/#simple-alphabetic
+// https://w3c.github.io/csswg-drafts/css-counter-styles/#alphabetic-system
+const lowerAlphaTextForIndex = i => {
+  let S = '';
+  for (const N = lowerLetters.length; i >= 0; i--) {
+    S = lowerLetters[i % N] + S;
+    i = Math.floor(i / N);
+  }
+  return S;
+};
+
+const weightedLowerRomanSymbols = Object.entries({
+  m: 1000,
+  cm: 900,
+  d: 500,
+  cd: 400,
+  c: 100,
+  xc: 90,
+  l: 50,
+  xl: 40,
+  x: 10,
+  ix: 9,
+  v: 5,
+  iv: 4,
+  i: 1,
+});
+// Implement the lower-roman 'additive' algorithm,
+// adjusting for indexing from 0 rather than 1.
+// https://w3c.github.io/csswg-drafts/css-counter-styles/#simple-numeric
+// https://w3c.github.io/csswg-drafts/css-counter-styles/#additive-system
+const lowerRomanTextForIndex = i => {
+  let value = i + 1;
+  let S = '';
+  for (const [symbol, weight] of weightedLowerRomanSymbols) {
+    if (!value) break;
+    if (weight > value) continue;
+    const reps = Math.floor(value / weight);
+    S += symbol.repeat(reps);
+    value -= weight * reps;
+  }
+  return S;
+};
+
+// Memoize pure index-to-text functions with an exposed cache for fast retrieval.
+const makeCounter = (pureGetTextForIndex, precomputeCount = 30) => {
+  const cache = Array.from({ length: precomputeCount }, (_, i) => pureGetTextForIndex(i));
+  const getTextForIndex = i => {
+    if (i >= cache.length) cache[i] = pureGetTextForIndex(i);
+    return cache[i];
+  };
+  return { getTextForIndex, cache };
+};
+
+const counterByStyle = {
+  __proto__: null,
+  decimal: makeCounter(i => String(i + 1)),
+  'lower-alpha': makeCounter(lowerAlphaTextForIndex),
+  'upper-alpha': makeCounter(i => lowerAlphaTextForIndex(i).toUpperCase()),
+  'lower-roman': makeCounter(lowerRomanTextForIndex),
+  'upper-roman': makeCounter(i => lowerRomanTextForIndex(i).toUpperCase()),
+};
+const fallbackCounter = makeCounter(() => '?');
+const counterByDepth = [];
+
+function addStepNumberText(
+  ol,
+  depth = 0,
+  special = [...ol.classList].some(c => c.startsWith('nested-'))
+) {
+  let counter = !special && counterByDepth[depth];
+  if (!counter) {
+    const counterStyle = getComputedStyle(ol)['list-style-type'];
+    counter = counterByStyle[counterStyle];
+    if (!counter) {
+      console.warn('unsupported list-style-type', {
+        ol,
+        counterStyle,
+        id: ol.closest('[id]')?.getAttribute('id'),
+      });
+      counterByStyle[counterStyle] = fallbackCounter;
+      counter = fallbackCounter;
     }
+    if (!special) {
+      counterByDepth[depth] = counter;
+    }
+  }
+  const { cache, getTextForIndex } = counter;
+  let i = (Number(ol.getAttribute('start')) || 1) - 1;
+  for (const li of ol.children) {
+    const marker = document.createElement('span');
+    marker.textContent = `${i < cache.length ? cache[i] : getTextForIndex(i)}. `;
+    marker.setAttribute('aria-hidden', 'true');
+    li.prepend(marker);
+    for (const sublist of li.querySelectorAll(':scope > ol')) {
+      addStepNumberText(sublist, depth + 1, special);
+    }
+    i++;
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('emu-alg > ol').forEach(ol => {
+    addStepNumberText(ol);
   });
-}
+});
 
-document.addEventListener('DOMContentLoaded', installFindLocalReferences);
-</script><style>body {
+let sdoMap = JSON.parse(`{}`);
+let biblio = JSON.parse(`{"refsByClause":{"sec-internal-slots":["_ref_0"],"sec-abstract-operations":["_ref_1"],"sec-lookupmatcher":["_ref_2","_ref_3"],"sec-bestfitmatcher":["_ref_4","_ref_5"],"sec-resolvelocale":["_ref_6","_ref_7","_ref_8","_ref_9"],"sec-lookupsupportedlocales":["_ref_10"],"sec-supportedlocales":["_ref_11","_ref_12","_ref_13","_ref_14"],"sec-getoptionsobject":["_ref_15"],"sec-coerceoptionstoobject":["_ref_16","_ref_17"],"sec-getnumberoption":["_ref_18"]},"entries":[{"type":"clause","id":"sec-internal-slots","titleHTML":"Internal slots of Service Constructors","number":"1.1","referencingIds":["_ref_1"]},{"type":"op","aoid":"CanonicalizeLocaleList","refId":"sec-canonicalizelocalelist"},{"type":"clause","id":"sec-canonicalizelocalelist","title":"CanonicalizeLocaleList ( locales )","titleHTML":"CanonicalizeLocaleList ( <var>locales</var> )","number":"1.2.1","referencingIds":["_ref_2","_ref_4"]},{"type":"op","aoid":"BestAvailableLocale","refId":"sec-bestavailablelocale"},{"type":"clause","id":"sec-bestavailablelocale","title":"BestAvailableLocale ( availableLocales, locale )","titleHTML":"BestAvailableLocale ( <var>availableLocales</var>, <var>locale</var> )","number":"1.2.2","referencingIds":["_ref_3","_ref_10"]},{"type":"op","aoid":"LookupMatcher","refId":"sec-lookupmatcher"},{"type":"clause","id":"sec-lookupmatcher","title":"LookupMatcher ( availableLocales, requestedLocales )","titleHTML":"LookupMatcher ( <var>availableLocales</var>, <var>requestedLocales</var> )","number":"1.2.3","referencingIds":["_ref_5","_ref_6"]},{"type":"op","aoid":"BestFitMatcher","refId":"sec-bestfitmatcher"},{"type":"clause","id":"sec-bestfitmatcher","title":"BestFitMatcher ( availableLocales, requestedLocales )","titleHTML":"BestFitMatcher ( <var>availableLocales</var>, <var>requestedLocales</var> )","number":"1.2.4","referencingIds":["_ref_7"]},{"type":"op","aoid":"UnicodeExtensionComponents","refId":"sec-unicode-extension-components"},{"type":"clause","id":"sec-unicode-extension-components","title":"UnicodeExtensionComponents ( extension )","titleHTML":"UnicodeExtensionComponents ( <var>extension</var> )","number":"1.2.5","referencingIds":["_ref_8"]},{"type":"op","aoid":"InsertUnicodeExtensionAndCanonicalize","refId":"sec-insert-unicode-extension-and-canonicalize"},{"type":"clause","id":"sec-insert-unicode-extension-and-canonicalize","title":"InsertUnicodeExtensionAndCanonicalize ( locale, extension )","titleHTML":"InsertUnicodeExtensionAndCanonicalize ( <var>locale</var>, <var>extension</var> )","number":"1.2.6","referencingIds":["_ref_9"]},{"type":"op","aoid":"ResolveLocale","refId":"sec-resolvelocale"},{"type":"clause","id":"sec-resolvelocale","title":"ResolveLocale ( availableLocales, requestedLocales, options, relevantExtensionKeys, localeData )","titleHTML":"ResolveLocale ( <var>availableLocales</var>, <var>requestedLocales</var>, <var>options</var>, <var>relevantExtensionKeys</var>, <var>localeData</var> )","number":"1.2.7","referencingIds":["_ref_0"]},{"type":"op","aoid":"LookupSupportedLocales","refId":"sec-lookupsupportedlocales"},{"type":"clause","id":"sec-lookupsupportedlocales","title":"LookupSupportedLocales ( availableLocales, requestedLocales )","titleHTML":"LookupSupportedLocales ( <var>availableLocales</var>, <var>requestedLocales</var> )","number":"1.2.8","referencingIds":["_ref_14"]},{"type":"op","aoid":"BestFitSupportedLocales","refId":"sec-bestfitsupportedlocales"},{"type":"clause","id":"sec-bestfitsupportedlocales","title":"BestFitSupportedLocales ( availableLocales, requestedLocales )","titleHTML":"BestFitSupportedLocales ( <var>availableLocales</var>, <var>requestedLocales</var> )","number":"1.2.9","referencingIds":["_ref_13"]},{"type":"op","aoid":"SupportedLocales","refId":"sec-supportedlocales"},{"type":"clause","id":"sec-supportedlocales","title":"SupportedLocales ( availableLocales, requestedLocales, options )","titleHTML":"SupportedLocales ( <var>availableLocales</var>, <var>requestedLocales</var>, <var>options</var> )","number":"1.2.10"},{"type":"op","aoid":"GetOptionsObject","refId":"sec-getoptionsobject"},{"type":"clause","id":"sec-getoptionsobject","title":"GetOptionsObject ( options )","titleHTML":"GetOptionsObject ( <var>options</var> )","number":"1.2.11","referencingIds":["_ref_17"]},{"type":"op","aoid":"CoerceOptionsToObject","refId":"sec-coerceoptionstoobject"},{"type":"clause","id":"sec-coerceoptionstoobject","title":"CoerceOptionsToObject ( options )","titleHTML":"CoerceOptionsToObject ( <var>options</var> )","number":"1.2.12","referencingIds":["_ref_11"]},{"type":"op","aoid":"GetOption","refId":"sec-getoption"},{"type":"clause","id":"sec-getoption","title":"GetOption ( options, property, type, values, default )","titleHTML":"GetOption ( <var>options</var>, <var>property</var>, <var>type</var>, <var>values</var>, <var>default</var> )","number":"1.2.13","referencingIds":["_ref_12","_ref_15","_ref_16"]},{"type":"op","aoid":"GetBooleanOrStringNumberFormatOption","refId":"sec-getbooleanorstringnumberformatoption"},{"type":"clause","id":"sec-getbooleanorstringnumberformatoption","title":"GetBooleanOrStringNumberFormatOption ( options, property, stringValues, fallback )","titleHTML":"GetBooleanOrStringNumberFormatOption ( <var>options</var>, <var>property</var>, <var>stringValues</var>, <var>fallback</var> )","number":"1.2.14"},{"type":"op","aoid":"DefaultNumberOption","refId":"sec-defaultnumberoption"},{"type":"clause","id":"sec-defaultnumberoption","title":"DefaultNumberOption ( value, minimum, maximum, fallback )","titleHTML":"DefaultNumberOption ( <var>value</var>, <var>minimum</var>, <var>maximum</var>, <var>fallback</var> )","number":"1.2.15","referencingIds":["_ref_18"]},{"type":"op","aoid":"GetNumberOption","refId":"sec-getnumberoption"},{"type":"clause","id":"sec-getnumberoption","title":"GetNumberOption ( options, property, minimum, maximum, fallback )","titleHTML":"GetNumberOption ( <var>options</var>, <var>property</var>, <var>minimum</var>, <var>maximum</var>, <var>fallback</var> )","number":"1.2.16"},{"type":"op","aoid":"PartitionPattern","refId":"sec-partitionpattern"},{"type":"clause","id":"sec-partitionpattern","title":"PartitionPattern ( pattern )","titleHTML":"PartitionPattern ( <var>pattern</var> )","number":"1.2.17"},{"type":"clause","id":"sec-abstract-operations","titleHTML":"Abstract Operations","number":"1.2"},{"type":"clause","id":"locale-and-parameter-negotiation","titleHTML":"Locale and Parameter Negotiation","number":"1"}]}`);
+;let usesMultipage = false</script><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.0.1/styles/base16/solarized-light.min.css"><style>body {
   display: flex;
+  word-wrap: break-word;
   font-size: 18px;
   line-height: 1.5;
   font-family: Cambria, Palatino Linotype, Palatino, Liberation Serif, serif;
@@ -912,6 +1364,7 @@ document.addEventListener('DOMContentLoaded', installFindLocalReferences);
   flex-basis: 66%;
   box-sizing: border-box;
   overflow: hidden;
+  padding-bottom: 1em;
 }
 
 body.oldtoc {
@@ -919,8 +1372,8 @@ body.oldtoc {
 }
 
 a {
-    text-decoration: none;
-    color: #206ca7;
+  text-decoration: none;
+  color: #206ca7;
 }
 
 a:visited {
@@ -928,15 +1381,51 @@ a:visited {
 }
 
 a:hover {
-    text-decoration: underline;
-    color: #239dee;
+  text-decoration: underline;
+  color: #239dee;
 }
 
+a.e-user-code,
+span.e-user-code {
+  white-space: nowrap;
+}
+
+a.e-user-code::before,
+span.e-user-code::before {
+  display: none;
+  color: brown;
+  background-color: white;
+  border: 2pt solid brown;
+  padding: 0.3ex;
+  margin: 0 0.25em 0 0;
+  line-height: 1;
+  vertical-align: text-top;
+  text-transform: uppercase;
+  font-family: 'Comic Code', sans-serif;
+  font-weight: 900;
+  font-size: x-small;
+}
+
+a.e-user-code:hover::before,
+span.e-user-code:hover::before {
+  background-color: brown;
+  color: white;
+}
+
+html.show-ao-annotations a.e-user-code::before,
+html.show-ao-annotations span.e-user-code::before {
+  display: inline-block;
+}
+
+a.e-user-code::before,
+span.e-user-code::before {
+  content: 'UC';
+}
 
 code {
-    font-weight: bold;
-    font-family: Consolas, Monaco, monospace;
-    white-space: pre;
+  font-weight: bold;
+  font-family: Consolas, Monaco, monospace;
+  white-space: pre;
 }
 
 pre code {
@@ -950,13 +1439,13 @@ pre code.hljs {
 }
 
 ol.toc {
-    list-style: none;
-    padding-left: 0;
+  list-style: none;
+  padding-left: 0;
 }
 
 ol.toc ol.toc {
-    padding-left: 2ex;
-    list-style: none;
+  padding-left: 2ex;
+  list-style: none;
 }
 
 var {
@@ -965,8 +1454,40 @@ var {
   cursor: pointer;
 }
 
-var.referenced {
+var.referenced0 {
+  color: inherit;
   background-color: #ffff33;
+  box-shadow: 0 0 0 2px #ffff33;
+}
+var.referenced1 {
+  color: inherit;
+  background-color: #ff87a2;
+  box-shadow: 0 0 0 2px #ff87a2;
+}
+var.referenced2 {
+  color: inherit;
+  background-color: #96e885;
+  box-shadow: 0 0 0 2px #96e885;
+}
+var.referenced3 {
+  color: inherit;
+  background-color: #3eeed2;
+  box-shadow: 0 0 0 2px #3eeed2;
+}
+var.referenced4 {
+  color: inherit;
+  background-color: #eacfb6;
+  box-shadow: 0 0 0 2px #eacfb6;
+}
+var.referenced5 {
+  color: inherit;
+  background-color: #82ddff;
+  box-shadow: 0 0 0 2px #82ddff;
+}
+var.referenced6 {
+  color: inherit;
+  background-color: #ffbcf2;
+  box-shadow: 0 0 0 2px #ffbcf2;
 }
 
 emu-const {
@@ -1015,6 +1536,10 @@ emu-alg ol.nested-lots ol {
   list-style-type: lower-roman;
 }
 
+emu-alg [aria-hidden=true] {
+  font-size: 0;
+}
+
 emu-eqn {
   display: block;
   margin-left: 4em;
@@ -1030,29 +1555,32 @@ emu-eqn div:first-child {
 }
 
 emu-note {
-    margin: 1em 0;
-    color: #666;
-    border-left: 5px solid #ccc;
-    display: flex;
-    flex-direction: row;
+  margin: 1em 0;
+  display: flex;
+  flex-direction: row;
+  color: inherit;
+  border-left: 5px solid #52e052;
+  background: #e9fbe9;
+  padding: 10px 10px 10px 0;
 }
 
 emu-note > span.note {
-    flex-basis: 100px;
-    min-width: 100px;
-    flex-grow: 0;
-    flex-shrink: 1;
-    text-transform: uppercase;
-    padding-left: 5px;
+  flex-basis: 100px;
+  min-width: 100px;
+  flex-grow: 0;
+  flex-shrink: 1;
+  text-transform: uppercase;
+  padding-left: 5px;
 }
 
-emu-note[type=editor] {
+emu-note[type='editor'] {
   border-left-color: #faa;
 }
 
 emu-note > div.note-contents {
   flex-grow: 1;
   flex-shrink: 1;
+  overflow: auto;
 }
 
 emu-note > div.note-contents > p:first-of-type {
@@ -1063,9 +1591,9 @@ emu-note > div.note-contents > p:last-of-type {
   margin-bottom: 0;
 }
 
-emu-table td code {
+emu-table:not(.code) td code {
   white-space: normal;
-} 
+}
 
 emu-figure {
   display: block;
@@ -1090,99 +1618,120 @@ emu-table figure {
 }
 
 emu-production {
-    display: block;
+  display: block;
 }
 
-emu-grammar[type="example"] emu-production,
-emu-grammar[type="definition"] emu-production {
-    margin-top: 1em;
-    margin-bottom: 1em;
-    margin-left: 5ex;
+emu-grammar[type='example'] emu-production,
+emu-grammar[type='definition'] emu-production {
+  margin-top: 1em;
+  margin-bottom: 1em;
+  margin-left: 5ex;
 }
 
-emu-grammar.inline, emu-production.inline,
-emu-grammar.inline emu-production emu-rhs, emu-production.inline emu-rhs,
-emu-grammar[collapsed] emu-production emu-rhs, emu-production[collapsed] emu-rhs {
-    display: inline;
-    padding-left: 1ex;
-    margin-left: 0;
+emu-grammar.inline,
+emu-production.inline,
+emu-grammar.inline emu-production emu-rhs,
+emu-production.inline emu-rhs,
+emu-grammar[collapsed] emu-production emu-rhs {
+  display: inline;
+  padding-left: 1ex;
+  margin-left: 0;
 }
 
-emu-grammar[collapsed] emu-production, emu-production[collapsed] {
-    margin: 0;
+emu-production[collapsed] emu-rhs {
+  display: inline;
+  padding-left: 0.5ex;
+  margin-left: 0;
+}
+
+emu-grammar[collapsed] emu-production,
+emu-production[collapsed] {
+  margin: 0;
 }
 
 emu-constraints {
-    font-size: .75em;
-    margin-right: 1ex;
+  font-size: 0.75em;
+  margin-right: 0.5ex;
 }
 
 emu-gann {
-    margin-right: 1ex;
+  margin-right: 0.5ex;
 }
 
 emu-gann emu-t:last-child,
 emu-gann emu-gprose:last-child,
 emu-gann emu-nt:last-child {
-    margin-right: 0;
+  margin-right: 0;
 }
 
 emu-geq {
-    margin-left: 1ex;
-    font-weight: bold;
+  margin-left: 0.5ex;
+  font-weight: bold;
 }
 
 emu-oneof {
-    font-weight: bold;
-    margin-left: 1ex;
+  font-weight: bold;
+  margin-left: 0.5ex;
 }
 
 emu-nt {
-    display: inline-block;
-    font-style: italic;
-    white-space: nowrap;
-    text-indent: 0;
+  display: inline-block;
+  font-style: italic;
+  white-space: nowrap;
+  text-indent: 0;
 }
 
-emu-nt a, emu-nt a:visited {
+emu-nt a,
+emu-nt a:visited {
   color: #333;
 }
 
 emu-rhs emu-nt {
-    margin-right: 1ex;
+  margin-right: 0.5ex;
 }
 
 emu-t {
-    display: inline-block;
-    font-family: monospace;
-    font-weight: bold;
-    white-space: nowrap;
-    text-indent: 0;
+  display: inline-block;
+  font-family: monospace;
+  font-weight: bold;
+  white-space: nowrap;
+  text-indent: 0;
 }
 
 emu-production emu-t {
-    margin-right: 1ex;
+  margin-right: 0.5ex;
 }
 
 emu-rhs {
-    display: block;
-    padding-left: 75px;
-    text-indent: -25px;
+  display: block;
+  padding-left: 75px;
+  text-indent: -25px;
+}
+
+emu-production:not([collapsed]) emu-rhs {
+  border: 0.2ex dashed transparent;
+}
+
+emu-production:not([collapsed]) emu-rhs:hover {
+  border-color: #888;
+  background-color: #f0f0f0;
 }
 
 emu-mods {
-    font-size: .85em;
-    vertical-align: sub;
-    font-style: normal;
-    font-weight: normal;
+  font-size: 0.85em;
+  vertical-align: sub;
+  font-style: normal;
+  font-weight: normal;
 }
 
-emu-params, emu-opt {
+emu-params,
+emu-opt {
   margin-right: 1ex;
   font-family: monospace;
 }
 
-emu-params, emu-constraints {
+emu-params,
+emu-constraints {
   color: #2aa198;
 }
 
@@ -1191,12 +1740,12 @@ emu-opt {
 }
 
 emu-gprose {
-    font-size: 0.9em;
-    font-family: Helvetica, Arial, sans-serif;
+  font-size: 0.9em;
+  font-family: Helvetica, Arial, sans-serif;
 }
 
 emu-production emu-gprose {
-    margin-right: 1ex;
+  margin-right: 1ex;
 }
 
 h1.shortname {
@@ -1208,20 +1757,19 @@ h1.shortname {
 h1.version {
   color: #f60;
   font-size: 1.5em;
-  margin: 0;
 }
 
 h1.title {
-  margin-top: 0;
   color: #f60;
 }
 
-h1.first {
-  margin-top: 0;
-}
-
-h1, h2, h3, h4, h5, h6 {
-    position: relative;
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  position: relative;
 }
 
 h1 .secnum {
@@ -1233,142 +1781,267 @@ h1 span.title {
   order: 2;
 }
 
+h1 {
+  font-size: 2.67em;
+  margin-bottom: 0;
+  line-height: 1em;
+}
+h2 {
+  font-size: 2em;
+}
+h3 {
+  font-size: 1.56em;
+}
+h4 {
+  font-size: 1.25em;
+}
+h5 {
+  font-size: 1.11em;
+}
+h6 {
+  font-size: 1em;
+}
 
-h1 { font-size: 2.67em; margin-top: 2em; margin-bottom: 0; line-height: 1em;}
-h2 { font-size: 2em; }
-h3 { font-size: 1.56em; }
-h4 { font-size: 1.25em; }
-h5 { font-size: 1.11em; }
-h6 { font-size: 1em; }
+pre code.hljs {
+  background: transparent;
+}
 
-h1:hover span.utils {
+emu-clause[id],
+emu-annex[id],
+emu-intro[id] {
+  scroll-margin-top: 2ex;
+}
+
+emu-intro h1,
+emu-clause h1,
+emu-annex h1 {
+  font-size: 2em;
+}
+emu-intro h2,
+emu-clause h2,
+emu-annex h2 {
+  font-size: 1.56em;
+}
+emu-intro h3,
+emu-clause h3,
+emu-annex h3 {
+  font-size: 1.25em;
+}
+emu-intro h4,
+emu-clause h4,
+emu-annex h4 {
+  font-size: 1.11em;
+}
+emu-intro h5,
+emu-clause h5,
+emu-annex h5 {
+  font-size: 1em;
+}
+emu-intro h6,
+emu-clause h6,
+emu-annex h6 {
+  font-size: 0.9em;
+}
+emu-intro emu-intro h1,
+emu-clause emu-clause h1,
+emu-annex emu-annex h1 {
+  font-size: 1.56em;
+}
+emu-intro emu-intro h2,
+emu-clause emu-clause h2,
+emu-annex emu-annex h2 {
+  font-size: 1.25em;
+}
+emu-intro emu-intro h3,
+emu-clause emu-clause h3,
+emu-annex emu-annex h3 {
+  font-size: 1.11em;
+}
+emu-intro emu-intro h4,
+emu-clause emu-clause h4,
+emu-annex emu-annex h4 {
+  font-size: 1em;
+}
+emu-intro emu-intro h5,
+emu-clause emu-clause h5,
+emu-annex emu-annex h5 {
+  font-size: 0.9em;
+}
+emu-intro emu-intro emu-intro h1,
+emu-clause emu-clause emu-clause h1,
+emu-annex emu-annex emu-annex h1 {
+  font-size: 1.25em;
+}
+emu-intro emu-intro emu-intro h2,
+emu-clause emu-clause emu-clause h2,
+emu-annex emu-annex emu-annex h2 {
+  font-size: 1.11em;
+}
+emu-intro emu-intro emu-intro h3,
+emu-clause emu-clause emu-clause h3,
+emu-annex emu-annex emu-annex h3 {
+  font-size: 1em;
+}
+emu-intro emu-intro emu-intro h4,
+emu-clause emu-clause emu-clause h4,
+emu-annex emu-annex emu-annex h4 {
+  font-size: 0.9em;
+}
+emu-intro emu-intro emu-intro emu-intro h1,
+emu-clause emu-clause emu-clause emu-clause h1,
+emu-annex emu-annex emu-annex emu-annex h1 {
+  font-size: 1.11em;
+}
+emu-intro emu-intro emu-intro emu-intro h2,
+emu-clause emu-clause emu-clause emu-clause h2,
+emu-annex emu-annex emu-annex emu-annex h2 {
+  font-size: 1em;
+}
+emu-intro emu-intro emu-intro emu-intro h3,
+emu-clause emu-clause emu-clause emu-clause h3,
+emu-annex emu-annex emu-annex emu-annex h3 {
+  font-size: 0.9em;
+}
+emu-intro emu-intro emu-intro emu-intro emu-intro h1,
+emu-clause emu-clause emu-clause emu-clause emu-clause h1,
+emu-annex emu-annex emu-annex emu-annex emu-annex h1 {
+  font-size: 1em;
+}
+emu-intro emu-intro emu-intro emu-intro emu-intro h2,
+emu-clause emu-clause emu-clause emu-clause emu-clause h2,
+emu-annex emu-annex emu-annex emu-annex emu-annex h2 {
+  font-size: 0.9em;
+}
+emu-intro emu-intro emu-intro emu-intro emu-intro emu-intro h1,
+emu-clause emu-clause emu-clause emu-clause emu-clause emu-clause h1,
+emu-annex emu-annex emu-annex emu-annex emu-annex emu-annex h1 {
+  font-size: 0.9em;
+}
+
+emu-clause,
+emu-intro,
+emu-annex {
   display: block;
 }
 
-span.utils {
-  font-size: 18px;
-  line-height: 18px;
-  display: none;
-  position: absolute;
-  top: 100%;
-  left: 0;
-  right: 0;
-  font-weight: normal;
+/* these values are twice the font-size for the <h1> titles for clauses */
+emu-intro,
+emu-clause,
+emu-annex {
+  margin-top: 4em;
+}
+emu-intro emu-intro,
+emu-clause emu-clause,
+emu-annex emu-annex {
+  margin-top: 3.12em;
+}
+emu-intro emu-intro emu-intro,
+emu-clause emu-clause emu-clause,
+emu-annex emu-annex emu-annex {
+  margin-top: 2.5em;
+}
+emu-intro emu-intro emu-intro emu-intro,
+emu-clause emu-clause emu-clause emu-clause,
+emu-annex emu-annex emu-annex emu-annex {
+  margin-top: 2.22em;
+}
+emu-intro emu-intro emu-intro emu-intro emu-intro,
+emu-clause emu-clause emu-clause emu-clause emu-clause,
+emu-annex emu-annex emu-annex emu-annex emu-annex {
+  margin-top: 2em;
+}
+emu-intro emu-intro emu-intro emu-intro emu-intro emu-intro,
+emu-clause emu-clause emu-clause emu-clause emu-clause emu-clause,
+emu-annex emu-annex emu-annex emu-annex emu-annex emu-annex {
+  margin-top: 1.8em;
 }
 
-span.utils:before {
-    content: "⤷";
-    display: inline-block;
-    padding: 0 5px;
-}
-
-span.utils > * {
-  display: inline-block;
-  margin-right: 20px;
-}
-
-h1 span.utils span.anchor a,
-h2 span.utils span.anchor a,
-h3 span.utils span.anchor a,
-h4 span.utils span.anchor a,
-h5 span.utils span.anchor a,
-h6 span.utils span.anchor a {
-  text-decoration: none;
-  font-variant: small-caps;
-}
-
-h1 span.utils span.anchor a:hover,
-h2 span.utils span.anchor a:hover,
-h3 span.utils span.anchor a:hover,
-h4 span.utils span.anchor a:hover,
-h5 span.utils span.anchor a:hover,
-h6 span.utils span.anchor a:hover {
-  color: #333;
-}
-
-emu-intro h1, emu-clause h1, emu-annex h1 { font-size: 2em; }
-emu-intro h2, emu-clause h2, emu-annex h2 { font-size: 1.56em; }
-emu-intro h3, emu-clause h3, emu-annex h3 { font-size: 1.25em; }
-emu-intro h4, emu-clause h4, emu-annex h4 { font-size: 1.11em; }
-emu-intro h5, emu-clause h5, emu-annex h5 { font-size: 1em; }
-emu-intro h6, emu-clause h6, emu-annex h6 { font-size: 0.9em; }
-emu-intro emu-intro h1, emu-clause emu-clause h1, emu-annex emu-annex h1 { font-size: 1.56em; }
-emu-intro emu-intro h2, emu-clause emu-clause h2, emu-annex emu-annex h2 { font-size: 1.25em; }
-emu-intro emu-intro h3, emu-clause emu-clause h3, emu-annex emu-annex h3 { font-size: 1.11em; }
-emu-intro emu-intro h4, emu-clause emu-clause h4, emu-annex emu-annex h4 { font-size: 1em; }
-emu-intro emu-intro h5, emu-clause emu-clause h5, emu-annex emu-annex h5 { font-size: 0.9em; }
-emu-intro emu-intro emu-intro h1, emu-clause emu-clause emu-clause h1, emu-annex emu-annex emu-annex h1 { font-size: 1.25em; }
-emu-intro emu-intro emu-intro h2, emu-clause emu-clause emu-clause h2, emu-annex emu-annex emu-annex h2 { font-size: 1.11em; }
-emu-intro emu-intro emu-intro h3, emu-clause emu-clause emu-clause h3, emu-annex emu-annex emu-annex h3 { font-size: 1em; }
-emu-intro emu-intro emu-intro h4, emu-clause emu-clause emu-clause h4, emu-annex emu-annex emu-annex h4 { font-size: 0.9em; }
-emu-intro emu-intro emu-intro emu-intro h1, emu-clause emu-clause emu-clause emu-clause h1, emu-annex emu-annex emu-annex emu-annex h1 { font-size: 1.11em; }
-emu-intro emu-intro emu-intro emu-intro h2, emu-clause emu-clause emu-clause emu-clause h2, emu-annex emu-annex emu-annex emu-annex h2 { font-size: 1em; }
-emu-intro emu-intro emu-intro emu-intro h3, emu-clause emu-clause emu-clause emu-clause h3, emu-annex emu-annex emu-annex emu-annex h3 { font-size: 0.9em; }
-emu-intro emu-intro emu-intro emu-intro emu-intro h1, emu-clause emu-clause emu-clause emu-clause emu-clause h1, emu-annex emu-annex emu-annex emu-annex emu-annex h1 { font-size: 1em; }
-emu-intro emu-intro emu-intro emu-intro emu-intro h2, emu-clause emu-clause emu-clause emu-clause emu-clause h2, emu-annex emu-annex emu-annex emu-annex emu-annex h2 { font-size: 0.9em; }
-emu-intro emu-intro emu-intro emu-intro emu-intro emu-intro h1, emu-clause emu-clause emu-clause emu-clause emu-clause emu-clause h1, emu-annex emu-annex emu-annex emu-annex emu-annex emu-annex h1 { font-size: 0.9em }
-
-emu-clause, emu-intro, emu-annex {
-    display: block;
+#spec-container > emu-intro:first-of-type,
+#spec-container > emu-clause:first-of-type,
+#spec-container > emu-annex:first-of-type {
+  margin-top: 0;
 }
 
 /* Figures and tables */
-figure { display: block; margin: 1em 0 3em 0; }
-figure object { display: block; margin: 0 auto; }
-figure table.real-table { margin: 0 auto; }
+figure {
+  display: block;
+  margin: 1em 0 3em 0;
+}
+figure object {
+  display: block;
+  margin: 0 auto;
+}
+figure table.real-table {
+  margin: 0 auto;
+}
 figure figcaption {
-    display: block;
-    color: #555555;
-    font-weight: bold;
-    text-align: center;
+  display: block;
+  color: #555555;
+  font-weight: bold;
+  text-align: center;
 }
 
 emu-table table {
   margin: 0 auto;
 }
 
-emu-table table, table.real-table {
-    border-collapse: collapse;
+emu-table table,
+table.real-table {
+  border-collapse: collapse;
 }
 
-emu-table td, emu-table th, table.real-table td, table.real-table th {
-    border: 1px solid black;
-    padding: 0.4em;
-    vertical-align: baseline;
+emu-table td,
+emu-table th,
+table.real-table td,
+table.real-table th {
+  border: 1px solid black;
+  padding: 0.4em;
+  vertical-align: baseline;
 }
-emu-table th, emu-table thead td, table.real-table th {
-    background-color: #eeeeee;
+emu-table th,
+emu-table thead td,
+table.real-table th {
+  background-color: #eeeeee;
+}
+
+emu-table td {
+  background: #fff;
 }
 
 /* Note: the left content edges of table.lightweight-table >tbody >tr >td
    and div.display line up. */
 table.lightweight-table {
-    border-collapse: collapse;
-    margin: 0 0 0 1.5em;
+  border-collapse: collapse;
+  margin: 0 0 0 1.5em;
 }
-table.lightweight-table td, table.lightweight-table th {
-    border: none;
-    padding: 0 0.5em;
-    vertical-align: baseline;
+table.lightweight-table td,
+table.lightweight-table th {
+  border: none;
+  padding: 0 0.5em;
+  vertical-align: baseline;
 }
 
 /* diff styles */
 ins {
-    background-color: #e0f8e0;
-    text-decoration: none;
-    border-bottom: 1px solid #396;
+  background-color: #e0f8e0;
+  text-decoration: none;
+  border-bottom: 1px solid #396;
 }
 
 del {
-    background-color: #fee;
+  background-color: #fee;
 }
 
-ins.block, del.block,
-emu-production > ins, emu-production > del,
-emu-grammar > ins, emu-grammar > del {
+ins.block,
+del.block,
+emu-production > ins,
+emu-production > del,
+emu-grammar > ins,
+emu-grammar > del {
   display: block;
 }
-emu-rhs > ins, emu-rhs > del { 
+emu-rhs > ins,
+emu-rhs > del {
   display: inline;
 }
 
@@ -1405,7 +2078,7 @@ tr.del > td {
   -khtml-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
-  user-select: none;;
+  user-select: none;
 
   cursor: pointer;
 }
@@ -1413,7 +2086,8 @@ tr.del > td {
 #menu {
   display: flex;
   flex-direction: column;
-  width: 33%; height: 100vh;
+  width: 33%;
+  height: 100vh;
   max-width: 500px;
   box-sizing: border-box;
   background-color: #ddd;
@@ -1421,13 +2095,14 @@ tr.del > td {
   transition: opacity 0.1s linear;
   padding: 0 5px;
   position: fixed;
-  left: 0; top: 0;
+  left: 0;
+  top: 0;
   border-right: 2px solid #bbb;
 
   z-index: 2;
 }
 
-#menu-spacer {
+.menu-spacer {
   flex-basis: 33%;
   max-width: 500px;
   flex-grow: 0;
@@ -1482,7 +2157,8 @@ tr.del > td {
   padding: 0;
 }
 
-#menu-toc > ol , #menu-toc > ol ol {
+#menu-toc > ol,
+#menu-toc > ol ol {
   list-style-type: none;
   margin: 0;
   padding: 0;
@@ -1512,7 +2188,7 @@ tr.del > td {
   -khtml-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
-  user-select: none;;
+  user-select: none;
 
   cursor: pointer;
 }
@@ -1543,7 +2219,7 @@ tr.del > td {
   */
 }
 
-#menu-toc li.revealed-leaf> a {
+#menu-toc li.revealed-leaf > a {
   color: #206ca7;
   /*
   background-color: #222;
@@ -1579,6 +2255,34 @@ tr.del > td {
   font-size: 0.8em;
 }
 
+.menu-pane-header emu-opt,
+.menu-pane-header emu-t,
+.menu-pane-header emu-nt {
+  margin-right: 0px;
+  display: inline;
+  color: inherit;
+}
+
+.menu-pane-header emu-rhs {
+  display: inline;
+  padding-left: 0px;
+  text-indent: 0px;
+}
+
+.menu-pane-header emu-geq {
+  margin-left: 0px;
+}
+
+a.menu-pane-header-production {
+  color: inherit;
+}
+
+.menu-pane-header-production {
+  text-transform: none;
+  letter-spacing: 1.5px;
+  padding-left: 0.5em;
+}
+
 #menu-toc {
   display: flex;
   flex-direction: column;
@@ -1597,10 +2301,10 @@ tr.del > td {
   flex-grow: 0;
   flex-shrink: 0;
   width: 100%;
-  
+
   display: flex;
   flex-direction: column;
-  
+
   max-height: 300px;
 }
 
@@ -1625,43 +2329,42 @@ tr.del > td {
 }
 
 li.menu-search-result-clause:before {
-    content: 'clause';
-    width: 40px;
-    display: inline-block;
-    text-align: right;
-    padding-right: 1ex;
-    color: #666;
-    font-size: 75%;
+  content: 'clause';
+  width: 40px;
+  display: inline-block;
+  text-align: right;
+  padding-right: 1ex;
+  color: #666;
+  font-size: 75%;
 }
 li.menu-search-result-op:before {
-    content: 'op';
-    width: 40px;
-    display: inline-block;
-    text-align: right;
-    padding-right: 1ex;
-    color: #666;
-    font-size: 75%;
+  content: 'op';
+  width: 40px;
+  display: inline-block;
+  text-align: right;
+  padding-right: 1ex;
+  color: #666;
+  font-size: 75%;
 }
 
 li.menu-search-result-prod:before {
-    content: 'prod';
-    width: 40px;
-    display: inline-block;
-    text-align: right;
-    padding-right: 1ex;
-    color: #666;
-    font-size: 75%
+  content: 'prod';
+  width: 40px;
+  display: inline-block;
+  text-align: right;
+  padding-right: 1ex;
+  color: #666;
+  font-size: 75%;
 }
 
-
 li.menu-search-result-term:before {
-    content: 'term';
-    width: 40px;
-    display: inline-block;
-    text-align: right;
-    padding-right: 1ex;
-    color: #666;
-    font-size: 75%
+  content: 'term';
+  width: 40px;
+  display: inline-block;
+  text-align: right;
+  padding-right: 1ex;
+  color: #666;
+  font-size: 75%;
 }
 
 #menu-search-results ul {
@@ -1674,7 +2377,6 @@ li.menu-search-result-term:before {
   text-overflow: ellipsis;
 }
 
-
 #menu-trace-list {
   counter-reset: item;
   margin: 0 0 0 20px;
@@ -1686,19 +2388,19 @@ li.menu-search-result-term:before {
 }
 
 #menu-trace-list li .secnum:after {
-  content: " ";
+  content: ' ';
 }
 #menu-trace-list li:before {
-    content: counter(item) " ";
-    background-color: #222;
-    counter-increment: item;
-    color: #999;
-    width: 20px;
-    height: 20px;
-    line-height: 20px;
-    display: inline-block;
-    text-align: center;
-    margin: 2px 4px 2px 0;
+  content: counter(item) ' ';
+  background-color: #222;
+  counter-increment: item;
+  color: #999;
+  width: 20px;
+  height: 20px;
+  line-height: 20px;
+  display: inline-block;
+  text-align: center;
+  margin: 2px 4px 2px 0;
 }
 
 @media (max-width: 1000px) {
@@ -1740,24 +2442,29 @@ li.menu-search-result-term:before {
   }
 
   h1 .secnum:empty {
-    margin: 0; padding: 0;
+    margin: 0;
+    padding: 0;
   }
 }
 
-
 /* Toolbox */
-.toolbox {
-	position: absolute;
-	background: #ddd;
-	border: 1px solid #aaa;
+.toolbox-container {
+  position: absolute;
   display: none;
+  padding-bottom: 7px;
+}
+
+.toolbox-container.active {
+  display: inline-block;
+}
+
+.toolbox {
+  position: relative;
+  background: #ddd;
+  border: 1px solid #aaa;
   color: #eee;
   padding: 5px;
   border-radius: 3px;
-}
-
-.toolbox.active {
-  display: inline-block;
 }
 
 .toolbox a {
@@ -1769,28 +2476,29 @@ li.menu-search-result-term:before {
   text-decoration: underline;
 }
 
-.toolbox:after, .toolbox:before {
-	top: 100%;
-	left: 15px;
-	border: solid transparent;
-	content: " ";
-	height: 0;
-	width: 0;
-	position: absolute;
-	pointer-events: none;
+.toolbox:after,
+.toolbox:before {
+  top: 100%;
+  left: 15px;
+  border: solid transparent;
+  content: ' ';
+  height: 0;
+  width: 0;
+  position: absolute;
+  pointer-events: none;
 }
 
 .toolbox:after {
-	border-color: rgba(0, 0, 0, 0);
-	border-top-color: #ddd;
-	border-width: 10px;
-	margin-left: -10px;
+  border-color: rgba(0, 0, 0, 0);
+  border-top-color: #ddd;
+  border-width: 10px;
+  margin-left: -10px;
 }
 .toolbox:before {
-	border-color: rgba(204, 204, 204, 0);
-	border-top-color: #aaa;
-	border-width: 12px;
-	margin-left: -12px;
+  border-color: rgba(204, 204, 204, 0);
+  border-top-color: #aaa;
+  border-width: 12px;
+  margin-left: -12px;
 }
 
 #references-pane-container {
@@ -1807,11 +2515,6 @@ li.menu-search-result-term:before {
 #references-pane-table-container {
   overflow-x: hidden;
   overflow-y: auto;
-}
-
-#references-pane-spacer {
-  flex-basis: 33%;
-  max-width: 500px;
 }
 
 #references-pane {
@@ -1831,6 +2534,10 @@ li.menu-search-result-term:before {
   cursor: pointer;
 }
 
+#references-pane table tbody {
+  vertical-align: baseline;
+}
+
 #references-pane table tr td:first-child {
   text-align: right;
   padding-right: 5px;
@@ -1838,43 +2545,94 @@ li.menu-search-result-term:before {
 
 @media print {
   #menu-toggle {
-    display: none; 
+    display: none;
   }
 }
-</style></head><body><div id="menu-toggle">☰</div><div id="menu-spacer"></div><div id="menu"><div id="menu-search"><input type="text" id="menu-search-box" placeholder="Search..."><div id="menu-search-results" class="inactive"></div></div><div id="menu-pins"><div class="menu-pane-header">Pins</div><ul id="menu-pins-list"></ul></div><div class="menu-pane-header">Table of Contents</div><div id="menu-toc"><ol class="toc"><li><span class="item-toggle">◢</span><a href="#locale-and-parameter-negotiation" title="Locale and Parameter Negotiation"><span class="secnum">1</span> Locale and Parameter Negotiation</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-internal-slots" title="Internal slots of Service Constructors"><span class="secnum">1.1</span> Internal slots of Service Constructors</a></li><li><span class="item-toggle">◢</span><a href="#sec-abstract-operations" title="Abstract Operations"><span class="secnum">1.2</span> Abstract Operations</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-canonicalizelocalelist" title="CanonicalizeLocaleList ( locales )"><span class="secnum">1.2.1</span> CanonicalizeLocaleList ( <var>locales</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-bestavailablelocale" title="BestAvailableLocale ( availableLocales, locale )"><span class="secnum">1.2.2</span> BestAvailableLocale ( <var>availableLocales</var>, <var>locale</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-lookupmatcher" title="LookupMatcher ( availableLocales, requestedLocales )"><span class="secnum">1.2.3</span> LookupMatcher ( <var>availableLocales</var>, <var>requestedLocales</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-bestfitmatcher" title="BestFitMatcher ( availableLocales, requestedLocales )"><span class="secnum">1.2.4</span> BestFitMatcher ( <var>availableLocales</var>, <var>requestedLocales</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-unicode-extension-components" title="UnicodeExtensionComponents ( extension )"><span class="secnum">1.2.5</span> UnicodeExtensionComponents ( <var>extension</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-insert-unicode-extension-and-canonicalize" title="InsertUnicodeExtensionAndCanonicalize ( locale, extension )"><span class="secnum">1.2.6</span> InsertUnicodeExtensionAndCanonicalize ( <var>locale</var>, <var>extension</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-resolvelocale" title="ResolveLocale ( availableLocales, requestedLocales, options, relevantExtensionKeys, localeData )"><span class="secnum">1.2.7</span> ResolveLocale ( <var>availableLocales</var>, <var>requestedLocales</var>, <var>options</var>, <var>relevantExtensionKeys</var>, <var>localeData</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-lookupsupportedlocales" title="LookupSupportedLocales ( availableLocales, requestedLocales )"><span class="secnum">1.2.8</span> LookupSupportedLocales ( <var>availableLocales</var>, <var>requestedLocales</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-bestfitsupportedlocales" title="BestFitSupportedLocales ( availableLocales, requestedLocales )"><span class="secnum">1.2.9</span> BestFitSupportedLocales ( <var>availableLocales</var>, <var>requestedLocales</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-supportedlocales" title="SupportedLocales ( availableLocales, requestedLocales, options )"><span class="secnum">1.2.10</span> SupportedLocales ( <var>availableLocales</var>, <var>requestedLocales</var>, <var>options</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-getoptionsobject" title="GetOptionsObject ( options )"><span class="secnum">1.2.11</span> GetOptionsObject ( <var>options</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-coerceoptionstoobject" title="CoerceOptionsToObject ( options )"><span class="secnum">1.2.12</span> CoerceOptionsToObject ( <var>options</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-getoption" title="
-        GetOption (
-          options: an Object,
-          property: a property key,
-          type: boolean, number, or string,
-          values: empty or a List of ECMAScript language values,
-          default: required or an ECMAScript language value,
-        )
-      "><span class="secnum">1.2.13</span> 
-        GetOption (
-          <var>options</var>: an Object,
-          <var>property</var>: a property key,
-          <var>type</var>: <emu-const>boolean</emu-const>, <emu-const>number</emu-const>, or <emu-const>string</emu-const>,
-          <var>values</var>: <emu-const>empty</emu-const> or a List of ECMAScript language values,
-          <var>default</var>: <emu-const>required</emu-const> or an ECMAScript language value,
-        )
-      </a></li><li><span class="item-toggle-none"></span><a href="#sec-getstringorbooleanoption" title="GetStringOrBooleanOption ( options, property, values, trueValue, falsyValue, fallback )"><span class="secnum">1.2.14</span> GetStringOrBooleanOption ( <var>options</var>, <var>property</var>, <var>values</var>, <var>trueValue</var>, <var>falsyValue</var>, <var>fallback</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-defaultnumberoption" title="DefaultNumberOption ( value, minimum, maximum, fallback )"><span class="secnum">1.2.15</span> DefaultNumberOption ( <var>value</var>, <var>minimum</var>, <var>maximum</var>, <var>fallback</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-getnumberoption" title="GetNumberOption ( options, property, minimum, maximum, fallback )"><span class="secnum">1.2.16</span> GetNumberOption ( <var>options</var>, <var>property</var>, <var>minimum</var>, <var>maximum</var>, <var>fallback</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-partitionpattern" title="PartitionPattern ( pattern )"><span class="secnum">1.2.17</span> PartitionPattern ( <var>pattern</var> )</a></li></ol></li></ol></li></ol></div></div><div id="spec-container"><emu-clause id="locale-and-parameter-negotiation">
-  <h1 class="first"><span class="secnum">1</span> Locale and Parameter Negotiation</h1>
+
+[normative-optional],
+[legacy] {
+  border-left: 5px solid #ff6600;
+  padding: 0.5em;
+  display: block;
+  background: #ffeedd;
+}
+
+.clause-attributes-tag {
+  text-transform: uppercase;
+  color: #884400;
+}
+
+.clause-attributes-tag a {
+  color: #884400;
+}
+
+/* Shortcuts help dialog */
+
+#shortcuts-help {
+  position: fixed;
+  left: 5%;
+  margin: 0 auto;
+  right: 5%;
+  z-index: 10;
+  top: 10%;
+  top: calc(5vw + 5vh);
+  padding: 30px 90px;
+  max-width: 500px;
+  outline: solid 10000px rgba(255, 255, 255, 0.6);
+  border-radius: 5px;
+  border-width: 1px 1px 0 1px;
+  background-color: #ddd;
+  display: none;
+}
+
+#shortcuts-help.active {
+  display: block;
+}
+
+#shortcuts-help ul {
+  padding: 0;
+}
+
+#shortcuts-help li {
+  display: flex;
+  justify-content: space-between;
+}
+
+#shortcuts-help code {
+  padding: 3px 10px;
+  border-radius: 3px;
+  border-width: 1px 1px 0 1px;
+  border-color: #bbb;
+  background-color: #eee;
+  box-shadow: inset 0 -1px 0 #ccc;
+}
+</style></head><body><div id="shortcuts-help">
+<ul>
+  <li><span>Toggle shortcuts help</span><code>?</code></li>
+  <li><span>Toggle "can call user code" annotations</span><code>u</code></li>
+
+  <li><span>Jump to search box</span><code>/</code></li>
+</ul></div><div id="menu-toggle"><svg xmlns="http://www.w3.org/2000/svg" style="width:100%; height:100%; stroke:currentColor" viewBox="0 0 120 120">
+      <title>Menu</title>
+      <path stroke-width="10" stroke-linecap="round" d="M30,60 h60  M30,30 m0,5 h60  M30,90 m0,-5 h60"></path>
+    </svg></div><div id="menu-spacer" class="menu-spacer"></div><div id="menu"><div id="menu-search"><input type="text" id="menu-search-box" placeholder="Search..."><div id="menu-search-results" class="inactive"></div></div><div id="menu-pins"><div class="menu-pane-header">Pins</div><ul id="menu-pins-list"></ul></div><div class="menu-pane-header">Table of Contents</div><div id="menu-toc"><ol class="toc"><li><span class="item-toggle">◢</span><a href="#locale-and-parameter-negotiation" title="Locale and Parameter Negotiation"><span class="secnum">1</span> Locale and Parameter Negotiation</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-internal-slots" title="Internal slots of Service Constructors"><span class="secnum">1.1</span> Internal slots of Service Constructors</a></li><li><span class="item-toggle">◢</span><a href="#sec-abstract-operations" title="Abstract Operations"><span class="secnum">1.2</span> Abstract Operations</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-canonicalizelocalelist" title="CanonicalizeLocaleList ( locales )"><span class="secnum">1.2.1</span> CanonicalizeLocaleList ( <var>locales</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-bestavailablelocale" title="BestAvailableLocale ( availableLocales, locale )"><span class="secnum">1.2.2</span> BestAvailableLocale ( <var>availableLocales</var>, <var>locale</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-lookupmatcher" title="LookupMatcher ( availableLocales, requestedLocales )"><span class="secnum">1.2.3</span> LookupMatcher ( <var>availableLocales</var>, <var>requestedLocales</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-bestfitmatcher" title="BestFitMatcher ( availableLocales, requestedLocales )"><span class="secnum">1.2.4</span> BestFitMatcher ( <var>availableLocales</var>, <var>requestedLocales</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-unicode-extension-components" title="UnicodeExtensionComponents ( extension )"><span class="secnum">1.2.5</span> UnicodeExtensionComponents ( <var>extension</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-insert-unicode-extension-and-canonicalize" title="InsertUnicodeExtensionAndCanonicalize ( locale, extension )"><span class="secnum">1.2.6</span> InsertUnicodeExtensionAndCanonicalize ( <var>locale</var>, <var>extension</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-resolvelocale" title="ResolveLocale ( availableLocales, requestedLocales, options, relevantExtensionKeys, localeData )"><span class="secnum">1.2.7</span> ResolveLocale ( <var>availableLocales</var>, <var>requestedLocales</var>, <var>options</var>, <var>relevantExtensionKeys</var>, <var>localeData</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-lookupsupportedlocales" title="LookupSupportedLocales ( availableLocales, requestedLocales )"><span class="secnum">1.2.8</span> LookupSupportedLocales ( <var>availableLocales</var>, <var>requestedLocales</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-bestfitsupportedlocales" title="BestFitSupportedLocales ( availableLocales, requestedLocales )"><span class="secnum">1.2.9</span> BestFitSupportedLocales ( <var>availableLocales</var>, <var>requestedLocales</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-supportedlocales" title="SupportedLocales ( availableLocales, requestedLocales, options )"><span class="secnum">1.2.10</span> SupportedLocales ( <var>availableLocales</var>, <var>requestedLocales</var>, <var>options</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-getoptionsobject" title="GetOptionsObject ( options )"><span class="secnum">1.2.11</span> GetOptionsObject ( <var>options</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-coerceoptionstoobject" title="CoerceOptionsToObject ( options )"><span class="secnum">1.2.12</span> CoerceOptionsToObject ( <var>options</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-getoption" title="GetOption ( options, property, type, values, default )"><span class="secnum">1.2.13</span> GetOption ( <var>options</var>, <var>property</var>, <var>type</var>, <var>values</var>, <var>default</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-getbooleanorstringnumberformatoption" title="GetBooleanOrStringNumberFormatOption ( options, property, stringValues, fallback )"><span class="secnum">1.2.14</span> GetBooleanOrStringNumberFormatOption ( <var>options</var>, <var>property</var>, <var>stringValues</var>, <var>fallback</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-defaultnumberoption" title="DefaultNumberOption ( value, minimum, maximum, fallback )"><span class="secnum">1.2.15</span> DefaultNumberOption ( <var>value</var>, <var>minimum</var>, <var>maximum</var>, <var>fallback</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-getnumberoption" title="GetNumberOption ( options, property, minimum, maximum, fallback )"><span class="secnum">1.2.16</span> GetNumberOption ( <var>options</var>, <var>property</var>, <var>minimum</var>, <var>maximum</var>, <var>fallback</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-partitionpattern" title="PartitionPattern ( pattern )"><span class="secnum">1.2.17</span> PartitionPattern ( <var>pattern</var> )</a></li></ol></li></ol></li></ol></div></div><div id="spec-container"><emu-clause id="locale-and-parameter-negotiation">
+  <h1><span class="secnum">1</span> Locale and Parameter Negotiation</h1>
 
   <p>
-    <emu-xref href="#service-constructor">Service constructors</emu-xref> use a common pattern to negotiate the requests represented by their <var>locales</var> and <var>options</var> arguments against the actual capabilities of their implementations. That common behaviour is explained here in terms of internal slots describing the capabilities and <emu-xref href="#sec-algorithm-conventions-abstract-operations"><a href="https://tc39.es/ecma262/#sec-algorithm-conventions-abstract-operations">abstract operations</a></emu-xref> using these internal slots.
+    <emu-xref href="#service-constructor">Service constructors</emu-xref> use a common pattern to negotiate the requests represented by their <var>locales</var> and <var>options</var> arguments against the actual capabilities of their implementations. That common behaviour is explained here in terms of internal slots describing the capabilities and abstract operations using these internal slots.
   </p>
 
   <emu-clause id="sec-internal-slots">
     <h1><span class="secnum">1.1</span> Internal slots of Service Constructors</h1>
 
     <p>
-      Each service <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> has the following internal slots:
+      Each service constructor has the following internal slots:
     </p>
 
     <ul>
-      <li>[[AvailableLocales]] is a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> that contains structurally valid (<emu-xref href="#sec-isstructurallyvalidlanguagetag"></emu-xref>) and canonicalized (<emu-xref href="#sec-canonicalizeunicodelocaleid"></emu-xref>) language tags identifying the locales for which the implementation provides the functionality of the constructed objects. Language tags on the list must not have a Unicode locale extension sequence. The list must include the value returned by the DefaultLocale abstract operation (<emu-xref href="#sec-defaultlocale"></emu-xref>), and must not include duplicates. Implementations must include in [[AvailableLocales]] locales that can serve as fallbacks in the algorithm used to resolve locales (see <emu-xref href="#sec-resolvelocale" id="_ref_0"><a href="#sec-resolvelocale">1.2.7</a></emu-xref>). For example, implementations that provide a <emu-val>"de-DE"</emu-val> locale must include a <emu-val>"de"</emu-val> locale that can serve as a fallback for requests such as <emu-val>"de-AT"</emu-val> and <emu-val>"de-CH"</emu-val>. For locales that include a script subtag in addition to language and region, the corresponding locale without a script subtag must also be supported; that is, if an implementation recognizes <emu-val>"zh-Hant-TW"</emu-val>, it is also expected to recognize <emu-val>"zh-TW"</emu-val>. The ordering of the locales within [[AvailableLocales]] is irrelevant.</li>
-      <li>[[RelevantExtensionKeys]] is a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> of keys of the language tag extensions defined in Unicode Technical Standard #35 that are relevant for the functionality of the constructed objects.</li>
-      <li>[[SortLocaleData]] and [[SearchLocaleData]] (for Intl.Collator) and [[LocaleData]] (for every other service <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref>) are records that have fields for each locale contained in [[AvailableLocales]]. The value of each of these fields must be a record that has fields for each key contained in [[RelevantExtensionKeys]]. The value of each of these fields must be a non-empty list of those values defined in Unicode Technical Standard #35 for the given key that are supported by the implementation for the given locale, with the first element providing the default value.</li>
+      <li>[[AvailableLocales]] is a List that contains structurally valid (<emu-xref href="#sec-isstructurallyvalidlanguagetag"></emu-xref>) and canonicalized (<emu-xref href="#sec-canonicalizeunicodelocaleid"></emu-xref>) language tags identifying the locales for which the implementation provides the functionality of the constructed objects. Language tags on the list must not have a Unicode locale extension sequence. The list must include the value returned by the DefaultLocale abstract operation (<emu-xref href="#sec-defaultlocale"></emu-xref>), and must not include duplicates. Implementations must include in [[AvailableLocales]] locales that can serve as fallbacks in the algorithm used to resolve locales (see <emu-xref href="#sec-resolvelocale" id="_ref_0"><a href="#sec-resolvelocale">1.2.7</a></emu-xref>). For example, implementations that provide a <emu-val>"de-DE"</emu-val> locale must include a <emu-val>"de"</emu-val> locale that can serve as a fallback for requests such as <emu-val>"de-AT"</emu-val> and <emu-val>"de-CH"</emu-val>. For locales that include a script subtag in addition to language and region, the corresponding locale without a script subtag must also be supported; that is, if an implementation recognizes <emu-val>"zh-Hant-TW"</emu-val>, it is also expected to recognize <emu-val>"zh-TW"</emu-val>. The ordering of the locales within [[AvailableLocales]] is irrelevant.</li>
+      <li>[[RelevantExtensionKeys]] is a List of keys of the language tag extensions defined in Unicode Technical Standard #35 that are relevant for the functionality of the constructed objects.</li>
+      <li>[[SortLocaleData]] and [[SearchLocaleData]] (for Intl.Collator) and [[LocaleData]] (for every other service constructor) are records that have fields for each locale contained in [[AvailableLocales]]. The value of each of these fields must be a record that has fields for each key contained in [[RelevantExtensionKeys]]. The value of each of these fields must be a non-empty list of those values defined in Unicode Technical Standard #35 for the given key that are supported by the implementation for the given locale, with the first element providing the default value.</li>
     </ul>
 
     <emu-note><span class="note">Note</span><div class="note-contents">
@@ -1888,7 +2646,7 @@ li.menu-search-result-term:before {
     <h1><span class="secnum">1.2</span> Abstract Operations</h1>
 
     <p>
-      Where the following <emu-xref href="#sec-algorithm-conventions-abstract-operations"><a href="https://tc39.es/ecma262/#sec-algorithm-conventions-abstract-operations">abstract operations</a></emu-xref> take an <var>availableLocales</var> argument, it must be an [[AvailableLocales]] <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> as specified in <emu-xref href="#sec-internal-slots" id="_ref_1"><a href="#sec-internal-slots">1.1</a></emu-xref>.
+      Where the following abstract operations take an <var>availableLocales</var> argument, it must be an [[AvailableLocales]] List as specified in <emu-xref href="#sec-internal-slots" id="_ref_1"><a href="#sec-internal-slots">1.1</a></emu-xref>.
     </p>
 
     <emu-clause id="sec-canonicalizelocalelist" aoid="CanonicalizeLocaleList">
@@ -1898,14 +2656,14 @@ li.menu-search-result-term:before {
         The abstract operation CanonicalizeLocaleList takes the following steps:
       </p>
 
-      <emu-alg><ol><li>If <var>locales</var> is <emu-val>undefined</emu-val>, then<ol><li>Return a new empty <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref>.</li></ol></li><li>Let <var>seen</var> be a new empty <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref>.</li><li>If <emu-xref aoid="Type" id="_ref_2"><a href="https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>locales</var>) is String or <emu-xref aoid="Type" id="_ref_3"><a href="https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>locales</var>) is Object and <var>locales</var> has an [[InitializedLocale]] internal slot, then<ol><li>Let <var>O</var> be <emu-xref aoid="CreateArrayFromList" id="_ref_4"><a href="https://tc39.es/ecma262/#sec-createarrayfromlist">CreateArrayFromList</a></emu-xref>(« <var>locales</var> »).</li></ol></li><li>Else,<ol><li>Let <var>O</var> be ?&nbsp;<emu-xref aoid="ToObject" id="_ref_5"><a href="https://tc39.es/ecma262/#sec-toobject">ToObject</a></emu-xref>(<var>locales</var>).</li></ol></li><li>Let <var>len</var> be ?&nbsp;<emu-xref aoid="ToLength" id="_ref_6"><a href="https://tc39.es/ecma262/#sec-tolength">ToLength</a></emu-xref>(? <emu-xref aoid="Get" id="_ref_7"><a href="https://tc39.es/ecma262/#sec-get-o-p">Get</a></emu-xref>(<var>O</var>, <emu-val>"length"</emu-val>)).</li><li>Let <var>k</var> be 0.</li><li>Repeat, while <var>k</var> &lt; <var>len</var>,<ol><li>Let <var>Pk</var> be !&nbsp;<emu-xref aoid="ToString" id="_ref_8"><a href="https://tc39.es/ecma262/#sec-tostring">ToString</a></emu-xref>(<var>k</var>).</li><li>Let <var>kPresent</var> be ?&nbsp;<emu-xref aoid="HasProperty" id="_ref_9"><a href="https://tc39.es/ecma262/#sec-hasproperty">HasProperty</a></emu-xref>(<var>O</var>, <var>Pk</var>).</li><li>If <var>kPresent</var> is <emu-val>true</emu-val>, then<ol><li>Let <var>kValue</var> be ?&nbsp;<emu-xref aoid="Get" id="_ref_10"><a href="https://tc39.es/ecma262/#sec-get-o-p">Get</a></emu-xref>(<var>O</var>, <var>Pk</var>).</li><li>If <emu-xref aoid="Type" id="_ref_11"><a href="https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>kValue</var>) is not String or Object, throw a <emu-val>TypeError</emu-val> exception.</li><li>If <emu-xref aoid="Type" id="_ref_12"><a href="https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>kValue</var>) is Object and <var>kValue</var> has an [[InitializedLocale]] internal slot, then<ol><li>Let <var>tag</var> be <var>kValue</var>.[[Locale]].</li></ol></li><li>Else,<ol><li>Let <var>tag</var> be ?&nbsp;<emu-xref aoid="ToString" id="_ref_13"><a href="https://tc39.es/ecma262/#sec-tostring">ToString</a></emu-xref>(<var>kValue</var>).</li></ol></li><li>If !&nbsp;IsStructurallyValidLanguageTag(<var>tag</var>) is <emu-val>false</emu-val>, throw a <emu-val>RangeError</emu-val> exception.</li><li>Let <var>canonicalizedTag</var> be !&nbsp;CanonicalizeUnicodeLocaleId(<var>tag</var>).</li><li>If <var>canonicalizedTag</var> is not an element of <var>seen</var>, append <var>canonicalizedTag</var> as the last element of <var>seen</var>.</li></ol></li><li>Increase <var>k</var> by 1.</li></ol></li><li>Return <var>seen</var>.</li></ol></emu-alg>
+      <emu-alg><ol><li>If <var>locales</var> is <emu-val>undefined</emu-val>, then<ol><li>Return a new empty List.</li></ol></li><li>Let <var>seen</var> be a new empty List.</li><li>If Type(<var>locales</var>) is String or Type(<var>locales</var>) is Object and <var>locales</var> has an [[InitializedLocale]] internal slot, then<ol><li>Let <var>O</var> be CreateArrayFromList(« <var>locales</var> »).</li></ol></li><li>Else,<ol><li>Let <var>O</var> be ?&nbsp;ToObject(<var>locales</var>).</li></ol></li><li>Let <var>len</var> be ?&nbsp;ToLength(? Get(<var>O</var>, <emu-val>"length"</emu-val>)).</li><li>Let <var>k</var> be 0.</li><li>Repeat, while <var>k</var> &lt; <var>len</var>,<ol><li>Let <var>Pk</var> be !&nbsp;ToString(<var>k</var>).</li><li>Let <var>kPresent</var> be ?&nbsp;HasProperty(<var>O</var>, <var>Pk</var>).</li><li>If <var>kPresent</var> is <emu-val>true</emu-val>, then<ol><li>Let <var>kValue</var> be ?&nbsp;Get(<var>O</var>, <var>Pk</var>).</li><li>If Type(<var>kValue</var>) is not String or Object, throw a <emu-val>TypeError</emu-val> exception.</li><li>If Type(<var>kValue</var>) is Object and <var>kValue</var> has an [[InitializedLocale]] internal slot, then<ol><li>Let <var>tag</var> be <var>kValue</var>.[[Locale]].</li></ol></li><li>Else,<ol><li>Let <var>tag</var> be ?&nbsp;ToString(<var>kValue</var>).</li></ol></li><li>If !&nbsp;IsStructurallyValidLanguageTag(<var>tag</var>) is <emu-val>false</emu-val>, throw a <emu-val>RangeError</emu-val> exception.</li><li>Let <var>canonicalizedTag</var> be !&nbsp;CanonicalizeUnicodeLocaleId(<var>tag</var>).</li><li>If <var>canonicalizedTag</var> is not an element of <var>seen</var>, append <var>canonicalizedTag</var> as the last element of <var>seen</var>.</li></ol></li><li>Increase <var>k</var> by 1.</li></ol></li><li>Return <var>seen</var>.</li></ol></emu-alg>
 
       <emu-note><span class="note">Note 1</span><div class="note-contents">
-        Non-normative summary: The abstract operation interprets the <var>locales</var> argument as an array and copies its elements into a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref>, validating the elements as structurally valid language tags and canonicalizing them, and omitting duplicates.
+        Non-normative summary: The abstract operation interprets the <var>locales</var> argument as an array and copies its elements into a List, validating the elements as structurally valid language tags and canonicalizing them, and omitting duplicates.
       </div></emu-note>
 
       <emu-note><span class="note">Note 2</span><div class="note-contents">
-        Requiring <var>kValue</var> to be a String or Object means that the <emu-xref href="#number-value"><a href="https://tc39.es/ecma262/#number-value">Number value</a></emu-xref> <emu-val>NaN</emu-val> will not be interpreted as the language tag <emu-val>"nan"</emu-val>, which stands for Min Nan Chinese.
+        Requiring <var>kValue</var> to be a String or Object means that the Number value <emu-val>NaN</emu-val> will not be interpreted as the language tag <emu-val>"nan"</emu-val>, which stands for Min Nan Chinese.
       </div></emu-note>
     </emu-clause>
 
@@ -1916,17 +2674,17 @@ li.menu-search-result-term:before {
         The BestAvailableLocale abstract operation compares the provided argument <var>locale</var>, which must be a String value with a structurally valid and canonicalized Unicode BCP 47 locale identifier, against the locales in <var>availableLocales</var> and returns either the longest non-empty prefix of <var>locale</var> that is an element of <var>availableLocales</var>, or <emu-val>undefined</emu-val> if there is no such element. It uses the fallback mechanism of RFC 4647, section 3.4. The following steps are taken:
       </p>
 
-      <emu-alg><ol><li>Let <var>candidate</var> be <var>locale</var>.</li><li>Repeat,<ol><li>If <var>availableLocales</var> contains an element equal to <var>candidate</var>, return <var>candidate</var>.</li><li>Let <var>pos</var> be the character index of the last occurrence of <emu-val>"-"</emu-val> (U+002D) within <var>candidate</var>. If that character does not occur, return <emu-val>undefined</emu-val>.</li><li>If <var>pos</var> ≥ 2 and the character <emu-val>"-"</emu-val> occurs at index <var>pos</var> - 2 of candidate, decrease <var>pos</var> by 2.</li><li>Let <var>candidate</var> be the substring of <var>candidate</var> from position 0, inclusive, to position <var>pos</var>, exclusive.</li></ol></li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>candidate</var> be <var>locale</var>.</li><li>Repeat,<ol><li>If <var>availableLocales</var> contains <var>candidate</var>, return <var>candidate</var>.</li><li>Let <var>pos</var> be the character index of the last occurrence of <emu-val>"-"</emu-val> (U+002D) within <var>candidate</var>. If that character does not occur, return <emu-val>undefined</emu-val>.</li><li>If <var>pos</var> ≥ 2 and the character <emu-val>"-"</emu-val> occurs at index <var>pos</var> - 2 of candidate, decrease <var>pos</var> by 2.</li><li>Let <var>candidate</var> be the substring of <var>candidate</var> from position 0, inclusive, to position <var>pos</var>, exclusive.</li></ol></li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-lookupmatcher" aoid="LookupMatcher">
       <h1><span class="secnum">1.2.3</span> LookupMatcher ( <var>availableLocales</var>, <var>requestedLocales</var> )</h1>
 
       <p>
-        The LookupMatcher abstract operation compares <var>requestedLocales</var>, which must be a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> as returned by <emu-xref aoid="CanonicalizeLocaleList" id="_ref_14"><a href="#sec-canonicalizelocalelist">CanonicalizeLocaleList</a></emu-xref>, against the locales in <var>availableLocales</var> and determines the best available language to meet the request. The following steps are taken:
+        The LookupMatcher abstract operation compares <var>requestedLocales</var>, which must be a List as returned by <emu-xref aoid="CanonicalizeLocaleList" id="_ref_2"><a href="#sec-canonicalizelocalelist">CanonicalizeLocaleList</a></emu-xref>, against the locales in <var>availableLocales</var> and determines the best available language to meet the request. The following steps are taken:
       </p>
 
-      <emu-alg><ol><li>Let <var>result</var> be a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref>.</li><li>For each element <var>locale</var> of <var>requestedLocales</var>, do<ol><li>Let <var>noExtensionsLocale</var> be the String value that is <var>locale</var> with any Unicode locale extension sequences removed.</li><li>Let <var>availableLocale</var> be !&nbsp;<emu-xref aoid="BestAvailableLocale" id="_ref_15"><a href="#sec-bestavailablelocale">BestAvailableLocale</a></emu-xref>(<var>availableLocales</var>, <var>noExtensionsLocale</var>).</li><li>If <var>availableLocale</var> is not <emu-val>undefined</emu-val>, then<ol><li>Set <var>result</var>.[[locale]] to <var>availableLocale</var>.</li><li>If <var>locale</var> and <var>noExtensionsLocale</var> are not the same String value, then<ol><li>Let <var>extension</var> be the String value consisting of the substring of the Unicode locale extension sequence within <var>locale</var>.</li><li>Set <var>result</var>.[[extension]] to <var>extension</var>.</li></ol></li><li>Return <var>result</var>.</li></ol></li></ol></li><li>Let <var>defLocale</var> be !&nbsp;DefaultLocale().</li><li>Set <var>result</var>.[[locale]] to <var>defLocale</var>.</li><li>Return <var>result</var>.</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>result</var> be a new Record.</li><li>For each element <var>locale</var> of <var>requestedLocales</var>, do<ol><li>Let <var>noExtensionsLocale</var> be the String value that is <var>locale</var> with any Unicode locale extension sequences removed.</li><li>Let <var>availableLocale</var> be !&nbsp;<emu-xref aoid="BestAvailableLocale" id="_ref_3"><a href="#sec-bestavailablelocale">BestAvailableLocale</a></emu-xref>(<var>availableLocales</var>, <var>noExtensionsLocale</var>).</li><li>If <var>availableLocale</var> is not <emu-val>undefined</emu-val>, then<ol><li>Set <var>result</var>.[[locale]] to <var>availableLocale</var>.</li><li>If <var>locale</var> and <var>noExtensionsLocale</var> are not the same String value, then<ol><li>Let <var>extension</var> be the String value consisting of the substring of the Unicode locale extension sequence within <var>locale</var>.</li><li>Set <var>result</var>.[[extension]] to <var>extension</var>.</li></ol></li><li>Return <var>result</var>.</li></ol></li></ol></li><li>Let <var>defLocale</var> be !&nbsp;DefaultLocale().</li><li>Set <var>result</var>.[[locale]] to <var>defLocale</var>.</li><li>Return <var>result</var>.</li></ol></emu-alg>
 
       <emu-note><span class="note">Note</span><div class="note-contents">
         The algorithm is based on the Lookup algorithm described in RFC 4647 section 3.4, but options specified through Unicode locale extension sequences are ignored in the lookup. Information about such subsequences is returned separately. The abstract operation returns a record with a [[locale]] field, whose value is the language tag of the selected locale, which must be an element of <var>availableLocales</var>. If the language tag of the request locale that led to the selected locale contained a Unicode locale extension sequence, then the returned record also contains an [[extension]] field whose value is the substring of the Unicode locale extension sequence within the request locale language tag.
@@ -1937,17 +2695,17 @@ li.menu-search-result-term:before {
       <h1><span class="secnum">1.2.4</span> BestFitMatcher ( <var>availableLocales</var>, <var>requestedLocales</var> )</h1>
 
       <p>
-        The BestFitMatcher abstract operation compares <var>requestedLocales</var>, which must be a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> as returned by <emu-xref aoid="CanonicalizeLocaleList" id="_ref_16"><a href="#sec-canonicalizelocalelist">CanonicalizeLocaleList</a></emu-xref>, against the locales in <var>availableLocales</var> and determines the best available language to meet the request. The algorithm is implementation dependent, but should produce results that a typical user of the requested locales would perceive as at least as good as those produced by the <emu-xref aoid="LookupMatcher" id="_ref_17"><a href="#sec-lookupmatcher">LookupMatcher</a></emu-xref> abstract operation. Options specified through Unicode locale extension sequences must be ignored by the algorithm. Information about such subsequences is returned separately. The abstract operation returns a record with a [[locale]] field, whose value is the language tag of the selected locale, which must be an element of <var>availableLocales</var>. If the language tag of the request locale that led to the selected locale contained a Unicode locale extension sequence, then the returned record also contains an [[extension]] field whose value is the substring of the Unicode locale extension sequence within the request locale language tag.
+        The BestFitMatcher abstract operation compares <var>requestedLocales</var>, which must be a List as returned by <emu-xref aoid="CanonicalizeLocaleList" id="_ref_4"><a href="#sec-canonicalizelocalelist">CanonicalizeLocaleList</a></emu-xref>, against the locales in <var>availableLocales</var> and determines the best available language to meet the request. The algorithm is implementation dependent, but should produce results that a typical user of the requested locales would perceive as at least as good as those produced by the <emu-xref aoid="LookupMatcher" id="_ref_5"><a href="#sec-lookupmatcher">LookupMatcher</a></emu-xref> abstract operation. Options specified through Unicode locale extension sequences must be ignored by the algorithm. Information about such subsequences is returned separately. The abstract operation returns a record with a [[locale]] field, whose value is the language tag of the selected locale, which must be an element of <var>availableLocales</var>. If the language tag of the request locale that led to the selected locale contained a Unicode locale extension sequence, then the returned record also contains an [[extension]] field whose value is the substring of the Unicode locale extension sequence within the request locale language tag.
       </p>
     </emu-clause>
 
     <emu-clause id="sec-unicode-extension-components" aoid="UnicodeExtensionComponents">
       <h1><span class="secnum">1.2.5</span> UnicodeExtensionComponents ( <var>extension</var> )</h1>
       <p>
-        The UnicodeExtensionComponents abstract operation returns the attributes and keywords from <var>extension</var>, which must be a String value whose contents are a Unicode locale extension sequence. If an attribute or a <emu-xref href="#sec-keywords-and-reserved-words"><a href="https://tc39.es/ecma262/#sec-keywords-and-reserved-words">keyword</a></emu-xref> occurs multiple times in <var>extension</var>, only the first occurence is returned. The following steps are taken:
+        The UnicodeExtensionComponents abstract operation returns the attributes and keywords from <var>extension</var>, which must be a String value whose contents are a Unicode locale extension sequence. If an attribute or a keyword occurs multiple times in <var>extension</var>, only the first occurence is returned. The following steps are taken:
       </p>
 
-      <emu-alg><ol><li>Let <var>attributes</var> be a new empty <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref>.</li><li>Let <var>keywords</var> be a new empty <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref>.</li><li>Let <var>keyword</var> be <emu-val>undefined</emu-val>.</li><li>Let <var>size</var> be the length of <var>extension</var>.</li><li>Let <var>k</var> be 3.</li><li>Repeat, while <var>k</var> &lt; <var>size</var>,<ol><li>Let <var>e</var> be StringIndexOf(<var>extension</var>, <emu-val>"-"</emu-val>, <var>k</var>).</li><li>If <var>e</var> = -1, let <var>len</var> be <var>size</var> - <var>k</var>; else let <var>len</var> be <var>e</var> - <var>k</var>.</li><li>Let <var>subtag</var> be the String value equal to the substring of <var>extension</var> consisting of the code units at indices <var>k</var> (inclusive) through <var>k</var> + <var>len</var> (exclusive).</li><li>If <var>keyword</var> is <emu-val>undefined</emu-val> and <var>len</var> ≠ 2, then<ol><li>If <var>subtag</var> is not an element of <var>attributes</var>, then<ol><li>Append <var>subtag</var> to <var>attributes</var>.</li></ol></li></ol></li><li>Else if <var>len</var> = 2, then<ol><li>If <var>keyword</var> is not <emu-val>undefined</emu-val> and <var>keywords</var> does not contain an element whose [[Key]] is the same as <var>keyword</var>.[[Key]], then<ol><li>Append <var>keyword</var> to <var>keywords</var>.</li></ol></li><li>Set <var>keyword</var> to the <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Key]]: <var>subtag</var>, [[Value]]: <emu-val>""</emu-val> }.</li></ol></li><li>Else,<ol><li>If <var>keyword</var>.[[Value]] is the empty String, then<ol><li>Set <var>keyword</var>.[[Value]] to <var>subtag</var>.</li></ol></li><li>Else,<ol><li>Set <var>keyword</var>.[[Value]] to the <emu-xref href="#sec-ecmascript-language-types-string-type"><a href="https://tc39.es/ecma262/#sec-ecmascript-language-types-string-type">string-concatenation</a></emu-xref> of <var>keyword</var>.[[Value]], <emu-val>"-"</emu-val>, and <var>subtag</var>.</li></ol></li></ol></li><li>Let <var>k</var> be <var>k</var> + <var>len</var> + 1.</li></ol></li><li>If <var>keyword</var> is not <emu-val>undefined</emu-val> and <var>keywords</var> does not contain an element whose [[Key]] is the same as <var>keyword</var>.[[Key]], then<ol><li>Append <var>keyword</var> to <var>keywords</var>.</li></ol></li><li>Return the <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Attributes]]: <var>attributes</var>, [[Keywords]]: <var>keywords</var> }.</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>attributes</var> be a new empty List.</li><li>Let <var>keywords</var> be a new empty List.</li><li>Let <var>keyword</var> be <emu-val>undefined</emu-val>.</li><li>Let <var>size</var> be the length of <var>extension</var>.</li><li>Let <var>k</var> be 3.</li><li>Repeat, while <var>k</var> &lt; <var>size</var>,<ol><li>Let <var>e</var> be StringIndexOf(<var>extension</var>, <emu-val>"-"</emu-val>, <var>k</var>).</li><li>If <var>e</var> = -1, let <var>len</var> be <var>size</var> - <var>k</var>; else let <var>len</var> be <var>e</var> - <var>k</var>.</li><li>Let <var>subtag</var> be the String value equal to the substring of <var>extension</var> consisting of the code units at indices <var>k</var> (inclusive) through <var>k</var> + <var>len</var> (exclusive).</li><li>If <var>keyword</var> is <emu-val>undefined</emu-val> and <var>len</var> ≠ 2, then<ol><li>If <var>subtag</var> is not an element of <var>attributes</var>, then<ol><li>Append <var>subtag</var> to <var>attributes</var>.</li></ol></li></ol></li><li>Else if <var>len</var> = 2, then<ol><li>If <var>keyword</var> is not <emu-val>undefined</emu-val> and <var>keywords</var> does not contain an element whose [[Key]] is the same as <var>keyword</var>.[[Key]], then<ol><li>Append <var>keyword</var> to <var>keywords</var>.</li></ol></li><li>Set <var>keyword</var> to the Record { [[Key]]: <var>subtag</var>, [[Value]]: <emu-val>""</emu-val> }.</li></ol></li><li>Else,<ol><li>If <var>keyword</var>.[[Value]] is the empty String, then<ol><li>Set <var>keyword</var>.[[Value]] to <var>subtag</var>.</li></ol></li><li>Else,<ol><li>Set <var>keyword</var>.[[Value]] to the string-concatenation of <var>keyword</var>.[[Value]], <emu-val>"-"</emu-val>, and <var>subtag</var>.</li></ol></li></ol></li><li>Let <var>k</var> be <var>k</var> + <var>len</var> + 1.</li></ol></li><li>If <var>keyword</var> is not <emu-val>undefined</emu-val> and <var>keywords</var> does not contain an element whose [[Key]] is the same as <var>keyword</var>.[[Key]], then<ol><li>Append <var>keyword</var> to <var>keywords</var>.</li></ol></li><li>Return the Record { [[Attributes]]: <var>attributes</var>, [[Keywords]]: <var>keywords</var> }.</li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-insert-unicode-extension-and-canonicalize" aoid="InsertUnicodeExtensionAndCanonicalize">
@@ -1959,21 +2717,21 @@ li.menu-search-result-term:before {
         The following algorithm refers to <a href="https://www.unicode.org/reports/tr35/#Identifiers">UTS 35's Unicode Language and Locale Identifiers grammar</a>.
       </p>
 
-      <emu-alg><ol><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>locale</var> matches the <code>unicode_locale_id</code> production.</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>locale</var> does not contain a Unicode locale extension sequence.</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>extension</var> is a Unicode locale extension sequence.</li><li>Let <var>privateIndex</var> be StringIndexOf(<var>locale</var>, <emu-val>"-x-"</emu-val>, 0).</li><li>If <var>privateIndex</var> = -1, then<ol><li>Let <var>locale</var> be the <emu-xref href="#sec-ecmascript-language-types-string-type"><a href="https://tc39.es/ecma262/#sec-ecmascript-language-types-string-type">string-concatenation</a></emu-xref> of <var>locale</var> and <var>extension</var>.</li></ol></li><li>Else,<ol><li>Let <var>preExtension</var> be the substring of <var>locale</var> from position 0, inclusive, to position <var>privateIndex</var>, exclusive.</li><li>Let <var>postExtension</var> be the substring of <var>locale</var> from position <var>privateIndex</var> to the end of the string.</li><li>Let <var>locale</var> be the <emu-xref href="#sec-ecmascript-language-types-string-type"><a href="https://tc39.es/ecma262/#sec-ecmascript-language-types-string-type">string-concatenation</a></emu-xref> of <var>preExtension</var>, <var>extension</var>, and <var>postExtension</var>.</li></ol></li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: !&nbsp;IsStructurallyValidLanguageTag(<var>locale</var>) is <emu-val>true</emu-val>.</li><li>Return !&nbsp;CanonicalizeUnicodeLocaleId(<var>locale</var>).</li></ol></emu-alg>
+      <emu-alg><ol><li>Assert: <var>locale</var> matches the <code>unicode_locale_id</code> production.</li><li>Assert: <var>locale</var> does not contain a Unicode locale extension sequence.</li><li>Assert: <var>extension</var> is a Unicode locale extension sequence.</li><li>Let <var>privateIndex</var> be StringIndexOf(<var>locale</var>, <emu-val>"-x-"</emu-val>, 0).</li><li>If <var>privateIndex</var> = -1, then<ol><li>Let <var>locale</var> be the string-concatenation of <var>locale</var> and <var>extension</var>.</li></ol></li><li>Else,<ol><li>Let <var>preExtension</var> be the substring of <var>locale</var> from position 0, inclusive, to position <var>privateIndex</var>, exclusive.</li><li>Let <var>postExtension</var> be the substring of <var>locale</var> from position <var>privateIndex</var> to the end of the string.</li><li>Let <var>locale</var> be the string-concatenation of <var>preExtension</var>, <var>extension</var>, and <var>postExtension</var>.</li></ol></li><li>Assert: !&nbsp;IsStructurallyValidLanguageTag(<var>locale</var>) is <emu-val>true</emu-val>.</li><li>Return !&nbsp;CanonicalizeUnicodeLocaleId(<var>locale</var>).</li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-resolvelocale" aoid="ResolveLocale">
       <h1><span class="secnum">1.2.7</span> ResolveLocale ( <var>availableLocales</var>, <var>requestedLocales</var>, <var>options</var>, <var>relevantExtensionKeys</var>, <var>localeData</var> )</h1>
 
       <p>
-        The ResolveLocale abstract operation compares a BCP 47 language priority list <var>requestedLocales</var> against the locales in <var>availableLocales</var> and determines the best available language to meet the request. <var>availableLocales</var>, <var>requestedLocales</var>, and <var>relevantExtensionKeys</var> must be provided as <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> values, <var>options</var> and <var>localeData</var> as Records.
+        The ResolveLocale abstract operation compares a BCP 47 language priority list <var>requestedLocales</var> against the locales in <var>availableLocales</var> and determines the best available language to meet the request. <var>availableLocales</var>, <var>requestedLocales</var>, and <var>relevantExtensionKeys</var> must be provided as List values, <var>options</var> and <var>localeData</var> as Records.
       </p>
 
       <p>
         The following steps are taken:
       </p>
 
-      <emu-alg><ol><li>Let <var>matcher</var> be <var>options</var>.[[localeMatcher]].</li><li>If <var>matcher</var> is <emu-val>"lookup"</emu-val>, then<ol><li>Let <var>r</var> be !&nbsp;<emu-xref aoid="LookupMatcher" id="_ref_18"><a href="#sec-lookupmatcher">LookupMatcher</a></emu-xref>(<var>availableLocales</var>, <var>requestedLocales</var>).</li></ol></li><li>Else,<ol><li>Let <var>r</var> be !&nbsp;<emu-xref aoid="BestFitMatcher" id="_ref_19"><a href="#sec-bestfitmatcher">BestFitMatcher</a></emu-xref>(<var>availableLocales</var>, <var>requestedLocales</var>).</li></ol></li><li>Let <var>foundLocale</var> be <var>r</var>.[[locale]].</li><li>Let <var>result</var> be a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref>.</li><li>Set <var>result</var>.[[dataLocale]] to <var>foundLocale</var>.</li><li>If <var>r</var> has an [[extension]] field, then<ol><li>Let <var>components</var> be !&nbsp;<emu-xref aoid="UnicodeExtensionComponents" id="_ref_20"><a href="#sec-unicode-extension-components">UnicodeExtensionComponents</a></emu-xref>(<var>r</var>.[[extension]]).</li><li>Let <var>keywords</var> be <var>components</var>.[[Keywords]].</li></ol></li><li>Let <var>supportedExtension</var> be <emu-val>"-u"</emu-val>.</li><li>For each element <var>key</var> of <var>relevantExtensionKeys</var>, do<ol><li>Let <var>foundLocaleData</var> be <var>localeData</var>.[[&lt;<var>foundLocale</var>&gt;]].</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <emu-xref aoid="Type" id="_ref_21"><a href="https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>foundLocaleData</var>) is <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref>.</li><li>Let <var>keyLocaleData</var> be <var>foundLocaleData</var>.[[&lt;<var>key</var>&gt;]].</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <emu-xref aoid="Type" id="_ref_22"><a href="https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>keyLocaleData</var>) is <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref>.</li><li>Let <var>value</var> be <var>keyLocaleData</var>[0].</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <emu-xref aoid="Type" id="_ref_23"><a href="https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>value</var>) is either String or Null.</li><li>Let <var>supportedExtensionAddition</var> be <emu-val>""</emu-val>.</li><li>If <var>r</var> has an [[extension]] field, then<ol><li>If <var>keywords</var> contains an element whose [[Key]] is the same as <var>key</var>, then<ol><li>Let <var>entry</var> be the element of <var>keywords</var> whose [[Key]] is the same as <var>key</var>.</li><li>Let <var>requestedValue</var> be <var>entry</var>.[[Value]].</li><li>If <var>requestedValue</var> is not the empty String, then<ol><li>If <var>keyLocaleData</var> contains <var>requestedValue</var>, then<ol><li>Let <var>value</var> be <var>requestedValue</var>.</li><li>Let <var>supportedExtensionAddition</var> be the <emu-xref href="#sec-ecmascript-language-types-string-type"><a href="https://tc39.es/ecma262/#sec-ecmascript-language-types-string-type">string-concatenation</a></emu-xref> of <emu-val>"-"</emu-val>, <var>key</var>, <emu-val>"-"</emu-val>, and <var>value</var>.</li></ol></li></ol></li><li>Else if <var>keyLocaleData</var> contains <emu-val>"true"</emu-val>, then<ol><li>Let <var>value</var> be <emu-val>"true"</emu-val>.</li><li>Let <var>supportedExtensionAddition</var> be the <emu-xref href="#sec-ecmascript-language-types-string-type"><a href="https://tc39.es/ecma262/#sec-ecmascript-language-types-string-type">string-concatenation</a></emu-xref> of <emu-val>"-"</emu-val> and <var>key</var>.</li></ol></li></ol></li></ol></li><li>If <var>options</var> has a field [[&lt;<var>key</var>&gt;]], then<ol><li>Let <var>optionsValue</var> be <var>options</var>.[[&lt;<var>key</var>&gt;]].</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <emu-xref aoid="Type" id="_ref_24"><a href="https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>optionsValue</var>) is either String, Undefined, or Null.</li><li>If <emu-xref aoid="Type" id="_ref_25"><a href="https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>optionsValue</var>) is String, then<ol><li>Let <var>optionsValue</var> be the string <var>optionsValue</var> after performing the algorithm steps to transform Unicode extension values to canonical syntax per <a href="https://unicode.org/reports/tr35/#Canonical_Unicode_Locale_Identifiers">Unicode Technical Standard #35 LDML § 3.2.1 Canonical Unicode Locale Identifiers</a>, treating <var>key</var> as <code>ukey</code> and <var>optionsValue</var> as <code>uvalue</code> productions.</li><li>Let <var>optionsValue</var> be the string <var>optionsValue</var> after performing the algorithm steps to replace Unicode extension values with their canonical form per <a href="https://unicode.org/reports/tr35/#Canonical_Unicode_Locale_Identifiers">Unicode Technical Standard #35 LDML § 3.2.1 Canonical Unicode Locale Identifiers</a>, treating <var>key</var> as <code>ukey</code> and <var>optionsValue</var> as <code>uvalue</code> productions.</li><li>If <var>optionsValue</var> is the empty String, then<ol><li>Let <var>optionsValue</var> be <emu-val>"true"</emu-val>.</li></ol></li></ol></li><li>If <var>keyLocaleData</var> contains <var>optionsValue</var>, then<ol><li>If <emu-xref aoid="SameValue" id="_ref_26"><a href="https://tc39.es/ecma262/#sec-samevalue">SameValue</a></emu-xref>(<var>optionsValue</var>, <var>value</var>) is <emu-val>false</emu-val>, then<ol><li>Let <var>value</var> be <var>optionsValue</var>.</li><li>Let <var>supportedExtensionAddition</var> be <emu-val>""</emu-val>.</li></ol></li></ol></li></ol></li><li>Set <var>result</var>.[[&lt;<var>key</var>&gt;]] to <var>value</var>.</li><li>Append <var>supportedExtensionAddition</var> to <var>supportedExtension</var>.</li></ol></li><li>If the number of elements in <var>supportedExtension</var> is greater than 2, then<ol><li>Let <var>foundLocale</var> be <emu-xref aoid="InsertUnicodeExtensionAndCanonicalize" id="_ref_27"><a href="#sec-insert-unicode-extension-and-canonicalize">InsertUnicodeExtensionAndCanonicalize</a></emu-xref>(<var>foundLocale</var>, <var>supportedExtension</var>).</li></ol></li><li>Set <var>result</var>.[[locale]] to <var>foundLocale</var>.</li><li>Return <var>result</var>.</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>matcher</var> be <var>options</var>.[[localeMatcher]].</li><li>If <var>matcher</var> is <emu-val>"lookup"</emu-val>, then<ol><li>Let <var>r</var> be !&nbsp;<emu-xref aoid="LookupMatcher" id="_ref_6"><a href="#sec-lookupmatcher">LookupMatcher</a></emu-xref>(<var>availableLocales</var>, <var>requestedLocales</var>).</li></ol></li><li>Else,<ol><li>Let <var>r</var> be !&nbsp;<emu-xref aoid="BestFitMatcher" id="_ref_7"><a href="#sec-bestfitmatcher">BestFitMatcher</a></emu-xref>(<var>availableLocales</var>, <var>requestedLocales</var>).</li></ol></li><li>Let <var>foundLocale</var> be <var>r</var>.[[locale]].</li><li>Let <var>result</var> be a new Record.</li><li>Set <var>result</var>.[[dataLocale]] to <var>foundLocale</var>.</li><li>If <var>r</var> has an [[extension]] field, then<ol><li>Let <var>components</var> be !&nbsp;<emu-xref aoid="UnicodeExtensionComponents" id="_ref_8"><a href="#sec-unicode-extension-components">UnicodeExtensionComponents</a></emu-xref>(<var>r</var>.[[extension]]).</li><li>Let <var>keywords</var> be <var>components</var>.[[Keywords]].</li></ol></li><li>Let <var>supportedExtension</var> be <emu-val>"-u"</emu-val>.</li><li>For each element <var>key</var> of <var>relevantExtensionKeys</var>, do<ol><li>Let <var>foundLocaleData</var> be <var>localeData</var>.[[&lt;<var>foundLocale</var>&gt;]].</li><li>Assert: Type(<var>foundLocaleData</var>) is Record.</li><li>Let <var>keyLocaleData</var> be <var>foundLocaleData</var>.[[&lt;<var>key</var>&gt;]].</li><li>Assert: Type(<var>keyLocaleData</var>) is List.</li><li>Let <var>value</var> be <var>keyLocaleData</var>[0].</li><li>Assert: Type(<var>value</var>) is either String or Null.</li><li>Let <var>supportedExtensionAddition</var> be <emu-val>""</emu-val>.</li><li>If <var>r</var> has an [[extension]] field, then<ol><li>If <var>keywords</var> contains an element whose [[Key]] is the same as <var>key</var>, then<ol><li>Let <var>entry</var> be the element of <var>keywords</var> whose [[Key]] is the same as <var>key</var>.</li><li>Let <var>requestedValue</var> be <var>entry</var>.[[Value]].</li><li>If <var>requestedValue</var> is not the empty String, then<ol><li>If <var>keyLocaleData</var> contains <var>requestedValue</var>, then<ol><li>Let <var>value</var> be <var>requestedValue</var>.</li><li>Let <var>supportedExtensionAddition</var> be the string-concatenation of <emu-val>"-"</emu-val>, <var>key</var>, <emu-val>"-"</emu-val>, and <var>value</var>.</li></ol></li></ol></li><li>Else if <var>keyLocaleData</var> contains <emu-val>"true"</emu-val>, then<ol><li>Let <var>value</var> be <emu-val>"true"</emu-val>.</li><li>Let <var>supportedExtensionAddition</var> be the string-concatenation of <emu-val>"-"</emu-val> and <var>key</var>.</li></ol></li></ol></li></ol></li><li>If <var>options</var> has a field [[&lt;<var>key</var>&gt;]], then<ol><li>Let <var>optionsValue</var> be <var>options</var>.[[&lt;<var>key</var>&gt;]].</li><li>Assert: Type(<var>optionsValue</var>) is either String, Undefined, or Null.</li><li>If Type(<var>optionsValue</var>) is String, then<ol><li>Let <var>optionsValue</var> be the string <var>optionsValue</var> after performing the algorithm steps to transform Unicode extension values to canonical syntax per <a href="https://unicode.org/reports/tr35/#Canonical_Unicode_Locale_Identifiers">Unicode Technical Standard #35 LDML § 3.2.1 Canonical Unicode Locale Identifiers</a>, treating <var>key</var> as <code>ukey</code> and <var>optionsValue</var> as <code>uvalue</code> productions.</li><li>Let <var>optionsValue</var> be the string <var>optionsValue</var> after performing the algorithm steps to replace Unicode extension values with their canonical form per <a href="https://unicode.org/reports/tr35/#Canonical_Unicode_Locale_Identifiers">Unicode Technical Standard #35 LDML § 3.2.1 Canonical Unicode Locale Identifiers</a>, treating <var>key</var> as <code>ukey</code> and <var>optionsValue</var> as <code>uvalue</code> productions.</li><li>If <var>optionsValue</var> is the empty String, then<ol><li>Let <var>optionsValue</var> be <emu-val>"true"</emu-val>.</li></ol></li></ol></li><li>If <var>keyLocaleData</var> contains <var>optionsValue</var>, then<ol><li>If SameValue(<var>optionsValue</var>, <var>value</var>) is <emu-val>false</emu-val>, then<ol><li>Let <var>value</var> be <var>optionsValue</var>.</li><li>Let <var>supportedExtensionAddition</var> be <emu-val>""</emu-val>.</li></ol></li></ol></li></ol></li><li>Set <var>result</var>.[[&lt;<var>key</var>&gt;]] to <var>value</var>.</li><li>Append <var>supportedExtensionAddition</var> to <var>supportedExtension</var>.</li></ol></li><li>If the number of elements in <var>supportedExtension</var> is greater than 2, then<ol><li>Let <var>foundLocale</var> be <emu-xref aoid="InsertUnicodeExtensionAndCanonicalize" id="_ref_9"><a href="#sec-insert-unicode-extension-and-canonicalize">InsertUnicodeExtensionAndCanonicalize</a></emu-xref>(<var>foundLocale</var>, <var>supportedExtension</var>).</li></ol></li><li>Set <var>result</var>.[[locale]] to <var>foundLocale</var>.</li><li>Return <var>result</var>.</li></ol></emu-alg>
 
       <emu-note><span class="note">Note</span><div class="note-contents">
         Non-normative summary: Two algorithms are available to match the locales: the Lookup algorithm described in RFC 4647 section 3.4, and an implementation dependent best-fit algorithm. Independent of the locale matching algorithm, options specified through Unicode locale extension sequences are negotiated separately, taking the caller's relevant extension keys and locale data as well as client-provided options into consideration. The abstract operation returns a record with a [[locale]] field whose value is the language tag of the selected locale, and fields for each key in <var>relevantExtensionKeys</var> providing the selected value for that key.
@@ -1987,7 +2745,7 @@ li.menu-search-result-term:before {
         The LookupSupportedLocales abstract operation returns the subset of the provided BCP 47 language priority list <var>requestedLocales</var> for which <var>availableLocales</var> has a matching locale when using the BCP 47 Lookup algorithm. Locales appear in the same order in the returned list as in <var>requestedLocales</var>. The following steps are taken:
       </p>
 
-      <emu-alg><ol><li>Let <var>subset</var> be a new empty <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref>.</li><li>For each element <var>locale</var> of <var>requestedLocales</var>, do<ol><li>Let <var>noExtensionsLocale</var> be the String value that is <var>locale</var> with any Unicode locale extension sequences removed.</li><li>Let <var>availableLocale</var> be !&nbsp;<emu-xref aoid="BestAvailableLocale" id="_ref_28"><a href="#sec-bestavailablelocale">BestAvailableLocale</a></emu-xref>(<var>availableLocales</var>, <var>noExtensionsLocale</var>).</li><li>If <var>availableLocale</var> is not <emu-val>undefined</emu-val>, append <var>locale</var> to the end of <var>subset</var>.</li></ol></li><li>Return <var>subset</var>.</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>subset</var> be a new empty List.</li><li>For each element <var>locale</var> of <var>requestedLocales</var>, do<ol><li>Let <var>noExtensionsLocale</var> be the String value that is <var>locale</var> with any Unicode locale extension sequences removed.</li><li>Let <var>availableLocale</var> be !&nbsp;<emu-xref aoid="BestAvailableLocale" id="_ref_10"><a href="#sec-bestavailablelocale">BestAvailableLocale</a></emu-xref>(<var>availableLocales</var>, <var>noExtensionsLocale</var>).</li><li>If <var>availableLocale</var> is not <emu-val>undefined</emu-val>, append <var>locale</var> to the end of <var>subset</var>.</li></ol></li><li>Return <var>subset</var>.</li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-bestfitsupportedlocales" aoid="BestFitSupportedLocales">
@@ -2005,72 +2763,57 @@ li.menu-search-result-term:before {
         The SupportedLocales abstract operation returns the subset of the provided BCP 47 language priority list <var>requestedLocales</var> for which <var>availableLocales</var> has a matching locale. Two algorithms are available to match the locales: the Lookup algorithm described in RFC 4647 section 3.4, and an implementation dependent best-fit algorithm. Locales appear in the same order in the returned list as in <var>requestedLocales</var>. The following steps are taken:
       </p>
 
-      <emu-alg><ol><li>Set <var>options</var> to ?&nbsp;<emu-xref aoid="CoerceOptionsToObject" id="_ref_29"><a href="#sec-coerceoptionstoobject">CoerceOptionsToObject</a></emu-xref>(<var>options</var>).</li><li>Let <var>matcher</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"localeMatcher"</emu-val>, <emu-const>string</emu-const>, « <emu-val>"lookup"</emu-val>, <emu-val>"best fit"</emu-val> », <emu-val>"best fit"</emu-val>).</li><li>If <var>matcher</var> is <emu-val>"best fit"</emu-val>, then<ol><li>Let <var>supportedLocales</var> be <emu-xref aoid="BestFitSupportedLocales" id="_ref_30"><a href="#sec-bestfitsupportedlocales">BestFitSupportedLocales</a></emu-xref>(<var>availableLocales</var>, <var>requestedLocales</var>).</li></ol></li><li>Else,<ol><li>Let <var>supportedLocales</var> be <emu-xref aoid="LookupSupportedLocales" id="_ref_31"><a href="#sec-lookupsupportedlocales">LookupSupportedLocales</a></emu-xref>(<var>availableLocales</var>, <var>requestedLocales</var>).</li></ol></li><li>Return <emu-xref aoid="CreateArrayFromList" id="_ref_32"><a href="https://tc39.es/ecma262/#sec-createarrayfromlist">CreateArrayFromList</a></emu-xref>(<var>supportedLocales</var>).</li></ol></emu-alg>
+      <emu-alg><ol><li>Set <var>options</var> to ?&nbsp;<emu-xref aoid="CoerceOptionsToObject" id="_ref_11"><a href="#sec-coerceoptionstoobject">CoerceOptionsToObject</a></emu-xref>(<var>options</var>).</li><li>Let <var>matcher</var> be ?&nbsp;<emu-xref aoid="GetOption" id="_ref_12"><a href="#sec-getoption">GetOption</a></emu-xref>(<var>options</var>, <emu-val>"localeMatcher"</emu-val>, <emu-const>string</emu-const>, « <emu-val>"lookup"</emu-val>, <emu-val>"best fit"</emu-val> », <emu-val>"best fit"</emu-val>).</li><li>If <var>matcher</var> is <emu-val>"best fit"</emu-val>, then<ol><li>Let <var>supportedLocales</var> be <emu-xref aoid="BestFitSupportedLocales" id="_ref_13"><a href="#sec-bestfitsupportedlocales">BestFitSupportedLocales</a></emu-xref>(<var>availableLocales</var>, <var>requestedLocales</var>).</li></ol></li><li>Else,<ol><li>Let <var>supportedLocales</var> be <emu-xref aoid="LookupSupportedLocales" id="_ref_14"><a href="#sec-lookupsupportedlocales">LookupSupportedLocales</a></emu-xref>(<var>availableLocales</var>, <var>requestedLocales</var>).</li></ol></li><li>Return CreateArrayFromList(<var>supportedLocales</var>).</li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-getoptionsobject" aoid="GetOptionsObject">
       <h1><span class="secnum">1.2.11</span> GetOptionsObject ( <var>options</var> )</h1>
       <p>
-        The abstract operation GetOptionsObject returns an Object suitable for use with GetOption, either <var>options</var> itself or a default empty Object.
+        The abstract operation GetOptionsObject returns an Object suitable for use with <emu-xref aoid="GetOption" id="_ref_15"><a href="#sec-getoption">GetOption</a></emu-xref>, either <var>options</var> itself or a default empty Object.
         It throws a TypeError if <var>options</var> is not undefined and not an Object.
       </p>
-      <emu-alg><ol><li>If <var>options</var> is <emu-val>undefined</emu-val>, then<ol><li>Return OrdinaryObjectCreate(<emu-val>null</emu-val>).</li></ol></li><li>If <emu-xref aoid="Type" id="_ref_33"><a href="https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>options</var>) is Object, then<ol><li>Return <var>options</var>.</li></ol></li><li>Throw a <emu-val>TypeError</emu-val> exception.</li></ol></emu-alg>
+      <emu-alg><ol><li>If <var>options</var> is <emu-val>undefined</emu-val>, then<ol><li>Return OrdinaryObjectCreate(<emu-val>null</emu-val>).</li></ol></li><li>If Type(<var>options</var>) is Object, then<ol><li>Return <var>options</var>.</li></ol></li><li>Throw a <emu-val>TypeError</emu-val> exception.</li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-coerceoptionstoobject" aoid="CoerceOptionsToObject">
       <h1><span class="secnum">1.2.12</span> CoerceOptionsToObject ( <var>options</var> )</h1>
       <p>
-        The abstract operation CoerceOptionsToObject coerces <var>options</var> into an Object suitable for use with GetOption, defaulting to an empty Object.
-        Because it coerces non-null primitive values into objects, its use is discouraged for new functionality in favour of <emu-xref aoid="GetOptionsObject" id="_ref_34"><a href="#sec-getoptionsobject">GetOptionsObject</a></emu-xref>.
+        The abstract operation CoerceOptionsToObject coerces <var>options</var> into an Object suitable for use with <emu-xref aoid="GetOption" id="_ref_16"><a href="#sec-getoption">GetOption</a></emu-xref>, defaulting to an empty Object.
+        Because it coerces non-null primitive values into objects, its use is discouraged for new functionality in favour of <emu-xref aoid="GetOptionsObject" id="_ref_17"><a href="#sec-getoptionsobject">GetOptionsObject</a></emu-xref>.
       </p>
-      <emu-alg><ol><li>If <var>options</var> is <emu-val>undefined</emu-val>, then<ol><li>Return OrdinaryObjectCreate(<emu-val>null</emu-val>).</li></ol></li><li>Return ?&nbsp;<emu-xref aoid="ToObject" id="_ref_35"><a href="https://tc39.es/ecma262/#sec-toobject">ToObject</a></emu-xref>(<var>options</var>).</li></ol></emu-alg>
+      <emu-alg><ol><li>If <var>options</var> is <emu-val>undefined</emu-val>, then<ol><li>Return OrdinaryObjectCreate(<emu-val>null</emu-val>).</li></ol></li><li>Return ?&nbsp;ToObject(<var>options</var>).</li></ol></emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-getoption" type="abstract operation">
-      <h1><span class="secnum">1.2.13</span> 
-        GetOption (
-          <var>options</var>: an Object,
-          <var>property</var>: a property key,
-          <var>type</var>: <emu-const>boolean</emu-const>, <emu-const>number</emu-const>, or <emu-const>string</emu-const>,
-          <var>values</var>: <emu-const>empty</emu-const> or a List of ECMAScript language values,
-          <var>default</var>: <emu-const>required</emu-const> or an ECMAScript language value,
-        )
-      </h1>
-      <dl class="header">
-        <dt>description</dt>
-        <dd>It extracts the value of the specified property of <var>options</var>, converts it to the required <var>type</var>, checks whether it is allowed by <var>values</var> if <var>values</var> is not <emu-const>empty</emu-const>, and substitutes <var>default</var> if the value is <emu-val>undefined</emu-val>.</dd>
-      </dl>
-      <emu-alg><ol><li>Let <var>value</var> be ?&nbsp;<emu-xref aoid="Get" id="_ref_36"><a href="https://tc39.es/ecma262/#sec-get-o-p">Get</a></emu-xref>(<var>options</var>, <var>property</var>).</li><li>If <var>value</var> is <emu-val>undefined</emu-val>, then<ol><li>If <var>default</var> is <emu-const>required</emu-const>, throw a <emu-val>RangeError</emu-val> exception.</li><li>Return <var>default</var>.</li></ol></li><li>If <var>type</var> is <emu-const>boolean</emu-const>, then<ol><li>Set <var>value</var> to <emu-xref aoid="ToBoolean" id="_ref_37"><a href="https://tc39.es/ecma262/#sec-toboolean">ToBoolean</a></emu-xref>(<var>value</var>).</li></ol></li><li>Else if <var>type</var> is <emu-const>number</emu-const>, then<ol><li>Set <var>value</var> to ?&nbsp;<emu-xref aoid="ToNumber" id="_ref_38"><a href="https://tc39.es/ecma262/#sec-tonumber">ToNumber</a></emu-xref>(<var>value</var>).</li><li>If <var>value</var> is <emu-val>NaN</emu-val>, throw a <emu-val>RangeError</emu-val> exception.</li></ol></li><li>Else,<ol><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>type</var> is <emu-const>string</emu-const>.</li><li>Set <var>value</var> to ?&nbsp;<emu-xref aoid="ToString" id="_ref_39"><a href="https://tc39.es/ecma262/#sec-tostring">ToString</a></emu-xref>(<var>value</var>).</li></ol></li><li>If <var>values</var> is not <emu-const>empty</emu-const> and <var>values</var> does not contain an element equal to <var>value</var>, throw a <emu-val>RangeError</emu-val> exception.</li><li>Return <var>value</var>.</li></ol></emu-alg>
+    <emu-clause id="sec-getoption" type="abstract operation" aoid="GetOption">
+      <h1><span class="secnum">1.2.13</span> GetOption ( <var>options</var>, <var>property</var>, <var>type</var>, <var>values</var>, <var>default</var> )</h1>
+      <p>The abstract operation GetOption takes arguments <var>options</var> (an Object), <var>property</var> (a property key), <var>type</var> (<emu-const>boolean</emu-const>, <emu-const>number</emu-const>, or <emu-const>string</emu-const>), <var>values</var> (<emu-const>empty</emu-const> or a List of ECMAScript language values), and <var>default</var> (<emu-const>required</emu-const> or an ECMAScript language value). It extracts the value of the specified property of <var>options</var>, converts it to the required <var>type</var>, checks whether it is allowed by <var>values</var> if <var>values</var> is not <emu-const>empty</emu-const>, and substitutes <var>default</var> if the value is <emu-val>undefined</emu-val>. It performs the following steps when called:</p>
+      <emu-alg><ol><li>Let <var>value</var> be ?&nbsp;Get(<var>options</var>, <var>property</var>).</li><li>If <var>value</var> is <emu-val>undefined</emu-val>, then<ol><li>If <var>default</var> is <emu-const>required</emu-const>, throw a <emu-val>RangeError</emu-val> exception.</li><li>Return <var>default</var>.</li></ol></li><li>If <var>type</var> is <emu-const>boolean</emu-const>, then<ol><li>Set <var>value</var> to ToBoolean(<var>value</var>).</li></ol></li><li>Else if <var>type</var> is <emu-const>number</emu-const>, then<ol><li>Set <var>value</var> to ?&nbsp;ToNumber(<var>value</var>).</li><li>If <var>value</var> is <emu-val>NaN</emu-val>, throw a <emu-val>RangeError</emu-val> exception.</li></ol></li><li>Else,<ol><li>Assert: <var>type</var> is <emu-const>string</emu-const>.</li><li>Set <var>value</var> to ?&nbsp;ToString(<var>value</var>).</li></ol></li><li>If <var>values</var> is not <emu-const>empty</emu-const> and <var>values</var> does not contain <var>value</var>, throw a <emu-val>RangeError</emu-val> exception.</li><li>Return <var>value</var>.</li></ol></emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-getstringorbooleanoption" aoid="GetStringOrBooleanOption">
-      <h1><span class="secnum">1.2.14</span> GetStringOrBooleanOption ( <var>options</var>, <var>property</var>, <var>values</var>, <var>trueValue</var>, <var>falsyValue</var>, <var>fallback</var> )</h1>
-
-      <p>
-        The abstract operation GetStringOrBooleanOption extracts the value of the property named <var>property</var> from the provided <var>options</var> object. It returns either <var>trueValue</var>, <var>falsyValue</var>, <var>fallback</var>, or one of the elements of the <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> <var>values</var>. The following steps are taken:
-      </p>
-
-      <emu-alg><ol><li>Let <var>value</var> be ?&nbsp;<emu-xref aoid="Get" id="_ref_40"><a href="https://tc39.es/ecma262/#sec-get-o-p">Get</a></emu-xref>(<var>options</var>, <var>property</var>).</li><li>If <var>value</var> is <emu-val>undefined</emu-val>, return <var>fallback</var>.</li><li>If <var>value</var> is <emu-val>true</emu-val>, return <var>trueValue</var>.</li><li>Let <var>valueBoolean</var> be <emu-xref aoid="ToBoolean" id="_ref_41"><a href="https://tc39.es/ecma262/#sec-toboolean">ToBoolean</a></emu-xref>(<var>value</var>).</li><li>If <var>valueBoolean</var> is <emu-val>false</emu-val>, return <var>falsyValue</var>.</li><li>Let <var>value</var> be ?&nbsp;<emu-xref aoid="ToString" id="_ref_42"><a href="https://tc39.es/ecma262/#sec-tostring">ToString</a></emu-xref>(<var>value</var>).</li><li>NOTE: For historical reasons, the strings <emu-val>"true"</emu-val> and <emu-val>"false"</emu-val> are treated the same as the <var>fallback</var> value.</li><li>If <var>value</var> is <emu-val>"true"</emu-val> or <emu-val>"false"</emu-val>, return <var>fallback</var>.</li><li>If <var>values</var> does not contain an element equal to <var>value</var>, throw a <emu-val>RangeError</emu-val> exception.</li><li>Return <var>value</var>.</li></ol></emu-alg>
+    <emu-clause id="sec-getbooleanorstringnumberformatoption" type="abstract operation" aoid="GetBooleanOrStringNumberFormatOption">
+      <h1><span class="secnum">1.2.14</span> GetBooleanOrStringNumberFormatOption ( <var>options</var>, <var>property</var>, <var>stringValues</var>, <var>fallback</var> )</h1>
+      <p>The abstract operation GetBooleanOrStringNumberFormatOption takes arguments <var>options</var> (an Object), <var>property</var> (a property key), <var>stringValues</var> (a List of Strings), and <var>fallback</var> (an ECMAScript language value) and returns either a normal completion containing either a Boolean, String, or <var>fallback</var>, or a throw completion. It extracts the value of the property named <var>property</var> from the provided <var>options</var> object. It returns <var>fallback</var> if that value is <emu-val>undefined</emu-val>, <emu-val>true</emu-val> if that value is <emu-val>true</emu-val>, <emu-val>false</emu-val> if that value coerces to <emu-val>false</emu-val>, and otherwise coerces it to a String and returns the result if it is allowed by <var>stringValues</var>. It performs the following steps when called:</p>
+      <emu-alg><ol><li>Let <var>value</var> be ?&nbsp;Get(<var>options</var>, <var>property</var>).</li><li>If <var>value</var> is <emu-val>undefined</emu-val>, return <var>fallback</var>.</li><li>If <var>value</var> is <emu-val>true</emu-val>, return <emu-val>true</emu-val>.</li><li>If ToBoolean(<var>value</var>) is <emu-val>false</emu-val>, return <emu-val>false</emu-val>.</li><li>Let <var>value</var> be ?&nbsp;ToString(<var>value</var>).</li><li>If <var>stringValues</var> does not contain <var>value</var>, throw a <emu-val>RangeError</emu-val> exception.</li><li>Return <var>value</var>.</li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-defaultnumberoption" aoid="DefaultNumberOption">
       <h1><span class="secnum">1.2.15</span> DefaultNumberOption ( <var>value</var>, <var>minimum</var>, <var>maximum</var>, <var>fallback</var> )</h1>
 
       <p>
-        The abstract operation DefaultNumberOption converts <var>value</var> to a <emu-xref href="#number-value"><a href="https://tc39.es/ecma262/#number-value">Number value</a></emu-xref>, checks whether it is in the allowed range, and fills in a <var>fallback</var> value if necessary.
+        The abstract operation DefaultNumberOption converts <var>value</var> to a Number value, checks whether it is in the allowed range, and fills in a <var>fallback</var> value if necessary.
       </p>
 
-      <emu-alg><ol><li>If <var>value</var> is <emu-val>undefined</emu-val>, return <var>fallback</var>.</li><li>Set <var>value</var> to ?&nbsp;<emu-xref aoid="ToNumber" id="_ref_43"><a href="https://tc39.es/ecma262/#sec-tonumber">ToNumber</a></emu-xref>(<var>value</var>).</li><li>If <var>value</var> is <emu-val>NaN</emu-val> or less than <var>minimum</var> or greater than <var>maximum</var>, throw a <emu-val>RangeError</emu-val> exception.</li><li>Return <emu-xref aoid="floor"><a href="https://tc39.es/ecma262/#eqn-floor">floor</a></emu-xref>(<var>value</var>).</li></ol></emu-alg>
+      <emu-alg><ol><li>If <var>value</var> is <emu-val>undefined</emu-val>, return <var>fallback</var>.</li><li>Set <var>value</var> to ?&nbsp;ToNumber(<var>value</var>).</li><li>If <var>value</var> is <emu-val>NaN</emu-val> or less than <var>minimum</var> or greater than <var>maximum</var>, throw a <emu-val>RangeError</emu-val> exception.</li><li>Return floor(<var>value</var>).</li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-getnumberoption" aoid="GetNumberOption">
       <h1><span class="secnum">1.2.16</span> GetNumberOption ( <var>options</var>, <var>property</var>, <var>minimum</var>, <var>maximum</var>, <var>fallback</var> )</h1>
 
       <p>
-        The abstract operation GetNumberOption extracts the value of the property named <var>property</var> from the provided <var>options</var> object, converts it to a <emu-xref href="#number-value"><a href="https://tc39.es/ecma262/#number-value">Number value</a></emu-xref>, checks whether it is in the allowed range, and fills in a <var>fallback</var> value if necessary.
+        The abstract operation GetNumberOption extracts the value of the property named <var>property</var> from the provided <var>options</var> object, converts it to a Number value, checks whether it is in the allowed range, and fills in a <var>fallback</var> value if necessary.
       </p>
 
-      <emu-alg><ol><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <emu-xref aoid="Type" id="_ref_44"><a href="https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>options</var>) is Object.</li><li>Let <var>value</var> be ?&nbsp;<emu-xref aoid="Get" id="_ref_45"><a href="https://tc39.es/ecma262/#sec-get-o-p">Get</a></emu-xref>(<var>options</var>, <var>property</var>).</li><li>Return ?&nbsp;<emu-xref aoid="DefaultNumberOption" id="_ref_46"><a href="#sec-defaultnumberoption">DefaultNumberOption</a></emu-xref>(<var>value</var>, <var>minimum</var>, <var>maximum</var>, <var>fallback</var>).</li></ol></emu-alg>
+      <emu-alg><ol><li>Assert: Type(<var>options</var>) is Object.</li><li>Let <var>value</var> be ?&nbsp;Get(<var>options</var>, <var>property</var>).</li><li>Return ?&nbsp;<emu-xref aoid="DefaultNumberOption" id="_ref_18"><a href="#sec-defaultnumberoption">DefaultNumberOption</a></emu-xref>(<var>value</var>, <var>minimum</var>, <var>maximum</var>, <var>fallback</var>).</li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-partitionpattern" aoid="PartitionPattern">
@@ -2084,7 +2827,7 @@ li.menu-search-result-term:before {
         The following steps are taken:
       </p>
 
-      <emu-alg><ol><li>Let <var>result</var> be a new empty <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref>.</li><li>Let <var>beginIndex</var> be StringIndexOf(<var>pattern</var>, <emu-val>"{"</emu-val>, 0).</li><li>Let <var>endIndex</var> be 0.</li><li>Let <var>nextIndex</var> be 0.</li><li>Let <var>length</var> be the number of code units in <var>pattern</var>.</li><li>Repeat, while <var>beginIndex</var> is an <emu-xref href="#integer-index"><a href="https://tc39.es/ecma262/#integer-index">integer index</a></emu-xref> into <var>pattern</var>,<ol><li>Set <var>endIndex</var> to StringIndexOf(<var>pattern</var>, <emu-val>"}"</emu-val>, <var>beginIndex</var>).</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>endIndex</var> is greater than <var>beginIndex</var>.</li><li>If <var>beginIndex</var> is greater than <var>nextIndex</var>, then<ol><li>Let <var>literal</var> be a substring of <var>pattern</var> from position <var>nextIndex</var>, inclusive, to position <var>beginIndex</var>, exclusive.</li><li>Append a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]]: <emu-val>"literal"</emu-val>, [[Value]]: <var>literal</var> } as the last element of the list <var>result</var>.</li></ol></li><li>Let <var>p</var> be the substring of <var>pattern</var> from position <var>beginIndex</var>, exclusive, to position <var>endIndex</var>, exclusive.</li><li>Append a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]]: <var>p</var>, [[Value]]: <emu-val>undefined</emu-val> } as the last element of the list <var>result</var>.</li><li>Set <var>nextIndex</var> to <var>endIndex</var> + 1.</li><li>Set <var>beginIndex</var> to StringIndexOf(<var>pattern</var>, <emu-val>"{"</emu-val>, <var>nextIndex</var>).</li></ol></li><li>If <var>nextIndex</var> is less than <var>length</var>, then<ol><li>Let <var>literal</var> be the substring of <var>pattern</var> from position <var>nextIndex</var>, inclusive, to position <var>length</var>, exclusive.</li><li>Append a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]]: <emu-val>"literal"</emu-val>, [[Value]]: <var>literal</var> } as the last element of the list <var>result</var>.</li></ol></li><li>Return <var>result</var>.</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>result</var> be a new empty List.</li><li>Let <var>beginIndex</var> be StringIndexOf(<var>pattern</var>, <emu-val>"{"</emu-val>, 0).</li><li>Let <var>endIndex</var> be 0.</li><li>Let <var>nextIndex</var> be 0.</li><li>Let <var>length</var> be the number of code units in <var>pattern</var>.</li><li>Repeat, while <var>beginIndex</var> is an integer index into <var>pattern</var>,<ol><li>Set <var>endIndex</var> to StringIndexOf(<var>pattern</var>, <emu-val>"}"</emu-val>, <var>beginIndex</var>).</li><li>Assert: <var>endIndex</var> is greater than <var>beginIndex</var>.</li><li>If <var>beginIndex</var> is greater than <var>nextIndex</var>, then<ol><li>Let <var>literal</var> be a substring of <var>pattern</var> from position <var>nextIndex</var>, inclusive, to position <var>beginIndex</var>, exclusive.</li><li>Append a new Record { [[Type]]: <emu-val>"literal"</emu-val>, [[Value]]: <var>literal</var> } as the last element of the list <var>result</var>.</li></ol></li><li>Let <var>p</var> be the substring of <var>pattern</var> from position <var>beginIndex</var>, exclusive, to position <var>endIndex</var>, exclusive.</li><li>Append a new Record { [[Type]]: <var>p</var>, [[Value]]: <emu-val>undefined</emu-val> } as the last element of the list <var>result</var>.</li><li>Set <var>nextIndex</var> to <var>endIndex</var> + 1.</li><li>Set <var>beginIndex</var> to StringIndexOf(<var>pattern</var>, <emu-val>"{"</emu-val>, <var>nextIndex</var>).</li></ol></li><li>If <var>nextIndex</var> is less than <var>length</var>, then<ol><li>Let <var>literal</var> be the substring of <var>pattern</var> from position <var>nextIndex</var>, inclusive, to position <var>length</var>, exclusive.</li><li>Append a new Record { [[Type]]: <emu-val>"literal"</emu-val>, [[Value]]: <var>literal</var> } as the last element of the list <var>result</var>.</li></ol></li><li>Return <var>result</var>.</li></ol></emu-alg>
     </emu-clause>
   </emu-clause>
 </emu-clause></div></body>

--- a/out/numberformat/diff.html
+++ b/out/numberformat/diff.html
@@ -1,6 +1,88 @@
 <!doctype html>
-<head><meta charset="utf-8"><script type="application/json" id="menu-search-biblio">[{"type":"term","term":"%NumberFormat%","refId":"sec-intl-numberformat-constructor","referencingIds":[],"namespace":"<no location>","location":"","key":"%NumberFormat%"},{"type":"op","aoid":"ChainNumberFormat","refId":"sec-chainnumberformat","location":"","referencingIds":[],"key":"ChainNumberFormat"},{"type":"clause","id":"sec-chainnumberformat","aoid":"ChainNumberFormat","title":"ChainNumberFormat ( numberFormat, newTarget, this )","titleHTML":"ChainNumberFormat ( <var>numberFormat</var>, <var>newTarget</var>, <var>this</var> )","number":"1.1.1.1","namespace":"<no location>","location":"","referencingIds":["_ref_19"],"key":"ChainNumberFormat ( numberFormat, newTarget, this )"},{"type":"clause","id":"sec-intl.numberformat","aoid":null,"title":"Intl.NumberFormat ( [ locales [ , options ] ] )","titleHTML":"Intl.NumberFormat ( [ <var>locales</var> [ , <var>options</var> ] ] )","number":"1.1.1","namespace":"<no location>","location":"","referencingIds":[],"key":"Intl.NumberFormat ( [ locales [ , options ] ] )"},{"type":"op","aoid":"InitializeNumberFormat","refId":"sec-initializenumberformat","location":"","referencingIds":[],"key":"InitializeNumberFormat"},{"type":"clause","id":"sec-initializenumberformat","aoid":"InitializeNumberFormat","title":"InitializeNumberFormat ( numberFormat, locales, options )","titleHTML":"InitializeNumberFormat ( <var>numberFormat</var>, <var>locales</var>, <var>options</var> )","number":"1.1.2","namespace":"<no location>","location":"","referencingIds":["_ref_18"],"key":"InitializeNumberFormat ( numberFormat, locales, options )"},{"type":"op","aoid":"SetNumberFormatDigitOptions","refId":"sec-setnfdigitoptions","location":"","referencingIds":[],"key":"SetNumberFormatDigitOptions"},{"type":"clause","id":"sec-setnfdigitoptions","aoid":"SetNumberFormatDigitOptions","title":"SetNumberFormatDigitOptions ( intlObj, options, mnfdDefault, mxfdDefault, notation )","titleHTML":"SetNumberFormatDigitOptions ( <var>intlObj</var>, <var>options</var>, <var>mnfdDefault</var>, <var>mxfdDefault</var>, <var>notation</var> )","number":"1.1.3","namespace":"<no location>","location":"","referencingIds":["_ref_28"],"key":"SetNumberFormatDigitOptions ( intlObj, options, mnfdDefault, mxfdDefault, notation )"},{"type":"op","aoid":"SetNumberFormatUnitOptions","refId":"sec-setnumberformatunitoptions","location":"","referencingIds":[],"key":"SetNumberFormatUnitOptions"},{"type":"clause","id":"sec-setnumberformatunitoptions","aoid":"SetNumberFormatUnitOptions","title":"SetNumberFormatUnitOptions ( intlObj, options )","titleHTML":"SetNumberFormatUnitOptions ( <var>intlObj</var>, <var>options</var> )","number":"1.1.4","namespace":"<no location>","location":"","referencingIds":["_ref_26"],"key":"SetNumberFormatUnitOptions ( intlObj, options )"},{"type":"clause","id":"sec-intl-numberformat-constructor","aoid":null,"title":"The Intl.NumberFormat Constructor","titleHTML":"The Intl.NumberFormat Constructor","number":"1.1","namespace":"<no location>","location":"","referencingIds":["_ref_21","_ref_23","_ref_24","_ref_25","_ref_37","_ref_38","_ref_91","_ref_94","_ref_96","_ref_97"],"key":"The Intl.NumberFormat Constructor"},{"type":"clause","id":"sec-intl.numberformat.prototype","aoid":null,"title":"Intl.NumberFormat.prototype","titleHTML":"Intl.NumberFormat.prototype","number":"1.2.1","namespace":"<no location>","location":"","referencingIds":[],"key":"Intl.NumberFormat.prototype"},{"type":"clause","id":"sec-intl.numberformat.supportedlocalesof","aoid":null,"title":"Intl.NumberFormat.supportedLocalesOf ( locales [ , options ] )","titleHTML":"Intl.NumberFormat.supportedLocalesOf ( <var>locales</var> [ , <var>options</var> ] )","number":"1.2.2","namespace":"<no location>","location":"","referencingIds":[],"key":"Intl.NumberFormat.supportedLocalesOf ( locales [ , options ] )"},{"type":"clause","id":"sec-intl.numberformat-internal-slots","aoid":null,"title":"Internal slots","titleHTML":"Internal slots","number":"1.2.3","namespace":"<no location>","location":"","referencingIds":["_ref_9","_ref_10","_ref_11","_ref_12"],"key":"Internal slots"},{"type":"clause","id":"sec-properties-of-intl-numberformat-constructor","aoid":null,"title":"Properties of the Intl.NumberFormat Constructor","titleHTML":"Properties of the Intl.NumberFormat Constructor","number":"1.2","namespace":"<no location>","location":"","referencingIds":[],"key":"Properties of the Intl.NumberFormat Constructor"},{"type":"term","term":"%NumberFormat.prototype%","refId":"sec-properties-of-intl-numberformat-prototype-object","referencingIds":[],"namespace":"<no location>","location":"","key":"%NumberFormat.prototype%"},{"type":"clause","id":"sec-intl.numberformat.prototype.constructor","aoid":null,"title":"Intl.NumberFormat.prototype.constructor","titleHTML":"Intl.NumberFormat.prototype.constructor","number":"1.3.1","namespace":"<no location>","location":"","referencingIds":[],"key":"Intl.NumberFormat.prototype.constructor"},{"type":"clause","id":"sec-intl.numberformat.prototype-@@tostringtag","aoid":null,"title":"Intl.NumberFormat.prototype [ @@toStringTag ]","titleHTML":"Intl.NumberFormat.prototype [ @@toStringTag ]","number":"1.3.2","namespace":"<no location>","location":"","referencingIds":[],"key":"Intl.NumberFormat.prototype [ @@toStringTag ]"},{"type":"clause","id":"sec-intl.numberformat.prototype.format","aoid":null,"title":"get Intl.NumberFormat.prototype.format","titleHTML":"get Intl.NumberFormat.prototype.format","number":"1.3.3","namespace":"<no location>","location":"","referencingIds":["_ref_4"],"key":"get Intl.NumberFormat.prototype.format"},{"type":"clause","id":"sec-intl.numberformat.prototype.formattoparts","aoid":null,"title":"Intl.NumberFormat.prototype.formatToParts ( value )","titleHTML":"Intl.NumberFormat.prototype.formatToParts ( <var>value</var> )","number":"1.3.4","namespace":"<no location>","location":"","referencingIds":[],"key":"Intl.NumberFormat.prototype.formatToParts ( value )"},{"type":"clause","id":"sec-intl.numberformat.prototype.formatrange","aoid":null,"title":"Intl.NumberFormat.prototype.formatRange ( start, end )","titleHTML":"Intl.NumberFormat.prototype.formatRange ( <var>start</var>, <var>end</var> )","number":"1.3.5","namespace":"<no location>","location":"","referencingIds":[],"key":"Intl.NumberFormat.prototype.formatRange ( start, end )"},{"type":"clause","id":"sec-intl.numberformat.prototype.formatrangetoparts","aoid":null,"title":"Intl.NumberFormat.prototype.formatRangeToParts ( start, end )","titleHTML":"Intl.NumberFormat.prototype.formatRangeToParts ( <var>start</var>, <var>end</var> )","number":"1.3.6","namespace":"<no location>","location":"","referencingIds":[],"key":"Intl.NumberFormat.prototype.formatRangeToParts ( start, end )"},{"type":"table","id":"table-numberformat-resolvedoptions-properties","number":1,"caption":"Table 1: Resolved Options of NumberFormat Instances","referencingIds":["_ref_1"],"namespace":"<no location>","location":"","key":"Table 1: Resolved Options of NumberFormat Instances"},{"type":"clause","id":"sec-intl.numberformat.prototype.resolvedoptions","aoid":null,"title":"Intl.NumberFormat.prototype.resolvedOptions ( )","titleHTML":"Intl.NumberFormat.prototype.resolvedOptions ( )","number":"1.3.7","namespace":"<no location>","location":"","referencingIds":["_ref_2"],"key":"Intl.NumberFormat.prototype.resolvedOptions ( )"},{"type":"clause","id":"sec-properties-of-intl-numberformat-prototype-object","aoid":null,"title":"Properties of the Intl.NumberFormat Prototype Object","titleHTML":"Properties of the Intl.NumberFormat Prototype Object","number":"1.3","namespace":"<no location>","location":"","referencingIds":["_ref_36","_ref_59"],"key":"Properties of the Intl.NumberFormat Prototype Object"},{"type":"table","id":"table-intl-rounding-modes","number":2,"caption":"Table 2: Rounding modes in Intl.NumberFormat","referencingIds":["_ref_3","_ref_13"],"namespace":"<no location>","location":"","key":"Table 2: Rounding modes in Intl.NumberFormat"},{"type":"clause","id":"sec-properties-of-intl-numberformat-instances","aoid":null,"title":"Properties of Intl.NumberFormat Instances","titleHTML":"Properties of Intl.NumberFormat Instances","number":"1.4","namespace":"<no location>","location":"","referencingIds":[],"key":"Properties of Intl.NumberFormat Instances"},{"type":"op","aoid":"CurrencyDigits","refId":"sec-currencydigits","location":"","referencingIds":[],"key":"CurrencyDigits"},{"type":"clause","id":"sec-currencydigits","aoid":"CurrencyDigits","title":"CurrencyDigits ( currency )","titleHTML":"CurrencyDigits ( <var>currency</var> )","number":"1.5.1","namespace":"<no location>","location":"","referencingIds":["_ref_27"],"key":"CurrencyDigits ( currency )"},{"type":"clause","id":"sec-number-format-functions","aoid":null,"title":"Number Format Functions","titleHTML":"Number Format Functions","number":"1.5.2","namespace":"<no location>","location":"","referencingIds":["_ref_0"],"key":"Number Format Functions"},{"type":"op","aoid":"FormatNumericToString","refId":"sec-formatnumberstring","location":"","referencingIds":[],"key":"FormatNumericToString"},{"type":"clause","id":"sec-formatnumberstring","aoid":"FormatNumericToString","title":"FormatNumericToString ( intlObject, x )","titleHTML":"FormatNumericToString ( <var>intlObject</var>, <var>x</var> )","number":"1.5.3","namespace":"<no location>","location":"","referencingIds":["_ref_73","_ref_99"],"key":"FormatNumericToString ( intlObject, x )"},{"type":"op","aoid":"PartitionNumberPattern","refId":"sec-partitionnumberpattern","location":"","referencingIds":[],"key":"PartitionNumberPattern"},{"type":"clause","id":"sec-partitionnumberpattern","aoid":"PartitionNumberPattern","title":"PartitionNumberPattern ( numberFormat, x )","titleHTML":"PartitionNumberPattern ( <var>numberFormat</var>, <var>x</var> )","number":"1.5.4","namespace":"<no location>","location":"","referencingIds":["_ref_78","_ref_79","_ref_108","_ref_109","_ref_112"],"key":"PartitionNumberPattern ( numberFormat, x )"},{"type":"table","id":"table-numbering-system-digits","number":3,"caption":"Table 3: Numbering systems with simple digit mappings","referencingIds":["_ref_5","_ref_6"],"namespace":"<no location>","location":"","key":"Table 3: Numbering systems with simple digit mappings"},{"type":"op","aoid":"PartitionNotationSubPattern","refId":"sec-partitionnotationsubpattern","location":"","referencingIds":[],"key":"PartitionNotationSubPattern"},{"type":"clause","id":"sec-partitionnotationsubpattern","aoid":"PartitionNotationSubPattern","title":"PartitionNotationSubPattern ( numberFormat, x, n, exponent )","titleHTML":"PartitionNotationSubPattern ( <var>numberFormat</var>, <var>x</var>, <var>n</var>, <var>exponent</var> )","number":"1.5.5","namespace":"<no location>","location":"","referencingIds":["_ref_75"],"key":"PartitionNotationSubPattern ( numberFormat, x, n, exponent )"},{"type":"op","aoid":"FormatNumeric","refId":"sec-formatnumber","location":"","referencingIds":[],"key":"FormatNumeric"},{"type":"clause","id":"sec-formatnumber","aoid":"FormatNumeric","title":"FormatNumeric ( numberFormat, x )","titleHTML":"FormatNumeric ( <var>numberFormat</var>, <var>x</var> )","number":"1.5.6","namespace":"<no location>","location":"","referencingIds":["_ref_63"],"key":"FormatNumeric ( numberFormat, x )"},{"type":"op","aoid":"FormatNumericToParts","refId":"sec-formatnumbertoparts","location":"","referencingIds":[],"key":"FormatNumericToParts"},{"type":"clause","id":"sec-formatnumbertoparts","aoid":"FormatNumericToParts","title":"FormatNumericToParts ( numberFormat, x )","titleHTML":"FormatNumericToParts ( <var>numberFormat</var>, <var>x</var> )","number":"1.5.7","namespace":"<no location>","location":"","referencingIds":["_ref_44"],"key":"FormatNumericToParts ( numberFormat, x )"},{"type":"op","aoid":"ToRawPrecisionFn","id":"eqn-ToRawPrecisionFn","referencingIds":["_ref_85","_ref_86"],"namespace":"<no location>","location":"","key":"ToRawPrecisionFn"},{"type":"op","aoid":"ToRawPrecision","refId":"sec-torawprecision","location":"","referencingIds":[],"key":"ToRawPrecision"},{"type":"clause","id":"sec-torawprecision","aoid":"ToRawPrecision","title":"ToRawPrecision ( x, minPrecision, maxPrecision, unsignedRoundingMode )","titleHTML":"ToRawPrecision ( <var>x</var>, <var>minPrecision</var>, <var>maxPrecision</var><ins>, <var>unsignedRoundingMode</var></ins> )","number":"1.5.8","namespace":"<no location>","location":"","referencingIds":["_ref_65","_ref_67","_ref_69"],"key":"ToRawPrecision ( x, minPrecision, maxPrecision, unsignedRoundingMode )"},{"type":"op","aoid":"ToRawFixedFn","id":"eqn-ToRawFixedFn","referencingIds":["_ref_88","_ref_89"],"namespace":"<no location>","location":"","key":"ToRawFixedFn"},{"type":"op","aoid":"ToRawFixed","refId":"sec-torawfixed","location":"","referencingIds":[],"key":"ToRawFixed"},{"type":"clause","id":"sec-torawfixed","aoid":"ToRawFixed","title":"ToRawFixed ( x, minInteger, minFraction, maxFraction, roundingIncrement, unsignedRoundingMode )","titleHTML":"ToRawFixed ( <var>x</var>, <del><var>minInteger</var>,</del> <var>minFraction</var>, <var>maxFraction</var><ins>, <var>roundingIncrement</var>, <var>unsignedRoundingMode</var></ins> )","number":"1.5.9","namespace":"<no location>","location":"","referencingIds":["_ref_66","_ref_68","_ref_70","_ref_77"],"key":"ToRawFixed ( x, minInteger, minFraction, maxFraction, roundingIncrement, unsignedRoundingMode )"},{"type":"op","aoid":"UnwrapNumberFormat","refId":"sec-unwrapnumberformat","location":"","referencingIds":[],"key":"UnwrapNumberFormat"},{"type":"clause","id":"sec-unwrapnumberformat","aoid":"UnwrapNumberFormat","title":"UnwrapNumberFormat ( nf )","titleHTML":"UnwrapNumberFormat ( <var>nf</var> )","number":"1.5.10","namespace":"<no location>","location":"","referencingIds":["_ref_39","_ref_53"],"key":"UnwrapNumberFormat ( nf )"},{"type":"op","aoid":"GetNumberFormatPattern","refId":"sec-getnumberformatpattern","location":"","referencingIds":[],"key":"GetNumberFormatPattern"},{"type":"clause","id":"sec-getnumberformatpattern","aoid":"GetNumberFormatPattern","title":"GetNumberFormatPattern ( numberFormat, x )","titleHTML":"GetNumberFormatPattern ( <var>numberFormat</var>, <var>x</var> )","number":"1.5.11","namespace":"<no location>","location":"","referencingIds":["_ref_74"],"key":"GetNumberFormatPattern ( numberFormat, x )"},{"type":"op","aoid":"GetNotationSubPattern","refId":"sec-getnotationsubpattern","location":"","referencingIds":[],"key":"GetNotationSubPattern"},{"type":"clause","id":"sec-getnotationsubpattern","aoid":"GetNotationSubPattern","title":"GetNotationSubPattern ( numberFormat, exponent )","titleHTML":"GetNotationSubPattern ( <var>numberFormat</var>, <var>exponent</var> )","number":"1.5.12","namespace":"<no location>","location":"","referencingIds":["_ref_76"],"key":"GetNotationSubPattern ( numberFormat, exponent )"},{"type":"op","aoid":"ComputeExponent","refId":"sec-computeexponent","location":"","referencingIds":[],"key":"ComputeExponent"},{"type":"clause","id":"sec-computeexponent","aoid":"ComputeExponent","title":"ComputeExponent ( numberFormat, x )","titleHTML":"ComputeExponent ( <var>numberFormat</var>, <var>x</var> )","number":"1.5.13","namespace":"<no location>","location":"","referencingIds":["_ref_71","_ref_72"],"key":"ComputeExponent ( numberFormat, x )"},{"type":"op","aoid":"ComputeExponentForMagnitude","refId":"sec-computeexponentformagnitude","location":"","referencingIds":[],"key":"ComputeExponentForMagnitude"},{"type":"clause","id":"sec-computeexponentformagnitude","aoid":"ComputeExponentForMagnitude","title":"ComputeExponentForMagnitude ( numberFormat, magnitude )","titleHTML":"ComputeExponentForMagnitude ( <var>numberFormat</var>, <var>magnitude</var> )","number":"1.5.14","namespace":"<no location>","location":"","referencingIds":["_ref_98","_ref_100"],"key":"ComputeExponentForMagnitude ( numberFormat, magnitude )"},{"type":"production","id":"prod-StringNumericLiteral","name":"StringNumericLiteral","referencingIds":["_ref_127","_ref_132"],"namespace":"<no location>","location":"","key":"StringNumericLiteral"},{"type":"production","id":"prod-StrNumericLiteral","name":"StrNumericLiteral","referencingIds":["_ref_128","_ref_129"],"namespace":"<no location>","location":"","key":"StrNumericLiteral"},{"type":"production","id":"prod-StrDecimalLiteral","name":"StrDecimalLiteral","referencingIds":[],"namespace":"<no location>","location":"","key":"StrDecimalLiteral"},{"type":"production","id":"prod-StrUnsignedDecimalLiteral","name":"StrUnsignedDecimalLiteral","referencingIds":["_ref_130","_ref_131"],"namespace":"<no location>","location":"","key":"StrUnsignedDecimalLiteral"},{"type":"clause","id":"sec-runtime-semantics-stringintlmv","aoid":null,"title":"Runtime Semantics: StringIntlMV","titleHTML":"Runtime Semantics: StringIntlMV","number":"1.5.15","namespace":"<no location>","location":"","referencingIds":[],"key":"Runtime Semantics: StringIntlMV"},{"type":"term","term":"Intl mathematical value","refId":"sec-tointlmathematicalvalue","referencingIds":["_ref_106","_ref_107","_ref_114","_ref_115","_ref_117","_ref_118"],"id":"intl-mathematical-value","namespace":"<no location>","location":"","key":"Intl mathematical value"},{"type":"op","aoid":"ToIntlMathematicalValue","refId":"sec-tointlmathematicalvalue","location":"","referencingIds":[],"key":"ToIntlMathematicalValue"},{"type":"clause","id":"sec-tointlmathematicalvalue","aoid":"ToIntlMathematicalValue","title":"ToIntlMathematicalValue ( value )","titleHTML":"ToIntlMathematicalValue ( <var>value</var> )","number":"1.5.16","namespace":"<no location>","location":"","referencingIds":["_ref_43","_ref_46","_ref_47","_ref_50","_ref_51","_ref_62"],"key":"ToIntlMathematicalValue ( value )"},{"type":"table","id":"table-intl-unsigned-rounding-modes","number":4,"caption":"Table 4: Conversion from rounding mode to unsigned rounding mode","referencingIds":["_ref_7","_ref_8","_ref_14","_ref_15","_ref_16"],"namespace":"<no location>","location":"","key":"Table 4: Conversion from rounding mode to unsigned rounding mode"},{"type":"op","aoid":"GetUnsignedRoundingMode","refId":"sec-getunsignedroundingmode","location":"","referencingIds":[],"key":"GetUnsignedRoundingMode"},{"type":"clause","id":"sec-getunsignedroundingmode","aoid":"GetUnsignedRoundingMode","title":"GetUnsignedRoundingMode ( roundingMode, isNegative )","titleHTML":"GetUnsignedRoundingMode ( <var>roundingMode</var>, <var>isNegative</var> )","number":"1.5.17","namespace":"<no location>","location":"","referencingIds":["_ref_64"],"key":"GetUnsignedRoundingMode ( roundingMode, isNegative )"},{"type":"op","aoid":"ApplyUnsignedRoundingMode","refId":"sec-applyunsignedroundingmode","location":"","referencingIds":[],"key":"ApplyUnsignedRoundingMode"},{"type":"clause","id":"sec-applyunsignedroundingmode","aoid":"ApplyUnsignedRoundingMode","title":"ApplyUnsignedRoundingMode ( x, r1, r2, unsignedRoundingMode )","titleHTML":"ApplyUnsignedRoundingMode ( <var>x</var>, <var>r1</var>, <var>r2</var>, <var>unsignedRoundingMode</var> )","number":"1.5.18","namespace":"<no location>","location":"","referencingIds":["_ref_87","_ref_90"],"key":"ApplyUnsignedRoundingMode ( x, r1, r2, unsignedRoundingMode )"},{"type":"op","aoid":"PartitionNumberRangePattern","refId":"sec-partitionnumberrangepattern","location":"","referencingIds":[],"key":"PartitionNumberRangePattern"},{"type":"clause","id":"sec-partitionnumberrangepattern","aoid":"PartitionNumberRangePattern","title":"PartitionNumberRangePattern ( numberFormat, x, y )","titleHTML":"PartitionNumberRangePattern ( <var>numberFormat</var>, <var>x</var>, <var>y</var> )","number":"1.5.19","namespace":"<no location>","location":"","referencingIds":["_ref_113","_ref_116","_ref_119"],"key":"PartitionNumberRangePattern ( numberFormat, x, y )"},{"type":"op","aoid":"FormatApproximately","refId":"sec-formatapproximately","location":"","referencingIds":[],"key":"FormatApproximately"},{"type":"clause","id":"sec-formatapproximately","aoid":"FormatApproximately","title":"FormatApproximately ( numberFormat, result )","titleHTML":"FormatApproximately ( <var>numberFormat</var>, <var>result</var> )","number":"1.5.20","namespace":"<no location>","location":"","referencingIds":["_ref_110"],"key":"FormatApproximately ( numberFormat, result )"},{"type":"op","aoid":"CollapseNumberRange","refId":"sec-collapsenumberrange","location":"","referencingIds":[],"key":"CollapseNumberRange"},{"type":"clause","id":"sec-collapsenumberrange","aoid":"CollapseNumberRange","title":"CollapseNumberRange ( result )","titleHTML":"CollapseNumberRange ( <var>result</var> )","number":"1.5.21","namespace":"<no location>","location":"","referencingIds":["_ref_111"],"key":"CollapseNumberRange ( result )"},{"type":"op","aoid":"FormatNumericRange","refId":"sec-formatnumericrange","location":"","referencingIds":[],"key":"FormatNumericRange"},{"type":"clause","id":"sec-formatnumericrange","aoid":"FormatNumericRange","title":"FormatNumericRange( numberFormat, x, y )","titleHTML":"FormatNumericRange( <var>numberFormat</var>, <var>x</var>, <var>y</var> )","number":"1.5.22","namespace":"<no location>","location":"","referencingIds":["_ref_48"],"key":"FormatNumericRange( numberFormat, x, y )"},{"type":"op","aoid":"FormatNumericRangeToParts","refId":"sec-formatnumericrangetoparts","location":"","referencingIds":[],"key":"FormatNumericRangeToParts"},{"type":"clause","id":"sec-formatnumericrangetoparts","aoid":"FormatNumericRangeToParts","title":"FormatNumericRangeToParts( numberFormat, x, y )","titleHTML":"FormatNumericRangeToParts( <var>numberFormat</var>, <var>x</var>, <var>y</var> )","number":"1.5.23","namespace":"<no location>","location":"","referencingIds":["_ref_52"],"key":"FormatNumericRangeToParts( numberFormat, x, y )"},{"type":"clause","id":"sec-numberformat-abstracts","aoid":null,"title":"Abstract Operations for NumberFormat Objects","titleHTML":"Abstract Operations for NumberFormat Objects","number":"1.5","namespace":"<no location>","location":"","referencingIds":[],"key":"Abstract Operations for NumberFormat Objects"},{"type":"clause","id":"numberformat-objects","aoid":null,"title":"NumberFormat Objects","titleHTML":"NumberFormat Objects","number":"1","namespace":"<no location>","location":"","referencingIds":[],"key":"NumberFormat Objects"}]</script><script>"use strict";
+<head><meta charset="utf-8"><script>'use strict';
+let sdoBox = {
+  init() {
+    this.$alternativeId = null;
+    this.$outer = document.createElement('div');
+    this.$outer.classList.add('toolbox-container');
+    this.$container = document.createElement('div');
+    this.$container.classList.add('toolbox');
+    this.$displayLink = document.createElement('a');
+    this.$displayLink.setAttribute('href', '#');
+    this.$displayLink.textContent = 'Syntax-Directed Operations';
+    this.$displayLink.addEventListener('click', e => {
+      e.preventDefault();
+      e.stopPropagation();
+      referencePane.showSDOs(sdoMap[this.$alternativeId] || {}, this.$alternativeId);
+    });
+    this.$container.appendChild(this.$displayLink);
+    this.$outer.appendChild(this.$container);
+    document.body.appendChild(this.$outer);
+  },
 
+  activate(el) {
+    clearTimeout(this.deactiveTimeout);
+    Toolbox.deactivate();
+    this.$alternativeId = el.id;
+    let numSdos = Object.keys(sdoMap[this.$alternativeId] || {}).length;
+    this.$displayLink.textContent = 'Syntax-Directed Operations (' + numSdos + ')';
+    this.$outer.classList.add('active');
+    let top = el.offsetTop - this.$outer.offsetHeight;
+    let left = el.offsetLeft + 50 - 10; // 50px = padding-left(=75px) + text-indent(=-25px)
+    this.$outer.setAttribute('style', 'left: ' + left + 'px; top: ' + top + 'px');
+    if (top < document.body.scrollTop) {
+      this.$container.scrollIntoView();
+    }
+  },
+
+  deactivate() {
+    clearTimeout(this.deactiveTimeout);
+    this.$outer.classList.remove('active');
+  },
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+  if (typeof sdoMap == 'undefined') {
+    console.error('could not find sdo map');
+    return;
+  }
+  sdoBox.init();
+
+  let insideTooltip = false;
+  sdoBox.$outer.addEventListener('pointerenter', () => {
+    insideTooltip = true;
+  });
+  sdoBox.$outer.addEventListener('pointerleave', () => {
+    insideTooltip = false;
+    sdoBox.deactivate();
+  });
+
+  sdoBox.deactiveTimeout = null;
+  [].forEach.call(document.querySelectorAll('emu-grammar[type=definition] emu-rhs'), node => {
+    node.addEventListener('pointerenter', function () {
+      sdoBox.activate(this);
+    });
+
+    node.addEventListener('pointerleave', () => {
+      sdoBox.deactiveTimeout = setTimeout(() => {
+        if (!insideTooltip) {
+          sdoBox.deactivate();
+        }
+      }, 500);
+    });
+  });
+
+  document.addEventListener(
+    'keydown',
+    debounce(e => {
+      if (e.code === 'Escape') {
+        sdoBox.deactivate();
+      }
+    })
+  );
+});
+
+'use strict';
 function Search(menu) {
   this.menu = menu;
   this.$search = document.getElementById('menu-search');
@@ -11,8 +93,14 @@ function Search(menu) {
 
   document.addEventListener('keydown', this.documentKeydown.bind(this));
 
-  this.$searchBox.addEventListener('keydown', debounce(this.searchBoxKeydown.bind(this), { stopPropagation: true }));
-  this.$searchBox.addEventListener('keyup', debounce(this.searchBoxKeyup.bind(this), { stopPropagation: true }));
+  this.$searchBox.addEventListener(
+    'keydown',
+    debounce(this.searchBoxKeydown.bind(this), { stopPropagation: true })
+  );
+  this.$searchBox.addEventListener(
+    'keyup',
+    debounce(this.searchBoxKeyup.bind(this), { stopPropagation: true })
+  );
 
   // Perform an initial search if the box is not empty.
   if (this.$searchBox.value) {
@@ -21,26 +109,34 @@ function Search(menu) {
 }
 
 Search.prototype.loadBiblio = function () {
-  var $biblio = document.getElementById('menu-search-biblio');
-  if (!$biblio) {
-    this.biblio = [];
+  if (typeof biblio === 'undefined') {
+    console.error('could not find biblio');
+    this.biblio = { refToClause: {}, entries: [] };
   } else {
-    this.biblio = JSON.parse($biblio.textContent);
-    this.biblio.clauses = this.biblio.filter(function (e) { return e.type === 'clause' });
-    this.biblio.byId = this.biblio.reduce(function (map, entry) {
+    this.biblio = biblio;
+    this.biblio.clauses = this.biblio.entries.filter(e => e.type === 'clause');
+    this.biblio.byId = this.biblio.entries.reduce((map, entry) => {
       map[entry.id] = entry;
       return map;
     }, {});
+    let refParentClause = Object.create(null);
+    this.biblio.refParentClause = refParentClause;
+    let refsByClause = this.biblio.refsByClause;
+    Object.keys(refsByClause).forEach(clause => {
+      refsByClause[clause].forEach(ref => {
+        refParentClause[ref] = clause;
+      });
+    });
   }
-}
+};
 
 Search.prototype.documentKeydown = function (e) {
-  if (e.keyCode === 191) {
+  if (e.key === '/') {
     e.preventDefault();
     e.stopPropagation();
     this.triggerSearch();
   }
-}
+};
 
 Search.prototype.searchBoxKeydown = function (e) {
   e.stopPropagation();
@@ -51,7 +147,7 @@ Search.prototype.searchBoxKeydown = function (e) {
     e.preventDefault();
     this.selectResult();
   }
-}
+};
 
 Search.prototype.searchBoxKeyup = function (e) {
   if (e.keyCode === 13 || e.keyCode === 9) {
@@ -59,10 +155,9 @@ Search.prototype.searchBoxKeyup = function (e) {
   }
 
   this.search(e.target.value);
-}
+};
 
-
-Search.prototype.triggerSearch = function (e) {
+Search.prototype.triggerSearch = function () {
   if (this.menu.isVisible()) {
     this._closeAfterSearch = false;
   } else {
@@ -72,14 +167,14 @@ Search.prototype.triggerSearch = function (e) {
 
   this.$searchBox.focus();
   this.$searchBox.select();
-}
+};
 // bit 12 - Set if the result starts with searchString
 // bits 8-11: 8 - number of chunks multiplied by 2 if cases match, otherwise 1.
 // bits 1-7: 127 - length of the entry
 // General scheme: prefer case sensitive matches with fewer chunks, and otherwise
 // prefer shorter matches.
-function relevance(result, searchString) {
-  var relevance = 0;
+function relevance(result) {
+  let relevance = 0;
 
   relevance = Math.max(0, 8 - result.match.chunks) << 7;
 
@@ -88,10 +183,10 @@ function relevance(result, searchString) {
   }
 
   if (result.match.prefix) {
-    relevance += 2048
+    relevance += 2048;
   }
 
-  relevance += Math.max(0, 255 - result.entry.key.length);
+  relevance += Math.max(0, 255 - result.key.length);
 
   return relevance;
 }
@@ -110,36 +205,34 @@ Search.prototype.search = function (searchString) {
     return;
   }
 
-  var results;
+  let results;
 
-  if (/^[\d\.]*$/.test(searchString)) {
-    results = this.biblio.clauses.filter(function (clause) {
-      return clause.number.substring(0, searchString.length) === searchString;
-    }).map(function (clause) {
-      return { entry: clause };
-    });
+  if (/^[\d.]*$/.test(searchString)) {
+    results = this.biblio.clauses
+      .filter(clause => clause.number.substring(0, searchString.length) === searchString)
+      .map(clause => ({ key: getKey(clause), entry: clause }));
   } else {
     results = [];
 
-    for (var i = 0; i < this.biblio.length; i++) {
-      var entry = this.biblio[i];
-      if (!entry.key) {
+    for (let i = 0; i < this.biblio.entries.length; i++) {
+      let entry = this.biblio.entries[i];
+      let key = getKey(entry);
+      if (!key) {
         // biblio entries without a key aren't searchable
         continue;
       }
 
-      var match = fuzzysearch(searchString, entry.key);
+      let match = fuzzysearch(searchString, key);
       if (match) {
-        results.push({ entry: entry, match: match });
+        results.push({ key, entry, match });
       }
     }
 
-    results.forEach(function (result) {
+    results.forEach(result => {
       result.relevance = relevance(result, searchString);
     });
 
-    results = results.sort(function (a, b) { return b.relevance - a.relevance });
-
+    results = results.sort((a, b) => b.relevance - a.relevance);
   }
 
   if (results.length > 50) {
@@ -147,17 +240,17 @@ Search.prototype.search = function (searchString) {
   }
 
   this.displayResults(results);
-}
+};
 Search.prototype.hideSearch = function () {
   this.$search.classList.remove('active');
-}
+};
 
 Search.prototype.showSearch = function () {
   this.$search.classList.add('active');
-}
+};
 
 Search.prototype.selectResult = function () {
-  var $first = this.$searchResults.querySelector('li:first-child a');
+  let $first = this.$searchResults.querySelector('li:first-child a');
 
   if ($first) {
     document.location = $first.getAttribute('href');
@@ -171,53 +264,79 @@ Search.prototype.selectResult = function () {
   if (this._closeAfterSearch) {
     this.menu.hide();
   }
-}
+};
 
 Search.prototype.displayResults = function (results) {
   if (results.length > 0) {
     this.$searchResults.classList.remove('no-results');
 
-    var html = '<ul>';
+    let html = '<ul>';
 
-    results.forEach(function (result) {
-      var entry = result.entry;
-      var id = entry.id;
-      var cssClass = '';
-      var text = '';
+    results.forEach(result => {
+      let key = result.key;
+      let entry = result.entry;
+      let id = entry.id;
+      let cssClass = '';
+      let text = '';
 
       if (entry.type === 'clause') {
-        var number = entry.number ? entry.number + ' ' : '';
-        text = number + entry.key;
+        let number = entry.number ? entry.number + ' ' : '';
+        text = number + key;
         cssClass = 'clause';
         id = entry.id;
       } else if (entry.type === 'production') {
-        text = entry.key;
+        text = key;
         cssClass = 'prod';
         id = entry.id;
       } else if (entry.type === 'op') {
-        text = entry.key;
+        text = key;
         cssClass = 'op';
         id = entry.id || entry.refId;
       } else if (entry.type === 'term') {
-        text = entry.key;
+        text = key;
         cssClass = 'term';
         id = entry.id || entry.refId;
       }
 
       if (text) {
-        html += '<li class=menu-search-result-' + cssClass + '><a href="#' + id + '">' + text + '</a></li>';
+        // prettier-ignore
+        html += `<li class=menu-search-result-${cssClass}><a href="${makeLinkToId(id)}">${text}</a></li>`;
       }
     });
 
-    html += '</ul>'
+    html += '</ul>';
 
     this.$searchResults.innerHTML = html;
   } else {
     this.$searchResults.innerHTML = '';
     this.$searchResults.classList.add('no-results');
   }
-}
+};
 
+function getKey(item) {
+  if (item.key) {
+    return item.key;
+  }
+  switch (item.type) {
+    case 'clause':
+      return item.title || item.titleHTML;
+    case 'production':
+      return item.name;
+    case 'op':
+      return item.aoid;
+    case 'term':
+      return item.term;
+    case 'table':
+    case 'figure':
+    case 'example':
+    case 'note':
+      return item.caption;
+    case 'step':
+      return item.id;
+    default:
+      throw new Error("Can't get key for " + item.type);
+  }
+}
 
 function Menu() {
   this.$toggle = document.getElementById('menu-toggle');
@@ -229,7 +348,7 @@ function Menu() {
   this.$specContainer = document.getElementById('spec-container');
   this.search = new Search(this);
 
-  this._pinnedIds = {}; 
+  this._pinnedIds = {};
   this.loadPinEntries();
 
   // toggle menu
@@ -239,23 +358,23 @@ function Menu() {
   document.addEventListener('keydown', this.documentKeydown.bind(this));
 
   // toc expansion
-  var tocItems = this.$menu.querySelectorAll('#menu-toc li');
-  for (var i = 0; i < tocItems.length; i++) {
-    var $item = tocItems[i];
-    $item.addEventListener('click', function($item, event) {
+  let tocItems = this.$menu.querySelectorAll('#menu-toc li');
+  for (let i = 0; i < tocItems.length; i++) {
+    let $item = tocItems[i];
+    $item.addEventListener('click', event => {
       $item.classList.toggle('active');
       event.stopPropagation();
-    }.bind(null, $item));
+    });
   }
 
   // close toc on toc item selection
-  var tocLinks = this.$menu.querySelectorAll('#menu-toc li > a');
-  for (var i = 0; i < tocLinks.length; i++) {
-    var $link = tocLinks[i];
-    $link.addEventListener('click', function(event) {
+  let tocLinks = this.$menu.querySelectorAll('#menu-toc li > a');
+  for (let i = 0; i < tocLinks.length; i++) {
+    let $link = tocLinks[i];
+    $link.addEventListener('click', event => {
       this.toggle();
       event.stopPropagation();
-    }.bind(this));
+    });
   }
 
   // update active clause on scroll
@@ -263,14 +382,13 @@ function Menu() {
   this.updateActiveClause();
 
   // prevent menu scrolling from scrolling the body
-  this.$toc.addEventListener('wheel', function (e) {
-    var target = e.currentTarget;
-    var offTop = e.deltaY < 0 && target.scrollTop === 0;
+  this.$toc.addEventListener('wheel', e => {
+    let target = e.currentTarget;
+    let offTop = e.deltaY < 0 && target.scrollTop === 0;
     if (offTop) {
       e.preventDefault();
     }
-    var offBottom = e.deltaY > 0
-                    && target.offsetHeight + target.scrollTop >= target.scrollHeight;
+    let offBottom = e.deltaY > 0 && target.offsetHeight + target.scrollTop >= target.scrollHeight;
 
     if (offBottom) {
       e.preventDefault();
@@ -285,62 +403,66 @@ Menu.prototype.documentKeydown = function (e) {
   } else if (e.keyCode > 48 && e.keyCode < 58) {
     this.selectPin(e.keyCode - 49);
   }
-}
+};
 
 Menu.prototype.updateActiveClause = function () {
-  this.setActiveClause(findActiveClause(this.$specContainer))
-}
+  this.setActiveClause(findActiveClause(this.$specContainer));
+};
 
 Menu.prototype.setActiveClause = function (clause) {
   this.$activeClause = clause;
   this.revealInToc(this.$activeClause);
-}
+};
 
 Menu.prototype.revealInToc = function (path) {
-  var current = this.$toc.querySelectorAll('li.revealed');
-  for (var i = 0; i < current.length; i++) {
+  let current = this.$toc.querySelectorAll('li.revealed');
+  for (let i = 0; i < current.length; i++) {
     current[i].classList.remove('revealed');
     current[i].classList.remove('revealed-leaf');
   }
 
-  var current = this.$toc;
-  var index = 0;
-  while (index < path.length) {
-    var children = current.children;
-    for (var i = 0; i < children.length; i++) {
-      if ('#' + path[index].id === children[i].children[1].getAttribute('href') ) {
+  current = this.$toc;
+  let index = 0;
+  outer: while (index < path.length) {
+    let children = current.children;
+    for (let i = 0; i < children.length; i++) {
+      if ('#' + path[index].id === children[i].children[1].hash) {
         children[i].classList.add('revealed');
         if (index === path.length - 1) {
           children[i].classList.add('revealed-leaf');
-          var rect = children[i].getBoundingClientRect();
+          let rect = children[i].getBoundingClientRect();
           // this.$toc.getBoundingClientRect().top;
-          var tocRect = this.$toc.getBoundingClientRect();
+          let tocRect = this.$toc.getBoundingClientRect();
           if (rect.top + 10 > tocRect.bottom) {
-            this.$toc.scrollTop = this.$toc.scrollTop + (rect.top - tocRect.bottom) + (rect.bottom - rect.top);
+            this.$toc.scrollTop =
+              this.$toc.scrollTop + (rect.top - tocRect.bottom) + (rect.bottom - rect.top);
           } else if (rect.top < tocRect.top) {
             this.$toc.scrollTop = this.$toc.scrollTop - (tocRect.top - rect.top);
           }
         }
         current = children[i].querySelector('ol');
         index++;
-        break;
+        continue outer;
       }
     }
-
+    console.log('could not find location in table of contents', path);
+    break;
   }
-}
+};
 
 function findActiveClause(root, path) {
-  var clauses = new ClauseWalker(root);
-  var $clause;
-  var path = path || [];
+  let clauses = getChildClauses(root);
+  path = path || [];
 
-  while ($clause = clauses.nextNode()) {
-    var rect = $clause.getBoundingClientRect();
-    var $header = $clause.querySelector("h1");
-    var marginTop = parseInt(getComputedStyle($header)["margin-top"]);
+  for (let $clause of clauses) {
+    let rect = $clause.getBoundingClientRect();
+    let $header = $clause.querySelector('h1');
+    let marginTop = Math.max(
+      parseInt(getComputedStyle($clause)['margin-top']),
+      parseInt(getComputedStyle($header)['margin-top'])
+    );
 
-    if ((rect.top - marginTop) <= 0 && rect.bottom > 0) {
+    if (rect.top - marginTop <= 1 && rect.bottom > 0) {
       return findActiveClause($clause, path.concat($clause)) || path;
     }
   }
@@ -348,57 +470,49 @@ function findActiveClause(root, path) {
   return path;
 }
 
-function ClauseWalker(root) {
-  var previous;
-  var treeWalker = document.createTreeWalker(
-    root,
-    NodeFilter.SHOW_ELEMENT,
-    {
-      acceptNode: function (node) {
-        if (previous === node.parentNode) {
-          return NodeFilter.FILTER_REJECT;
-        } else {
-          previous = node;
-        }
-        if (node.nodeName === 'EMU-CLAUSE' || node.nodeName === 'EMU-INTRO' || node.nodeName === 'EMU-ANNEX') {
-          return NodeFilter.FILTER_ACCEPT;
-        } else {
-          return NodeFilter.FILTER_SKIP;
-        }
-      }
-    },
-    false
-    );
+function* getChildClauses(root) {
+  for (let el of root.children) {
+    switch (el.nodeName) {
+      // descend into <emu-import>
+      case 'EMU-IMPORT':
+        yield* getChildClauses(el);
+        break;
 
-  return treeWalker;
+      // accept <emu-clause>, <emu-intro>, and <emu-annex>
+      case 'EMU-CLAUSE':
+      case 'EMU-INTRO':
+      case 'EMU-ANNEX':
+        yield el;
+    }
+  }
 }
 
 Menu.prototype.toggle = function () {
   this.$menu.classList.toggle('active');
-}
+};
 
 Menu.prototype.show = function () {
   this.$menu.classList.add('active');
-}
+};
 
 Menu.prototype.hide = function () {
   this.$menu.classList.remove('active');
-}
+};
 
-Menu.prototype.isVisible = function() {
+Menu.prototype.isVisible = function () {
   return this.$menu.classList.contains('active');
-}
+};
 
 Menu.prototype.showPins = function () {
   this.$pins.classList.add('active');
-}
+};
 
 Menu.prototype.hidePins = function () {
   this.$pins.classList.remove('active');
-}
+};
 
 Menu.prototype.addPinEntry = function (id) {
-  var entry = this.search.biblio.byId[id];
+  let entry = this.search.biblio.byId[id];
   if (!entry) {
     // id was deleted after pin (or something) so remove it
     delete this._pinnedIds[id];
@@ -407,15 +521,16 @@ Menu.prototype.addPinEntry = function (id) {
   }
 
   if (entry.type === 'clause') {
-    var prefix;
+    let prefix;
     if (entry.number) {
       prefix = entry.number + ' ';
     } else {
       prefix = '';
     }
-    this.$pinList.innerHTML += '<li><a href="#' + entry.id + '">' + prefix + entry.titleHTML + '</a></li>';
+    // prettier-ignore
+    this.$pinList.innerHTML += `<li><a href="${makeLinkToId(entry.id)}">${prefix}${entry.titleHTML}</a></li>`;
   } else {
-    this.$pinList.innerHTML += '<li><a href="#' + entry.id + '">' + entry.key + '</a></li>';
+    this.$pinList.innerHTML += `<li><a href="${makeLinkToId(entry.id)}">${getKey(entry)}</a></li>`;
   }
 
   if (Object.keys(this._pinnedIds).length === 0) {
@@ -423,10 +538,10 @@ Menu.prototype.addPinEntry = function (id) {
   }
   this._pinnedIds[id] = true;
   this.persistPinEntries();
-}
+};
 
 Menu.prototype.removePinEntry = function (id) {
-  var item = this.$pinList.querySelector('a[href="#' + id + '"]').parentNode;
+  let item = this.$pinList.querySelector(`a[href="${makeLinkToId(id)}"]`).parentNode;
   this.$pinList.removeChild(item);
   delete this._pinnedIds[id];
   if (Object.keys(this._pinnedIds).length === 0) {
@@ -434,7 +549,7 @@ Menu.prototype.removePinEntry = function (id) {
   }
 
   this.persistPinEntries();
-}
+};
 
 Menu.prototype.persistPinEntries = function () {
   try {
@@ -444,7 +559,7 @@ Menu.prototype.persistPinEntries = function () {
   }
 
   localStorage.pinEntries = JSON.stringify(Object.keys(this._pinnedIds));
-}
+};
 
 Menu.prototype.loadPinEntries = function () {
   try {
@@ -453,13 +568,13 @@ Menu.prototype.loadPinEntries = function () {
     return;
   }
 
-  var pinsString = window.localStorage.pinEntries;
+  let pinsString = window.localStorage.pinEntries;
   if (!pinsString) return;
-  var pins = JSON.parse(pinsString);
-  for(var i = 0; i < pins.length; i++) {
+  let pins = JSON.parse(pinsString);
+  for (let i = 0; i < pins.length; i++) {
     this.addPinEntry(pins[i]);
   }
-}
+};
 
 Menu.prototype.togglePinEntry = function (id) {
   if (!id) {
@@ -471,62 +586,49 @@ Menu.prototype.togglePinEntry = function (id) {
   } else {
     this.addPinEntry(id);
   }
-}
+};
 
 Menu.prototype.selectPin = function (num) {
   document.location = this.$pinList.children[num].children[0].href;
-}
+};
 
-var menu;
-function init() {
-  menu = new Menu();
-  var $container = document.getElementById('spec-container');
-  $container.addEventListener('mouseover', debounce(function (e) {
-    Toolbox.activateIfMouseOver(e);
-  }));
-  document.addEventListener('keydown', debounce(function (e) {
-    if (e.code === "Escape" && Toolbox.active) {
-      Toolbox.deactivate();
-    }
-  }));
-}
+let menu;
 
 document.addEventListener('DOMContentLoaded', init);
 
 function debounce(fn, opts) {
   opts = opts || {};
-  var timeout;
-  return function(e) {
+  let timeout;
+  return function (e) {
     if (opts.stopPropagation) {
       e.stopPropagation();
     }
-    var args = arguments;
+    let args = arguments;
     if (timeout) {
       clearTimeout(timeout);
     }
-    timeout = setTimeout(function() {
+    timeout = setTimeout(() => {
       timeout = null;
       fn.apply(this, args);
-    }.bind(this), 150);
-  }
+    }, 150);
+  };
 }
 
-var CLAUSE_NODES = ['EMU-CLAUSE', 'EMU-INTRO', 'EMU-ANNEX'];
-function findLocalReferences ($elem) {
-  var name = $elem.innerHTML;
-  var references = [];
-
-  var parentClause = $elem.parentNode;
+let CLAUSE_NODES = ['EMU-CLAUSE', 'EMU-INTRO', 'EMU-ANNEX'];
+function findContainer($elem) {
+  let parentClause = $elem.parentNode;
   while (parentClause && CLAUSE_NODES.indexOf(parentClause.nodeName) === -1) {
     parentClause = parentClause.parentNode;
   }
+  return parentClause;
+}
 
-  if(!parentClause) return;
+function findLocalReferences(parentClause, name) {
+  let vars = parentClause.querySelectorAll('var');
+  let references = [];
 
-  var vars = parentClause.querySelectorAll('var');
-
-  for (var i = 0; i < vars.length; i++) {
-    var $var = vars[i];
+  for (let i = 0; i < vars.length; i++) {
+    let $var = vars[i];
 
     if ($var.innerHTML === name) {
       references.push($var);
@@ -536,21 +638,38 @@ function findLocalReferences ($elem) {
   return references;
 }
 
+let REFERENCED_CLASSES = Array.from({ length: 7 }, (x, i) => `referenced${i}`);
+function chooseHighlightIndex(parentClause) {
+  let counts = REFERENCED_CLASSES.map($class => parentClause.getElementsByClassName($class).length);
+  // Find the earliest index with the lowest count.
+  let minCount = Infinity;
+  let index = null;
+  for (let i = 0; i < counts.length; i++) {
+    if (counts[i] < minCount) {
+      minCount = counts[i];
+      index = i;
+    }
+  }
+  return index;
+}
+
 function toggleFindLocalReferences($elem) {
-  var references = findLocalReferences($elem);
+  let parentClause = findContainer($elem);
+  let references = findLocalReferences(parentClause, $elem.innerHTML);
   if ($elem.classList.contains('referenced')) {
-    references.forEach(function ($reference) {
-      $reference.classList.remove('referenced');
+    references.forEach($reference => {
+      $reference.classList.remove('referenced', ...REFERENCED_CLASSES);
     });
   } else {
-    references.forEach(function ($reference) {
-      $reference.classList.add('referenced');
+    let index = chooseHighlightIndex(parentClause);
+    references.forEach($reference => {
+      $reference.classList.add('referenced', `referenced${index}`);
     });
   }
 }
 
-function installFindLocalReferences () {
-  document.addEventListener('click', function (e) {
+function installFindLocalReferences() {
+  document.addEventListener('click', e => {
     if (e.target.nodeName === 'VAR') {
       toggleFindLocalReferences(e.target);
     }
@@ -558,9 +677,6 @@ function installFindLocalReferences () {
 }
 
 document.addEventListener('DOMContentLoaded', installFindLocalReferences);
-
-
-
 
 // The following license applies to the fuzzysearch function
 // The MIT License (MIT)
@@ -582,11 +698,11 @@ document.addEventListener('DOMContentLoaded', installFindLocalReferences);
 // COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-function fuzzysearch (searchString, haystack, caseInsensitive) {
-  var tlen = haystack.length;
-  var qlen = searchString.length;
-  var chunks = 1;
-  var finding = false;
+function fuzzysearch(searchString, haystack, caseInsensitive) {
+  let tlen = haystack.length;
+  let qlen = searchString.length;
+  let chunks = 1;
+  let finding = false;
 
   if (qlen > tlen) {
     return false;
@@ -602,10 +718,11 @@ function fuzzysearch (searchString, haystack, caseInsensitive) {
     }
   }
 
-  outer: for (var i = 0, j = 0; i < qlen; i++) {
-    var nch = searchString[i];
+  let j = 0;
+  outer: for (let i = 0; i < qlen; i++) {
+    let nch = searchString[i];
     while (j < tlen) {
-      var targetChar = haystack[j++];
+      let targetChar = haystack[j++];
       if (targetChar === nch) {
         finding = true;
         continue outer;
@@ -616,113 +733,24 @@ function fuzzysearch (searchString, haystack, caseInsensitive) {
       }
     }
 
-    if (caseInsensitive) { return false; }
+    if (caseInsensitive) {
+      return false;
+    }
 
     return fuzzysearch(searchString.toLowerCase(), haystack.toLowerCase(), true);
   }
 
-  return { caseMatch: !caseInsensitive, chunks: chunks, prefix: j <= qlen };
+  return { caseMatch: !caseInsensitive, chunks, prefix: j <= qlen };
 }
 
-var Toolbox = {
-  init: function () {
-    this.$container = document.createElement('div');
-    this.$container.classList.add('toolbox');
-    this.$permalink = document.createElement('a');
-    this.$permalink.textContent = 'Permalink';
-    this.$pinLink = document.createElement('a');
-    this.$pinLink.textContent = 'Pin';
-    this.$pinLink.setAttribute('href', '#');
-    this.$pinLink.addEventListener('click', function (e) {
-      e.preventDefault();
-      e.stopPropagation();
-      menu.togglePinEntry(this.entry.id);
-    }.bind(this));
-
-    this.$refsLink = document.createElement('a');
-    this.$refsLink.setAttribute('href', '#');
-    this.$refsLink.addEventListener('click', function (e) {
-      e.preventDefault();
-      e.stopPropagation();
-      referencePane.showReferencesFor(this.entry);
-    }.bind(this));
-    this.$container.appendChild(this.$permalink);
-    this.$container.appendChild(this.$pinLink);
-    this.$container.appendChild(this.$refsLink);
-    document.body.appendChild(this.$container);
-  },
-
-  activate: function (el, entry, target) {
-    if (el === this._activeEl) return;
-    this.active = true;
-    this.entry = entry;
-    this.$container.classList.add('active');
-    this.top = el.offsetTop - this.$container.offsetHeight - 10;
-    this.left = el.offsetLeft;
-    this.$container.setAttribute('style', 'left: ' + this.left + 'px; top: ' + this.top + 'px');
-    this.updatePermalink();
-    this.updateReferences();
-    this._activeEl = el;
-    if (this.top < document.body.scrollTop && el === target) {
-      // don't scroll unless it's a small thing (< 200px)
-      this.$container.scrollIntoView();
-    }
-  },
-
-  updatePermalink: function () {
-    this.$permalink.setAttribute('href', '#' + this.entry.id);
-  },
-
-  updateReferences: function () {
-    this.$refsLink.textContent = 'References (' + this.entry.referencingIds.length + ')';
-  },
-
-  activateIfMouseOver: function (e) {
-    var ref = this.findReferenceUnder(e.target);
-    if (ref && (!this.active || e.pageY > this._activeEl.offsetTop)) {
-      var entry = menu.search.biblio.byId[ref.id];
-      this.activate(ref.element, entry, e.target);
-    } else if (this.active && ((e.pageY < this.top) || e.pageY > (this._activeEl.offsetTop + this._activeEl.offsetHeight))) {
-      this.deactivate();
-    }
-  },
-
-  findReferenceUnder: function (el) {
-    while (el) {
-      var parent = el.parentNode;
-      if (el.nodeName === 'H1' && parent.nodeName.match(/EMU-CLAUSE|EMU-ANNEX|EMU-INTRO/) && parent.id) {
-        return { element: el, id: parent.id };
-      } else if (el.nodeName.match(/EMU-(?!CLAUSE|XREF|ANNEX|INTRO)|DFN/) &&
-                el.id && el.id[0] !== '_') {
-        if (el.nodeName === 'EMU-FIGURE' || el.nodeName === 'EMU-TABLE' || el.nodeName === 'EMU-EXAMPLE') {
-          // return the figcaption element
-          return { element: el.children[0].children[0], id: el.id };
-        } else if (el.nodeName === 'EMU-PRODUCTION') {
-          // return the LHS non-terminal element
-          return { element: el.children[0], id: el.id };
-        } else {
-          return { element: el, id: el.id };
-        }
-      }
-      el = parent;
-    }
-  },
-
-  deactivate: function () {
-    this.$container.classList.remove('active');
-    this._activeEl = null;
-    this.activeElBounds = null;
-    this.active = false;
-  }
-}
-
-var referencePane = {
-  init: function() {
+let referencePane = {
+  init() {
     this.$container = document.createElement('div');
     this.$container.setAttribute('id', 'references-pane-container');
 
-    var $spacer = document.createElement('div');
+    let $spacer = document.createElement('div');
     $spacer.setAttribute('id', 'references-pane-spacer');
+    $spacer.classList.add('menu-spacer');
 
     this.$pane = document.createElement('div');
     this.$pane.setAttribute('id', 'references-pane');
@@ -732,18 +760,19 @@ var referencePane = {
 
     this.$header = document.createElement('div');
     this.$header.classList.add('menu-pane-header');
-    this.$header.textContent = 'References to ';
+    this.$headerText = document.createElement('span');
+    this.$header.appendChild(this.$headerText);
     this.$headerRefId = document.createElement('a');
     this.$header.appendChild(this.$headerRefId);
     this.$closeButton = document.createElement('span');
     this.$closeButton.setAttribute('id', 'references-pane-close');
-    this.$closeButton.addEventListener('click', function (e) {
+    this.$closeButton.addEventListener('click', () => {
       this.deactivate();
-    }.bind(this));
+    });
     this.$header.appendChild(this.$closeButton);
 
     this.$pane.appendChild(this.$header);
-    var tableContainer = document.createElement('div');
+    let tableContainer = document.createElement('div');
     tableContainer.setAttribute('id', 'references-pane-table-container');
 
     this.$table = document.createElement('table');
@@ -757,70 +786,238 @@ var referencePane = {
     menu.$specContainer.appendChild(this.$container);
   },
 
-  activate: function () {
+  activate() {
     this.$container.classList.add('active');
   },
 
-  deactivate: function () {
+  deactivate() {
     this.$container.classList.remove('active');
+    this.state = null;
   },
 
   showReferencesFor(entry) {
     this.activate();
-    var newBody = document.createElement('tbody');
-    var previousId;
-    var previousCell;
-    var dupCount = 0;
+    this.state = { type: 'ref', id: entry.id };
+    this.$headerText.textContent = 'References to ';
+    let newBody = document.createElement('tbody');
+    let previousId;
+    let previousCell;
+    let dupCount = 0;
     this.$headerRefId.textContent = '#' + entry.id;
-    this.$headerRefId.setAttribute('href', '#' + entry.id);
-    entry.referencingIds.map(function (id) {
-      var target = document.getElementById(id);
-      var cid = findParentClauseId(target);
-      var clause = menu.search.biblio.byId[cid];
-      return { id: id, clause: clause }
-    }).sort(function (a, b) {
-      return sortByClauseNumber(a.clause, b.clause);
-    }).forEach(function (record, i) {
-      if (previousId === record.clause.id) {
-        previousCell.innerHTML += ' (<a href="#' + record.id + '">' + (dupCount + 2) + '</a>)';
-        dupCount++;
-      } else {
-        var row = newBody.insertRow();
-        var cell = row.insertCell();
-        cell.innerHTML = record.clause.number;
-        cell = row.insertCell();
-        cell.innerHTML = '<a href="#' + record.id + '">' + record.clause.titleHTML + '</a>';
-        previousCell = cell;
-        previousId = record.clause.id;
-        dupCount = 0;
-      }
-    }, this);
+    this.$headerRefId.setAttribute('href', makeLinkToId(entry.id));
+    this.$headerRefId.style.display = 'inline';
+    (entry.referencingIds || [])
+      .map(id => {
+        let cid = menu.search.biblio.refParentClause[id];
+        let clause = menu.search.biblio.byId[cid];
+        if (clause == null) {
+          throw new Error('could not find clause for id ' + cid);
+        }
+        return { id, clause };
+      })
+      .sort((a, b) => sortByClauseNumber(a.clause, b.clause))
+      .forEach(record => {
+        if (previousId === record.clause.id) {
+          previousCell.innerHTML += ` (<a href="${makeLinkToId(record.id)}">${dupCount + 2}</a>)`;
+          dupCount++;
+        } else {
+          let row = newBody.insertRow();
+          let cell = row.insertCell();
+          cell.innerHTML = record.clause.number;
+          cell = row.insertCell();
+          cell.innerHTML = `<a href="${makeLinkToId(record.id)}">${record.clause.titleHTML}</a>`;
+          previousCell = cell;
+          previousId = record.clause.id;
+          dupCount = 0;
+        }
+      }, this);
     this.$table.removeChild(this.$tableBody);
     this.$tableBody = newBody;
     this.$table.appendChild(this.$tableBody);
-  }
-}
-function findParentClauseId(node) {
-  while (node && node.nodeName !== 'EMU-CLAUSE' && node.nodeName !== 'EMU-INTRO' && node.nodeName !== 'EMU-ANNEX') {
-    node = node.parentNode;
-  }
-  if (!node) return null;
-  return node.getAttribute('id');
-}
+  },
 
-function sortByClauseNumber(c1, c2) {
-  var c1c = c1.number.split('.');
-  var c2c = c2.number.split('.');
+  showSDOs(sdos, alternativeId) {
+    let rhs = document.getElementById(alternativeId);
+    let parentName = rhs.parentNode.getAttribute('name');
+    let colons = rhs.parentNode.querySelector('emu-geq');
+    rhs = rhs.cloneNode(true);
+    rhs.querySelectorAll('emu-params,emu-constraints').forEach(e => {
+      e.remove();
+    });
+    rhs.querySelectorAll('[id]').forEach(e => {
+      e.removeAttribute('id');
+    });
+    rhs.querySelectorAll('a').forEach(e => {
+      e.parentNode.replaceChild(document.createTextNode(e.textContent), e);
+    });
 
-  for (var i = 0; i < c1c.length; i++) {
+    // prettier-ignore
+    this.$headerText.innerHTML = `Syntax-Directed Operations for<br><a href="${makeLinkToId(alternativeId)}" class="menu-pane-header-production"><emu-nt>${parentName}</emu-nt> ${colons.outerHTML} </a>`;
+    this.$headerText.querySelector('a').append(rhs);
+    this.showSDOsBody(sdos, alternativeId);
+  },
+
+  showSDOsBody(sdos, alternativeId) {
+    this.activate();
+    this.state = { type: 'sdo', id: alternativeId, html: this.$headerText.innerHTML };
+    this.$headerRefId.style.display = 'none';
+    let newBody = document.createElement('tbody');
+    Object.keys(sdos).forEach(sdoName => {
+      let pair = sdos[sdoName];
+      let clause = pair.clause;
+      let ids = pair.ids;
+      let first = ids[0];
+      let row = newBody.insertRow();
+      let cell = row.insertCell();
+      cell.innerHTML = clause;
+      cell = row.insertCell();
+      let html = '<a href="' + makeLinkToId(first) + '">' + sdoName + '</a>';
+      for (let i = 1; i < ids.length; ++i) {
+        html += ' (<a href="' + makeLinkToId(ids[i]) + '">' + (i + 1) + '</a>)';
+      }
+      cell.innerHTML = html;
+    });
+    this.$table.removeChild(this.$tableBody);
+    this.$tableBody = newBody;
+    this.$table.appendChild(this.$tableBody);
+  },
+};
+
+let Toolbox = {
+  init() {
+    this.$outer = document.createElement('div');
+    this.$outer.classList.add('toolbox-container');
+    this.$container = document.createElement('div');
+    this.$container.classList.add('toolbox');
+    this.$outer.appendChild(this.$container);
+    this.$permalink = document.createElement('a');
+    this.$permalink.textContent = 'Permalink';
+    this.$pinLink = document.createElement('a');
+    this.$pinLink.textContent = 'Pin';
+    this.$pinLink.setAttribute('href', '#');
+    this.$pinLink.addEventListener('click', e => {
+      e.preventDefault();
+      e.stopPropagation();
+      menu.togglePinEntry(this.entry.id);
+      this.$pinLink.textContent = menu._pinnedIds[this.entry.id] ? 'Unpin' : 'Pin';
+    });
+
+    this.$refsLink = document.createElement('a');
+    this.$refsLink.setAttribute('href', '#');
+    this.$refsLink.addEventListener('click', e => {
+      e.preventDefault();
+      e.stopPropagation();
+      referencePane.showReferencesFor(this.entry);
+    });
+    this.$container.appendChild(this.$permalink);
+    this.$container.appendChild(this.$pinLink);
+    this.$container.appendChild(this.$refsLink);
+    document.body.appendChild(this.$outer);
+  },
+
+  activate(el, entry, target) {
+    if (el === this._activeEl) return;
+    sdoBox.deactivate();
+    this.active = true;
+    this.entry = entry;
+    this.$pinLink.textContent = menu._pinnedIds[entry.id] ? 'Unpin' : 'Pin';
+    this.$outer.classList.add('active');
+    this.top = el.offsetTop - this.$outer.offsetHeight;
+    this.left = el.offsetLeft - 10;
+    this.$outer.setAttribute('style', 'left: ' + this.left + 'px; top: ' + this.top + 'px');
+    this.updatePermalink();
+    this.updateReferences();
+    this._activeEl = el;
+    if (this.top < document.body.scrollTop && el === target) {
+      // don't scroll unless it's a small thing (< 200px)
+      this.$outer.scrollIntoView();
+    }
+  },
+
+  updatePermalink() {
+    this.$permalink.setAttribute('href', makeLinkToId(this.entry.id));
+  },
+
+  updateReferences() {
+    this.$refsLink.textContent = `References (${(this.entry.referencingIds || []).length})`;
+  },
+
+  activateIfMouseOver(e) {
+    let ref = this.findReferenceUnder(e.target);
+    if (ref && (!this.active || e.pageY > this._activeEl.offsetTop)) {
+      let entry = menu.search.biblio.byId[ref.id];
+      this.activate(ref.element, entry, e.target);
+    } else if (
+      this.active &&
+      (e.pageY < this.top || e.pageY > this._activeEl.offsetTop + this._activeEl.offsetHeight)
+    ) {
+      this.deactivate();
+    }
+  },
+
+  findReferenceUnder(el) {
+    while (el) {
+      let parent = el.parentNode;
+      if (el.nodeName === 'EMU-RHS' || el.nodeName === 'EMU-PRODUCTION') {
+        return null;
+      }
+      if (
+        el.nodeName === 'H1' &&
+        parent.nodeName.match(/EMU-CLAUSE|EMU-ANNEX|EMU-INTRO/) &&
+        parent.id
+      ) {
+        return { element: el, id: parent.id };
+      } else if (el.nodeName === 'EMU-NT') {
+        if (
+          parent.nodeName === 'EMU-PRODUCTION' &&
+          parent.id &&
+          parent.id[0] !== '_' &&
+          parent.firstElementChild === el
+        ) {
+          // return the LHS non-terminal element
+          return { element: el, id: parent.id };
+        }
+        return null;
+      } else if (
+        el.nodeName.match(/EMU-(?!CLAUSE|XREF|ANNEX|INTRO)|DFN/) &&
+        el.id &&
+        el.id[0] !== '_'
+      ) {
+        if (
+          el.nodeName === 'EMU-FIGURE' ||
+          el.nodeName === 'EMU-TABLE' ||
+          el.nodeName === 'EMU-EXAMPLE'
+        ) {
+          // return the figcaption element
+          return { element: el.children[0].children[0], id: el.id };
+        } else {
+          return { element: el, id: el.id };
+        }
+      }
+      el = parent;
+    }
+  },
+
+  deactivate() {
+    this.$outer.classList.remove('active');
+    this._activeEl = null;
+    this.active = false;
+  },
+};
+
+function sortByClauseNumber(clause1, clause2) {
+  let c1c = clause1.number.split('.');
+  let c2c = clause2.number.split('.');
+
+  for (let i = 0; i < c1c.length; i++) {
     if (i >= c2c.length) {
       return 1;
     }
 
-    var c1 = c1c[i];
-    var c2 = c2c[i];
-    var c1cn = Number(c1);
-    var c2cn = Number(c2);
+    let c1 = c1c[i];
+    let c2 = c2c[i];
+    let c1cn = Number(c1);
+    let c2cn = Number(c2);
 
     if (Number.isNaN(c1cn) && Number.isNaN(c2cn)) {
       if (c1 > c2) {
@@ -832,7 +1029,7 @@ function sortByClauseNumber(c1, c2) {
       return -1;
     } else if (Number.isNaN(c1cn) && !Number.isNaN(c2cn)) {
       return 1;
-    } else if(c1cn > c2cn) {
+    } else if (c1cn > c2cn) {
       return 1;
     } else if (c1cn < c2cn) {
       return -1;
@@ -845,59 +1042,314 @@ function sortByClauseNumber(c1, c2) {
   return -1;
 }
 
-document.addEventListener('DOMContentLoaded', function () {
+function makeLinkToId(id) {
+  let hash = '#' + id;
+  if (typeof idToSection === 'undefined' || !idToSection[id]) {
+    return hash;
+  }
+  let targetSec = idToSection[id];
+  return (targetSec === 'index' ? './' : targetSec + '.html') + hash;
+}
+
+function doShortcut(e) {
+  if (!(e.target instanceof HTMLElement)) {
+    return;
+  }
+  let target = e.target;
+  let name = target.nodeName.toLowerCase();
+  if (name === 'textarea' || name === 'input' || name === 'select' || target.isContentEditable) {
+    return;
+  }
+  if (e.altKey || e.ctrlKey || e.metaKey) {
+    return;
+  }
+  if (e.key === 'm' && usesMultipage) {
+    let pathParts = location.pathname.split('/');
+    let hash = location.hash;
+    if (pathParts[pathParts.length - 2] === 'multipage') {
+      if (hash === '') {
+        let sectionName = pathParts[pathParts.length - 1];
+        if (sectionName.endsWith('.html')) {
+          sectionName = sectionName.slice(0, -5);
+        }
+        if (idToSection['sec-' + sectionName] !== undefined) {
+          hash = '#sec-' + sectionName;
+        }
+      }
+      location = pathParts.slice(0, -2).join('/') + '/' + hash;
+    } else {
+      location = 'multipage/' + hash;
+    }
+  } else if (e.key === 'u') {
+    document.documentElement.classList.toggle('show-ao-annotations');
+  } else if (e.key === '?') {
+    document.getElementById('shortcuts-help').classList.toggle('active');
+  }
+}
+
+function init() {
+  menu = new Menu();
+  let $container = document.getElementById('spec-container');
+  $container.addEventListener(
+    'mouseover',
+    debounce(e => {
+      Toolbox.activateIfMouseOver(e);
+    })
+  );
+  document.addEventListener(
+    'keydown',
+    debounce(e => {
+      if (e.code === 'Escape') {
+        if (Toolbox.active) {
+          Toolbox.deactivate();
+        }
+        document.getElementById('shortcuts-help').classList.remove('active');
+      }
+    })
+  );
+}
+
+document.addEventListener('keypress', doShortcut);
+
+document.addEventListener('DOMContentLoaded', () => {
   Toolbox.init();
   referencePane.init();
-})
-var CLAUSE_NODES = ['EMU-CLAUSE', 'EMU-INTRO', 'EMU-ANNEX'];
-function findLocalReferences ($elem) {
-  var name = $elem.innerHTML;
-  var references = [];
+});
 
-  var parentClause = $elem.parentNode;
-  while (parentClause && CLAUSE_NODES.indexOf(parentClause.nodeName) === -1) {
-    parentClause = parentClause.parentNode;
+// preserve state during navigation
+
+function getTocPath(li) {
+  let path = [];
+  let pointer = li;
+  while (true) {
+    let parent = pointer.parentElement;
+    if (parent == null) {
+      return null;
+    }
+    let index = [].indexOf.call(parent.children, pointer);
+    if (index == -1) {
+      return null;
+    }
+    path.unshift(index);
+    pointer = parent.parentElement;
+    if (pointer == null) {
+      return null;
+    }
+    if (pointer.id === 'menu-toc') {
+      break;
+    }
+    if (pointer.tagName !== 'LI') {
+      return null;
+    }
   }
+  return path;
+}
 
-  if(!parentClause) return;
+function activateTocPath(path) {
+  try {
+    let pointer = document.getElementById('menu-toc');
+    for (let index of path) {
+      pointer = pointer.querySelector('ol').children[index];
+    }
+    pointer.classList.add('active');
+  } catch (e) {
+    // pass
+  }
+}
 
-  var vars = parentClause.querySelectorAll('var');
+function getActiveTocPaths() {
+  return [...menu.$menu.querySelectorAll('.active')].map(getTocPath).filter(p => p != null);
+}
 
-  for (var i = 0; i < vars.length; i++) {
-    var $var = vars[i];
-
-    if ($var.innerHTML === name) {
-      references.push($var);
+function loadStateFromSessionStorage() {
+  if (!window.sessionStorage || typeof menu === 'undefined' || window.navigating) {
+    return;
+  }
+  if (sessionStorage.referencePaneState != null) {
+    let state = JSON.parse(sessionStorage.referencePaneState);
+    if (state != null) {
+      if (state.type === 'ref') {
+        let entry = menu.search.biblio.byId[state.id];
+        if (entry != null) {
+          referencePane.showReferencesFor(entry);
+        }
+      } else if (state.type === 'sdo') {
+        let sdos = sdoMap[state.id];
+        if (sdos != null) {
+          referencePane.$headerText.innerHTML = state.html;
+          referencePane.showSDOsBody(sdos, state.id);
+        }
+      }
+      delete sessionStorage.referencePaneState;
     }
   }
 
-  return references;
-}
+  if (sessionStorage.activeTocPaths != null) {
+    document
+      .getElementById('menu-toc')
+      .querySelectorAll('.active')
+      .forEach(e => {
+        e.classList.remove('active');
+      });
+    let active = JSON.parse(sessionStorage.activeTocPaths);
+    active.forEach(activateTocPath);
+    delete sessionStorage.activeTocPaths;
+  }
 
-function toggleFindLocalReferences($elem) {
-  var references = findLocalReferences($elem);
-  if ($elem.classList.contains('referenced')) {
-    references.forEach(function ($reference) {
-      $reference.classList.remove('referenced');
-    });
-  } else {
-    references.forEach(function ($reference) {
-      $reference.classList.add('referenced');
-    });
+  if (sessionStorage.searchValue != null) {
+    let value = JSON.parse(sessionStorage.searchValue);
+    menu.search.$searchBox.value = value;
+    menu.search.search(value);
+    delete sessionStorage.searchValue;
+  }
+
+  if (sessionStorage.tocScroll != null) {
+    let tocScroll = JSON.parse(sessionStorage.tocScroll);
+    menu.$toc.scrollTop = tocScroll;
+    delete sessionStorage.tocScroll;
   }
 }
 
-function installFindLocalReferences () {
-  document.addEventListener('click', function (e) {
-    if (e.target.nodeName === 'VAR') {
-      toggleFindLocalReferences(e.target);
+document.addEventListener('DOMContentLoaded', loadStateFromSessionStorage);
+
+window.addEventListener('pageshow', loadStateFromSessionStorage);
+
+window.addEventListener('beforeunload', () => {
+  if (!window.sessionStorage || typeof menu === 'undefined') {
+    return;
+  }
+  sessionStorage.referencePaneState = JSON.stringify(referencePane.state || null);
+  sessionStorage.activeTocPaths = JSON.stringify(getActiveTocPaths());
+  sessionStorage.searchValue = JSON.stringify(menu.search.$searchBox.value);
+  sessionStorage.tocScroll = JSON.stringify(menu.$toc.scrollTop);
+});
+
+'use strict';
+
+// Manually prefix algorithm step list items with hidden counter representations
+// corresponding with their markers so they get selected and copied with content.
+// We read list-style-type to avoid divergence with the style sheet, but
+// for efficiency assume that all lists at the same nesting depth use the same
+// style (except for those associated with replacement steps).
+// We also precompute some initial items for each supported style type.
+// https://w3c.github.io/csswg-drafts/css-counter-styles/
+
+const lowerLetters = Array.from({ length: 26 }, (_, i) =>
+  String.fromCharCode('a'.charCodeAt(0) + i)
+);
+// Implement the lower-alpha 'alphabetic' algorithm,
+// adjusting for indexing from 0 rather than 1.
+// https://w3c.github.io/csswg-drafts/css-counter-styles/#simple-alphabetic
+// https://w3c.github.io/csswg-drafts/css-counter-styles/#alphabetic-system
+const lowerAlphaTextForIndex = i => {
+  let S = '';
+  for (const N = lowerLetters.length; i >= 0; i--) {
+    S = lowerLetters[i % N] + S;
+    i = Math.floor(i / N);
+  }
+  return S;
+};
+
+const weightedLowerRomanSymbols = Object.entries({
+  m: 1000,
+  cm: 900,
+  d: 500,
+  cd: 400,
+  c: 100,
+  xc: 90,
+  l: 50,
+  xl: 40,
+  x: 10,
+  ix: 9,
+  v: 5,
+  iv: 4,
+  i: 1,
+});
+// Implement the lower-roman 'additive' algorithm,
+// adjusting for indexing from 0 rather than 1.
+// https://w3c.github.io/csswg-drafts/css-counter-styles/#simple-numeric
+// https://w3c.github.io/csswg-drafts/css-counter-styles/#additive-system
+const lowerRomanTextForIndex = i => {
+  let value = i + 1;
+  let S = '';
+  for (const [symbol, weight] of weightedLowerRomanSymbols) {
+    if (!value) break;
+    if (weight > value) continue;
+    const reps = Math.floor(value / weight);
+    S += symbol.repeat(reps);
+    value -= weight * reps;
+  }
+  return S;
+};
+
+// Memoize pure index-to-text functions with an exposed cache for fast retrieval.
+const makeCounter = (pureGetTextForIndex, precomputeCount = 30) => {
+  const cache = Array.from({ length: precomputeCount }, (_, i) => pureGetTextForIndex(i));
+  const getTextForIndex = i => {
+    if (i >= cache.length) cache[i] = pureGetTextForIndex(i);
+    return cache[i];
+  };
+  return { getTextForIndex, cache };
+};
+
+const counterByStyle = {
+  __proto__: null,
+  decimal: makeCounter(i => String(i + 1)),
+  'lower-alpha': makeCounter(lowerAlphaTextForIndex),
+  'upper-alpha': makeCounter(i => lowerAlphaTextForIndex(i).toUpperCase()),
+  'lower-roman': makeCounter(lowerRomanTextForIndex),
+  'upper-roman': makeCounter(i => lowerRomanTextForIndex(i).toUpperCase()),
+};
+const fallbackCounter = makeCounter(() => '?');
+const counterByDepth = [];
+
+function addStepNumberText(
+  ol,
+  depth = 0,
+  special = [...ol.classList].some(c => c.startsWith('nested-'))
+) {
+  let counter = !special && counterByDepth[depth];
+  if (!counter) {
+    const counterStyle = getComputedStyle(ol)['list-style-type'];
+    counter = counterByStyle[counterStyle];
+    if (!counter) {
+      console.warn('unsupported list-style-type', {
+        ol,
+        counterStyle,
+        id: ol.closest('[id]')?.getAttribute('id'),
+      });
+      counterByStyle[counterStyle] = fallbackCounter;
+      counter = fallbackCounter;
     }
+    if (!special) {
+      counterByDepth[depth] = counter;
+    }
+  }
+  const { cache, getTextForIndex } = counter;
+  let i = (Number(ol.getAttribute('start')) || 1) - 1;
+  for (const li of ol.children) {
+    const marker = document.createElement('span');
+    marker.textContent = `${i < cache.length ? cache[i] : getTextForIndex(i)}. `;
+    marker.setAttribute('aria-hidden', 'true');
+    li.prepend(marker);
+    for (const sublist of li.querySelectorAll(':scope > ol')) {
+      addStepNumberText(sublist, depth + 1, special);
+    }
+    i++;
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('emu-alg > ol').forEach(ol => {
+    addStepNumberText(ol);
   });
-}
+});
 
-document.addEventListener('DOMContentLoaded', installFindLocalReferences);
-</script><style>body {
+let sdoMap = JSON.parse(`{}`);
+let biblio = JSON.parse(`{"refsByClause":{"sec-intl.numberformat.prototype.format":["_ref_0","_ref_30"],"sec-intl.numberformat.prototype.resolvedoptions":["_ref_1","_ref_39"],"sec-properties-of-intl-numberformat-instances":["_ref_2","_ref_3","_ref_4","_ref_40"],"sec-partitionnotationsubpattern":["_ref_5","_ref_6","_ref_56","_ref_57","_ref_58"],"sec-torawprecision":["_ref_7","_ref_61","_ref_62","_ref_63"],"sec-torawfixed":["_ref_8","_ref_64","_ref_65","_ref_66"],"sec-getnumberformatpattern":["_ref_9","_ref_10","_ref_69","_ref_70"],"sec-getnotationsubpattern":["_ref_11","_ref_12","_ref_71"],"sec-getunsignedroundingmode":["_ref_13","_ref_14","_ref_15"],"sec-applyunsignedroundingmode":["_ref_16"],"sec-intl.numberformat":["_ref_17","_ref_18"],"sec-chainnumberformat":["_ref_19"],"sec-initializenumberformat":["_ref_20","_ref_21","_ref_22","_ref_23","_ref_24","_ref_25"],"sec-setnfdigitoptions":["_ref_26"],"sec-intl.numberformat.prototype":["_ref_27"],"sec-intl.numberformat.supportedlocalesof":["_ref_28"],"sec-intl.numberformat.prototype.constructor":["_ref_29"],"sec-intl.numberformat.prototype.formattoparts":["_ref_31","_ref_32"],"sec-intl.numberformat.prototype.formatrange":["_ref_33","_ref_34","_ref_35"],"sec-intl.numberformat.prototype.formatrangetoparts":["_ref_36","_ref_37","_ref_38"],"sec-number-format-functions":["_ref_41","_ref_42"],"sec-formatnumberstring":["_ref_43","_ref_44","_ref_45","_ref_46","_ref_47","_ref_48","_ref_49","_ref_50"],"sec-partitionnumberpattern":["_ref_51","_ref_52","_ref_53","_ref_54","_ref_55"],"sec-formatnumber":["_ref_59"],"sec-formatnumbertoparts":["_ref_60"],"sec-unwrapnumberformat":["_ref_67","_ref_68"],"sec-computeexponent":["_ref_72","_ref_73","_ref_74"],"sec-runtime-semantics-stringintlmv":["_ref_75","_ref_76"],"sec-tointlmathematicalvalue":["_ref_77"],"sec-partitionnumberrangepattern":["_ref_78","_ref_79","_ref_80","_ref_81","_ref_82","_ref_83"],"sec-formatapproximately":["_ref_84"],"sec-collapsenumberrange":["_ref_85"],"sec-formatnumericrange":["_ref_86","_ref_87","_ref_88"],"sec-formatnumericrangetoparts":["_ref_89","_ref_90","_ref_91"]},"entries":[{"type":"term","term":"%NumberFormat%","refId":"sec-intl-numberformat-constructor"},{"type":"op","aoid":"ChainNumberFormat","refId":"sec-chainnumberformat"},{"type":"clause","id":"sec-chainnumberformat","title":"ChainNumberFormat ( numberFormat, newTarget, this )","titleHTML":"ChainNumberFormat ( <var>numberFormat</var>, <var>newTarget</var>, <var>this</var> )","number":"1.1.1.1","referencingIds":["_ref_18"]},{"type":"clause","id":"sec-intl.numberformat","title":"Intl.NumberFormat ( [ locales [ , options ] ] )","titleHTML":"Intl.NumberFormat ( [ <var>locales</var> [ , <var>options</var> ] ] )","number":"1.1.1"},{"type":"op","aoid":"InitializeNumberFormat","refId":"sec-initializenumberformat"},{"type":"clause","id":"sec-initializenumberformat","title":"InitializeNumberFormat ( numberFormat, locales, options )","titleHTML":"InitializeNumberFormat ( <var>numberFormat</var>, <var>locales</var>, <var>options</var> )","number":"1.1.2","referencingIds":["_ref_17"]},{"type":"op","aoid":"SetNumberFormatDigitOptions","refId":"sec-setnfdigitoptions"},{"type":"clause","id":"sec-setnfdigitoptions","title":"SetNumberFormatDigitOptions ( intlObj, options, mnfdDefault, mxfdDefault, notation )","titleHTML":"SetNumberFormatDigitOptions ( <var>intlObj</var>, <var>options</var>, <var>mnfdDefault</var>, <var>mxfdDefault</var>, <var>notation</var> )","number":"1.1.3","referencingIds":["_ref_25","_ref_26"]},{"type":"op","aoid":"SetNumberFormatUnitOptions","refId":"sec-setnumberformatunitoptions"},{"type":"clause","id":"sec-setnumberformatunitoptions","title":"SetNumberFormatUnitOptions ( intlObj, options )","titleHTML":"SetNumberFormatUnitOptions ( <var>intlObj</var>, <var>options</var> )","number":"1.1.4","referencingIds":["_ref_23"]},{"type":"clause","id":"sec-intl-numberformat-constructor","titleHTML":"The Intl.NumberFormat Constructor","number":"1.1","referencingIds":["_ref_19","_ref_20","_ref_21","_ref_22","_ref_28","_ref_29","_ref_67","_ref_68","_ref_70","_ref_71"]},{"type":"clause","id":"sec-intl.numberformat.prototype","titleHTML":"Intl.NumberFormat.prototype","number":"1.2.1"},{"type":"clause","id":"sec-intl.numberformat.supportedlocalesof","title":"Intl.NumberFormat.supportedLocalesOf ( locales [ , options ] )","titleHTML":"Intl.NumberFormat.supportedLocalesOf ( <var>locales</var> [ , <var>options</var> ] )","number":"1.2.2"},{"type":"clause","id":"sec-intl.numberformat-internal-slots","titleHTML":"Internal slots","number":"1.2.3","referencingIds":["_ref_9","_ref_10","_ref_11","_ref_12"]},{"type":"clause","id":"sec-properties-of-intl-numberformat-constructor","titleHTML":"Properties of the Intl.NumberFormat Constructor","number":"1.2"},{"type":"term","term":"%NumberFormat.prototype%","refId":"sec-properties-of-intl-numberformat-prototype-object"},{"type":"clause","id":"sec-intl.numberformat.prototype.constructor","titleHTML":"Intl.NumberFormat.prototype.constructor","number":"1.3.1"},{"type":"clause","id":"sec-intl.numberformat.prototype-@@tostringtag","titleHTML":"Intl.NumberFormat.prototype [ @@toStringTag ]","number":"1.3.2"},{"type":"clause","id":"sec-intl.numberformat.prototype.format","titleHTML":"get Intl.NumberFormat.prototype.format","number":"1.3.3","referencingIds":["_ref_4"]},{"type":"clause","id":"sec-intl.numberformat.prototype.formattoparts","title":"Intl.NumberFormat.prototype.formatToParts ( value )","titleHTML":"Intl.NumberFormat.prototype.formatToParts ( <var>value</var> )","number":"1.3.4"},{"type":"clause","id":"sec-intl.numberformat.prototype.formatrange","title":"Intl.NumberFormat.prototype.formatRange ( start, end )","titleHTML":"Intl.NumberFormat.prototype.formatRange ( <var>start</var>, <var>end</var> )","number":"1.3.5"},{"type":"clause","id":"sec-intl.numberformat.prototype.formatrangetoparts","title":"Intl.NumberFormat.prototype.formatRangeToParts ( start, end )","titleHTML":"Intl.NumberFormat.prototype.formatRangeToParts ( <var>start</var>, <var>end</var> )","number":"1.3.6"},{"type":"table","id":"table-numberformat-resolvedoptions-properties","number":1,"caption":"Table 1: Resolved Options of NumberFormat Instances","referencingIds":["_ref_1"]},{"type":"clause","id":"sec-intl.numberformat.prototype.resolvedoptions","titleHTML":"Intl.NumberFormat.prototype.resolvedOptions ( )","number":"1.3.7","referencingIds":["_ref_2"]},{"type":"clause","id":"sec-properties-of-intl-numberformat-prototype-object","titleHTML":"Properties of the Intl.NumberFormat Prototype Object","number":"1.3","referencingIds":["_ref_27","_ref_40"]},{"type":"table","id":"table-intl-rounding-modes","number":2,"caption":"Table 2: Rounding modes in Intl.NumberFormat","referencingIds":["_ref_3","_ref_13"]},{"type":"clause","id":"sec-properties-of-intl-numberformat-instances","titleHTML":"Properties of Intl.NumberFormat Instances","number":"1.4"},{"type":"op","aoid":"CurrencyDigits","refId":"sec-currencydigits"},{"type":"clause","id":"sec-currencydigits","title":"CurrencyDigits ( currency )","titleHTML":"CurrencyDigits ( <var>currency</var> )","number":"1.5.1","referencingIds":["_ref_24"]},{"type":"clause","id":"sec-number-format-functions","titleHTML":"Number Format Functions","number":"1.5.2","referencingIds":["_ref_0"]},{"type":"op","aoid":"FormatNumericToString","refId":"sec-formatnumberstring"},{"type":"clause","id":"sec-formatnumberstring","title":"FormatNumericToString ( intlObject, x )","titleHTML":"FormatNumericToString ( <var>intlObject</var>, <var>x</var> )","number":"1.5.3","referencingIds":["_ref_53","_ref_73"]},{"type":"op","aoid":"PartitionNumberPattern","refId":"sec-partitionnumberpattern"},{"type":"clause","id":"sec-partitionnumberpattern","title":"PartitionNumberPattern ( numberFormat, x )","titleHTML":"PartitionNumberPattern ( <var>numberFormat</var>, <var>x</var> )","number":"1.5.4","referencingIds":["_ref_59","_ref_60","_ref_80","_ref_81","_ref_84"]},{"type":"table","id":"table-numbering-system-digits","number":3,"caption":"Table 3: Numbering systems with simple digit mappings","referencingIds":["_ref_5","_ref_6"]},{"type":"op","aoid":"PartitionNotationSubPattern","refId":"sec-partitionnotationsubpattern"},{"type":"clause","id":"sec-partitionnotationsubpattern","title":"PartitionNotationSubPattern ( numberFormat, x, n, exponent )","titleHTML":"PartitionNotationSubPattern ( <var>numberFormat</var>, <var>x</var>, <var>n</var>, <var>exponent</var> )","number":"1.5.5","referencingIds":["_ref_55"]},{"type":"op","aoid":"FormatNumeric","refId":"sec-formatnumber"},{"type":"clause","id":"sec-formatnumber","title":"FormatNumeric ( numberFormat, x )","titleHTML":"FormatNumeric ( <var>numberFormat</var>, <var>x</var> )","number":"1.5.6","referencingIds":["_ref_42"]},{"type":"op","aoid":"FormatNumericToParts","refId":"sec-formatnumbertoparts"},{"type":"clause","id":"sec-formatnumbertoparts","title":"FormatNumericToParts ( numberFormat, x )","titleHTML":"FormatNumericToParts ( <var>numberFormat</var>, <var>x</var> )","number":"1.5.7","referencingIds":["_ref_32"]},{"type":"op","aoid":"ToRawPrecisionFn","id":"eqn-ToRawPrecisionFn","referencingIds":["_ref_61","_ref_62"]},{"type":"op","aoid":"ToRawPrecision","refId":"sec-torawprecision"},{"type":"clause","id":"sec-torawprecision","title":"ToRawPrecision ( x, minPrecision, maxPrecision, unsignedRoundingMode )","titleHTML":"ToRawPrecision ( <var>x</var>, <var>minPrecision</var>, <var>maxPrecision</var><ins>, <var>unsignedRoundingMode</var></ins> )","number":"1.5.8","referencingIds":["_ref_45","_ref_47","_ref_49"]},{"type":"op","aoid":"ToRawFixedFn","id":"eqn-ToRawFixedFn","referencingIds":["_ref_64","_ref_65"]},{"type":"op","aoid":"ToRawFixed","refId":"sec-torawfixed"},{"type":"clause","id":"sec-torawfixed","title":"ToRawFixed ( x, minInteger, minFraction, maxFraction, roundingIncrement, unsignedRoundingMode )","titleHTML":"ToRawFixed ( <var>x</var>, <del><var>minInteger</var>,</del> <var>minFraction</var>, <var>maxFraction</var><ins>, <var>roundingIncrement</var>, <var>unsignedRoundingMode</var></ins> )","number":"1.5.9","referencingIds":["_ref_46","_ref_48","_ref_50","_ref_58"]},{"type":"op","aoid":"UnwrapNumberFormat","refId":"sec-unwrapnumberformat"},{"type":"clause","id":"sec-unwrapnumberformat","title":"UnwrapNumberFormat ( nf )","titleHTML":"UnwrapNumberFormat ( <var>nf</var> )","number":"1.5.10","referencingIds":["_ref_30","_ref_39"]},{"type":"op","aoid":"GetNumberFormatPattern","refId":"sec-getnumberformatpattern"},{"type":"clause","id":"sec-getnumberformatpattern","title":"GetNumberFormatPattern ( numberFormat, x )","titleHTML":"GetNumberFormatPattern ( <var>numberFormat</var>, <var>x</var> )","number":"1.5.11","referencingIds":["_ref_54"]},{"type":"op","aoid":"GetNotationSubPattern","refId":"sec-getnotationsubpattern"},{"type":"clause","id":"sec-getnotationsubpattern","title":"GetNotationSubPattern ( numberFormat, exponent )","titleHTML":"GetNotationSubPattern ( <var>numberFormat</var>, <var>exponent</var> )","number":"1.5.12","referencingIds":["_ref_57"]},{"type":"op","aoid":"ComputeExponent","refId":"sec-computeexponent"},{"type":"clause","id":"sec-computeexponent","title":"ComputeExponent ( numberFormat, x )","titleHTML":"ComputeExponent ( <var>numberFormat</var>, <var>x</var> )","number":"1.5.13","referencingIds":["_ref_51","_ref_52"]},{"type":"op","aoid":"ComputeExponentForMagnitude","refId":"sec-computeexponentformagnitude"},{"type":"clause","id":"sec-computeexponentformagnitude","title":"ComputeExponentForMagnitude ( numberFormat, magnitude )","titleHTML":"ComputeExponentForMagnitude ( <var>numberFormat</var>, <var>magnitude</var> )","number":"1.5.14","referencingIds":["_ref_72","_ref_74"]},{"type":"op","aoid":"StringIntlMV","refId":"sec-runtime-semantics-stringintlmv"},{"type":"clause","id":"sec-runtime-semantics-stringintlmv","titleHTML":"Runtime Semantics: StringIntlMV","number":"1.5.15","referencingIds":["_ref_75","_ref_76","_ref_77"]},{"type":"term","term":"Intl mathematical value","id":"intl-mathematical-value","referencingIds":["_ref_43","_ref_56","_ref_69","_ref_78","_ref_79","_ref_86","_ref_87","_ref_89","_ref_90"]},{"type":"op","aoid":"ToIntlMathematicalValue","refId":"sec-tointlmathematicalvalue"},{"type":"clause","id":"sec-tointlmathematicalvalue","title":"ToIntlMathematicalValue ( value )","titleHTML":"ToIntlMathematicalValue ( <var>value</var> )","number":"1.5.16","referencingIds":["_ref_31","_ref_33","_ref_34","_ref_36","_ref_37","_ref_41"]},{"type":"table","id":"table-intl-unsigned-rounding-modes","number":4,"caption":"Table 4: Conversion from rounding mode to unsigned rounding mode","referencingIds":["_ref_7","_ref_8","_ref_14","_ref_15","_ref_16"]},{"type":"op","aoid":"GetUnsignedRoundingMode","refId":"sec-getunsignedroundingmode"},{"type":"clause","id":"sec-getunsignedroundingmode","title":"GetUnsignedRoundingMode ( roundingMode, isNegative )","titleHTML":"GetUnsignedRoundingMode ( <var>roundingMode</var>, <var>isNegative</var> )","number":"1.5.17","referencingIds":["_ref_44"]},{"type":"op","aoid":"ApplyUnsignedRoundingMode","refId":"sec-applyunsignedroundingmode"},{"type":"clause","id":"sec-applyunsignedroundingmode","title":"ApplyUnsignedRoundingMode ( x, r1, r2, unsignedRoundingMode )","titleHTML":"ApplyUnsignedRoundingMode ( <var>x</var>, <var>r1</var>, <var>r2</var>, <var>unsignedRoundingMode</var> )","number":"1.5.18","referencingIds":["_ref_63","_ref_66"]},{"type":"op","aoid":"PartitionNumberRangePattern","refId":"sec-partitionnumberrangepattern"},{"type":"clause","id":"sec-partitionnumberrangepattern","title":"PartitionNumberRangePattern ( numberFormat, x, y )","titleHTML":"PartitionNumberRangePattern ( <var>numberFormat</var>, <var>x</var>, <var>y</var> )","number":"1.5.19","referencingIds":["_ref_85","_ref_88","_ref_91"]},{"type":"op","aoid":"FormatApproximately","refId":"sec-formatapproximately"},{"type":"clause","id":"sec-formatapproximately","title":"FormatApproximately ( numberFormat, result )","titleHTML":"FormatApproximately ( <var>numberFormat</var>, <var>result</var> )","number":"1.5.20","referencingIds":["_ref_82"]},{"type":"op","aoid":"CollapseNumberRange","refId":"sec-collapsenumberrange"},{"type":"clause","id":"sec-collapsenumberrange","title":"CollapseNumberRange ( result )","titleHTML":"CollapseNumberRange ( <var>result</var> )","number":"1.5.21","referencingIds":["_ref_83"]},{"type":"op","aoid":"FormatNumericRange","refId":"sec-formatnumericrange"},{"type":"clause","id":"sec-formatnumericrange","title":"FormatNumericRange( numberFormat, x, y )","titleHTML":"FormatNumericRange( <var>numberFormat</var>, <var>x</var>, <var>y</var> )","number":"1.5.22","referencingIds":["_ref_35"]},{"type":"op","aoid":"FormatNumericRangeToParts","refId":"sec-formatnumericrangetoparts"},{"type":"clause","id":"sec-formatnumericrangetoparts","title":"FormatNumericRangeToParts( numberFormat, x, y )","titleHTML":"FormatNumericRangeToParts( <var>numberFormat</var>, <var>x</var>, <var>y</var> )","number":"1.5.23","referencingIds":["_ref_38"]},{"type":"clause","id":"sec-numberformat-abstracts","titleHTML":"Abstract Operations for NumberFormat Objects","number":"1.5"},{"type":"clause","id":"numberformat-objects","titleHTML":"NumberFormat Objects","number":"1"}]}`);
+;let usesMultipage = false</script><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.0.1/styles/base16/solarized-light.min.css"><style>body {
   display: flex;
+  word-wrap: break-word;
   font-size: 18px;
   line-height: 1.5;
   font-family: Cambria, Palatino Linotype, Palatino, Liberation Serif, serif;
@@ -912,6 +1364,7 @@ document.addEventListener('DOMContentLoaded', installFindLocalReferences);
   flex-basis: 66%;
   box-sizing: border-box;
   overflow: hidden;
+  padding-bottom: 1em;
 }
 
 body.oldtoc {
@@ -919,8 +1372,8 @@ body.oldtoc {
 }
 
 a {
-    text-decoration: none;
-    color: #206ca7;
+  text-decoration: none;
+  color: #206ca7;
 }
 
 a:visited {
@@ -928,15 +1381,51 @@ a:visited {
 }
 
 a:hover {
-    text-decoration: underline;
-    color: #239dee;
+  text-decoration: underline;
+  color: #239dee;
 }
 
+a.e-user-code,
+span.e-user-code {
+  white-space: nowrap;
+}
+
+a.e-user-code::before,
+span.e-user-code::before {
+  display: none;
+  color: brown;
+  background-color: white;
+  border: 2pt solid brown;
+  padding: 0.3ex;
+  margin: 0 0.25em 0 0;
+  line-height: 1;
+  vertical-align: text-top;
+  text-transform: uppercase;
+  font-family: 'Comic Code', sans-serif;
+  font-weight: 900;
+  font-size: x-small;
+}
+
+a.e-user-code:hover::before,
+span.e-user-code:hover::before {
+  background-color: brown;
+  color: white;
+}
+
+html.show-ao-annotations a.e-user-code::before,
+html.show-ao-annotations span.e-user-code::before {
+  display: inline-block;
+}
+
+a.e-user-code::before,
+span.e-user-code::before {
+  content: 'UC';
+}
 
 code {
-    font-weight: bold;
-    font-family: Consolas, Monaco, monospace;
-    white-space: pre;
+  font-weight: bold;
+  font-family: Consolas, Monaco, monospace;
+  white-space: pre;
 }
 
 pre code {
@@ -950,13 +1439,13 @@ pre code.hljs {
 }
 
 ol.toc {
-    list-style: none;
-    padding-left: 0;
+  list-style: none;
+  padding-left: 0;
 }
 
 ol.toc ol.toc {
-    padding-left: 2ex;
-    list-style: none;
+  padding-left: 2ex;
+  list-style: none;
 }
 
 var {
@@ -965,8 +1454,40 @@ var {
   cursor: pointer;
 }
 
-var.referenced {
+var.referenced0 {
+  color: inherit;
   background-color: #ffff33;
+  box-shadow: 0 0 0 2px #ffff33;
+}
+var.referenced1 {
+  color: inherit;
+  background-color: #ff87a2;
+  box-shadow: 0 0 0 2px #ff87a2;
+}
+var.referenced2 {
+  color: inherit;
+  background-color: #96e885;
+  box-shadow: 0 0 0 2px #96e885;
+}
+var.referenced3 {
+  color: inherit;
+  background-color: #3eeed2;
+  box-shadow: 0 0 0 2px #3eeed2;
+}
+var.referenced4 {
+  color: inherit;
+  background-color: #eacfb6;
+  box-shadow: 0 0 0 2px #eacfb6;
+}
+var.referenced5 {
+  color: inherit;
+  background-color: #82ddff;
+  box-shadow: 0 0 0 2px #82ddff;
+}
+var.referenced6 {
+  color: inherit;
+  background-color: #ffbcf2;
+  box-shadow: 0 0 0 2px #ffbcf2;
 }
 
 emu-const {
@@ -1015,6 +1536,10 @@ emu-alg ol.nested-lots ol {
   list-style-type: lower-roman;
 }
 
+emu-alg [aria-hidden=true] {
+  font-size: 0;
+}
+
 emu-eqn {
   display: block;
   margin-left: 4em;
@@ -1030,29 +1555,32 @@ emu-eqn div:first-child {
 }
 
 emu-note {
-    margin: 1em 0;
-    color: #666;
-    border-left: 5px solid #ccc;
-    display: flex;
-    flex-direction: row;
+  margin: 1em 0;
+  display: flex;
+  flex-direction: row;
+  color: inherit;
+  border-left: 5px solid #52e052;
+  background: #e9fbe9;
+  padding: 10px 10px 10px 0;
 }
 
 emu-note > span.note {
-    flex-basis: 100px;
-    min-width: 100px;
-    flex-grow: 0;
-    flex-shrink: 1;
-    text-transform: uppercase;
-    padding-left: 5px;
+  flex-basis: 100px;
+  min-width: 100px;
+  flex-grow: 0;
+  flex-shrink: 1;
+  text-transform: uppercase;
+  padding-left: 5px;
 }
 
-emu-note[type=editor] {
+emu-note[type='editor'] {
   border-left-color: #faa;
 }
 
 emu-note > div.note-contents {
   flex-grow: 1;
   flex-shrink: 1;
+  overflow: auto;
 }
 
 emu-note > div.note-contents > p:first-of-type {
@@ -1063,9 +1591,9 @@ emu-note > div.note-contents > p:last-of-type {
   margin-bottom: 0;
 }
 
-emu-table td code {
+emu-table:not(.code) td code {
   white-space: normal;
-} 
+}
 
 emu-figure {
   display: block;
@@ -1090,99 +1618,120 @@ emu-table figure {
 }
 
 emu-production {
-    display: block;
+  display: block;
 }
 
-emu-grammar[type="example"] emu-production,
-emu-grammar[type="definition"] emu-production {
-    margin-top: 1em;
-    margin-bottom: 1em;
-    margin-left: 5ex;
+emu-grammar[type='example'] emu-production,
+emu-grammar[type='definition'] emu-production {
+  margin-top: 1em;
+  margin-bottom: 1em;
+  margin-left: 5ex;
 }
 
-emu-grammar.inline, emu-production.inline,
-emu-grammar.inline emu-production emu-rhs, emu-production.inline emu-rhs,
-emu-grammar[collapsed] emu-production emu-rhs, emu-production[collapsed] emu-rhs {
-    display: inline;
-    padding-left: 1ex;
-    margin-left: 0;
+emu-grammar.inline,
+emu-production.inline,
+emu-grammar.inline emu-production emu-rhs,
+emu-production.inline emu-rhs,
+emu-grammar[collapsed] emu-production emu-rhs {
+  display: inline;
+  padding-left: 1ex;
+  margin-left: 0;
 }
 
-emu-grammar[collapsed] emu-production, emu-production[collapsed] {
-    margin: 0;
+emu-production[collapsed] emu-rhs {
+  display: inline;
+  padding-left: 0.5ex;
+  margin-left: 0;
+}
+
+emu-grammar[collapsed] emu-production,
+emu-production[collapsed] {
+  margin: 0;
 }
 
 emu-constraints {
-    font-size: .75em;
-    margin-right: 1ex;
+  font-size: 0.75em;
+  margin-right: 0.5ex;
 }
 
 emu-gann {
-    margin-right: 1ex;
+  margin-right: 0.5ex;
 }
 
 emu-gann emu-t:last-child,
 emu-gann emu-gprose:last-child,
 emu-gann emu-nt:last-child {
-    margin-right: 0;
+  margin-right: 0;
 }
 
 emu-geq {
-    margin-left: 1ex;
-    font-weight: bold;
+  margin-left: 0.5ex;
+  font-weight: bold;
 }
 
 emu-oneof {
-    font-weight: bold;
-    margin-left: 1ex;
+  font-weight: bold;
+  margin-left: 0.5ex;
 }
 
 emu-nt {
-    display: inline-block;
-    font-style: italic;
-    white-space: nowrap;
-    text-indent: 0;
+  display: inline-block;
+  font-style: italic;
+  white-space: nowrap;
+  text-indent: 0;
 }
 
-emu-nt a, emu-nt a:visited {
+emu-nt a,
+emu-nt a:visited {
   color: #333;
 }
 
 emu-rhs emu-nt {
-    margin-right: 1ex;
+  margin-right: 0.5ex;
 }
 
 emu-t {
-    display: inline-block;
-    font-family: monospace;
-    font-weight: bold;
-    white-space: nowrap;
-    text-indent: 0;
+  display: inline-block;
+  font-family: monospace;
+  font-weight: bold;
+  white-space: nowrap;
+  text-indent: 0;
 }
 
 emu-production emu-t {
-    margin-right: 1ex;
+  margin-right: 0.5ex;
 }
 
 emu-rhs {
-    display: block;
-    padding-left: 75px;
-    text-indent: -25px;
+  display: block;
+  padding-left: 75px;
+  text-indent: -25px;
+}
+
+emu-production:not([collapsed]) emu-rhs {
+  border: 0.2ex dashed transparent;
+}
+
+emu-production:not([collapsed]) emu-rhs:hover {
+  border-color: #888;
+  background-color: #f0f0f0;
 }
 
 emu-mods {
-    font-size: .85em;
-    vertical-align: sub;
-    font-style: normal;
-    font-weight: normal;
+  font-size: 0.85em;
+  vertical-align: sub;
+  font-style: normal;
+  font-weight: normal;
 }
 
-emu-params, emu-opt {
+emu-params,
+emu-opt {
   margin-right: 1ex;
   font-family: monospace;
 }
 
-emu-params, emu-constraints {
+emu-params,
+emu-constraints {
   color: #2aa198;
 }
 
@@ -1191,12 +1740,12 @@ emu-opt {
 }
 
 emu-gprose {
-    font-size: 0.9em;
-    font-family: Helvetica, Arial, sans-serif;
+  font-size: 0.9em;
+  font-family: Helvetica, Arial, sans-serif;
 }
 
 emu-production emu-gprose {
-    margin-right: 1ex;
+  margin-right: 1ex;
 }
 
 h1.shortname {
@@ -1208,20 +1757,19 @@ h1.shortname {
 h1.version {
   color: #f60;
   font-size: 1.5em;
-  margin: 0;
 }
 
 h1.title {
-  margin-top: 0;
   color: #f60;
 }
 
-h1.first {
-  margin-top: 0;
-}
-
-h1, h2, h3, h4, h5, h6 {
-    position: relative;
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  position: relative;
 }
 
 h1 .secnum {
@@ -1233,142 +1781,267 @@ h1 span.title {
   order: 2;
 }
 
+h1 {
+  font-size: 2.67em;
+  margin-bottom: 0;
+  line-height: 1em;
+}
+h2 {
+  font-size: 2em;
+}
+h3 {
+  font-size: 1.56em;
+}
+h4 {
+  font-size: 1.25em;
+}
+h5 {
+  font-size: 1.11em;
+}
+h6 {
+  font-size: 1em;
+}
 
-h1 { font-size: 2.67em; margin-top: 2em; margin-bottom: 0; line-height: 1em;}
-h2 { font-size: 2em; }
-h3 { font-size: 1.56em; }
-h4 { font-size: 1.25em; }
-h5 { font-size: 1.11em; }
-h6 { font-size: 1em; }
+pre code.hljs {
+  background: transparent;
+}
 
-h1:hover span.utils {
+emu-clause[id],
+emu-annex[id],
+emu-intro[id] {
+  scroll-margin-top: 2ex;
+}
+
+emu-intro h1,
+emu-clause h1,
+emu-annex h1 {
+  font-size: 2em;
+}
+emu-intro h2,
+emu-clause h2,
+emu-annex h2 {
+  font-size: 1.56em;
+}
+emu-intro h3,
+emu-clause h3,
+emu-annex h3 {
+  font-size: 1.25em;
+}
+emu-intro h4,
+emu-clause h4,
+emu-annex h4 {
+  font-size: 1.11em;
+}
+emu-intro h5,
+emu-clause h5,
+emu-annex h5 {
+  font-size: 1em;
+}
+emu-intro h6,
+emu-clause h6,
+emu-annex h6 {
+  font-size: 0.9em;
+}
+emu-intro emu-intro h1,
+emu-clause emu-clause h1,
+emu-annex emu-annex h1 {
+  font-size: 1.56em;
+}
+emu-intro emu-intro h2,
+emu-clause emu-clause h2,
+emu-annex emu-annex h2 {
+  font-size: 1.25em;
+}
+emu-intro emu-intro h3,
+emu-clause emu-clause h3,
+emu-annex emu-annex h3 {
+  font-size: 1.11em;
+}
+emu-intro emu-intro h4,
+emu-clause emu-clause h4,
+emu-annex emu-annex h4 {
+  font-size: 1em;
+}
+emu-intro emu-intro h5,
+emu-clause emu-clause h5,
+emu-annex emu-annex h5 {
+  font-size: 0.9em;
+}
+emu-intro emu-intro emu-intro h1,
+emu-clause emu-clause emu-clause h1,
+emu-annex emu-annex emu-annex h1 {
+  font-size: 1.25em;
+}
+emu-intro emu-intro emu-intro h2,
+emu-clause emu-clause emu-clause h2,
+emu-annex emu-annex emu-annex h2 {
+  font-size: 1.11em;
+}
+emu-intro emu-intro emu-intro h3,
+emu-clause emu-clause emu-clause h3,
+emu-annex emu-annex emu-annex h3 {
+  font-size: 1em;
+}
+emu-intro emu-intro emu-intro h4,
+emu-clause emu-clause emu-clause h4,
+emu-annex emu-annex emu-annex h4 {
+  font-size: 0.9em;
+}
+emu-intro emu-intro emu-intro emu-intro h1,
+emu-clause emu-clause emu-clause emu-clause h1,
+emu-annex emu-annex emu-annex emu-annex h1 {
+  font-size: 1.11em;
+}
+emu-intro emu-intro emu-intro emu-intro h2,
+emu-clause emu-clause emu-clause emu-clause h2,
+emu-annex emu-annex emu-annex emu-annex h2 {
+  font-size: 1em;
+}
+emu-intro emu-intro emu-intro emu-intro h3,
+emu-clause emu-clause emu-clause emu-clause h3,
+emu-annex emu-annex emu-annex emu-annex h3 {
+  font-size: 0.9em;
+}
+emu-intro emu-intro emu-intro emu-intro emu-intro h1,
+emu-clause emu-clause emu-clause emu-clause emu-clause h1,
+emu-annex emu-annex emu-annex emu-annex emu-annex h1 {
+  font-size: 1em;
+}
+emu-intro emu-intro emu-intro emu-intro emu-intro h2,
+emu-clause emu-clause emu-clause emu-clause emu-clause h2,
+emu-annex emu-annex emu-annex emu-annex emu-annex h2 {
+  font-size: 0.9em;
+}
+emu-intro emu-intro emu-intro emu-intro emu-intro emu-intro h1,
+emu-clause emu-clause emu-clause emu-clause emu-clause emu-clause h1,
+emu-annex emu-annex emu-annex emu-annex emu-annex emu-annex h1 {
+  font-size: 0.9em;
+}
+
+emu-clause,
+emu-intro,
+emu-annex {
   display: block;
 }
 
-span.utils {
-  font-size: 18px;
-  line-height: 18px;
-  display: none;
-  position: absolute;
-  top: 100%;
-  left: 0;
-  right: 0;
-  font-weight: normal;
+/* these values are twice the font-size for the <h1> titles for clauses */
+emu-intro,
+emu-clause,
+emu-annex {
+  margin-top: 4em;
+}
+emu-intro emu-intro,
+emu-clause emu-clause,
+emu-annex emu-annex {
+  margin-top: 3.12em;
+}
+emu-intro emu-intro emu-intro,
+emu-clause emu-clause emu-clause,
+emu-annex emu-annex emu-annex {
+  margin-top: 2.5em;
+}
+emu-intro emu-intro emu-intro emu-intro,
+emu-clause emu-clause emu-clause emu-clause,
+emu-annex emu-annex emu-annex emu-annex {
+  margin-top: 2.22em;
+}
+emu-intro emu-intro emu-intro emu-intro emu-intro,
+emu-clause emu-clause emu-clause emu-clause emu-clause,
+emu-annex emu-annex emu-annex emu-annex emu-annex {
+  margin-top: 2em;
+}
+emu-intro emu-intro emu-intro emu-intro emu-intro emu-intro,
+emu-clause emu-clause emu-clause emu-clause emu-clause emu-clause,
+emu-annex emu-annex emu-annex emu-annex emu-annex emu-annex {
+  margin-top: 1.8em;
 }
 
-span.utils:before {
-    content: "⤷";
-    display: inline-block;
-    padding: 0 5px;
-}
-
-span.utils > * {
-  display: inline-block;
-  margin-right: 20px;
-}
-
-h1 span.utils span.anchor a,
-h2 span.utils span.anchor a,
-h3 span.utils span.anchor a,
-h4 span.utils span.anchor a,
-h5 span.utils span.anchor a,
-h6 span.utils span.anchor a {
-  text-decoration: none;
-  font-variant: small-caps;
-}
-
-h1 span.utils span.anchor a:hover,
-h2 span.utils span.anchor a:hover,
-h3 span.utils span.anchor a:hover,
-h4 span.utils span.anchor a:hover,
-h5 span.utils span.anchor a:hover,
-h6 span.utils span.anchor a:hover {
-  color: #333;
-}
-
-emu-intro h1, emu-clause h1, emu-annex h1 { font-size: 2em; }
-emu-intro h2, emu-clause h2, emu-annex h2 { font-size: 1.56em; }
-emu-intro h3, emu-clause h3, emu-annex h3 { font-size: 1.25em; }
-emu-intro h4, emu-clause h4, emu-annex h4 { font-size: 1.11em; }
-emu-intro h5, emu-clause h5, emu-annex h5 { font-size: 1em; }
-emu-intro h6, emu-clause h6, emu-annex h6 { font-size: 0.9em; }
-emu-intro emu-intro h1, emu-clause emu-clause h1, emu-annex emu-annex h1 { font-size: 1.56em; }
-emu-intro emu-intro h2, emu-clause emu-clause h2, emu-annex emu-annex h2 { font-size: 1.25em; }
-emu-intro emu-intro h3, emu-clause emu-clause h3, emu-annex emu-annex h3 { font-size: 1.11em; }
-emu-intro emu-intro h4, emu-clause emu-clause h4, emu-annex emu-annex h4 { font-size: 1em; }
-emu-intro emu-intro h5, emu-clause emu-clause h5, emu-annex emu-annex h5 { font-size: 0.9em; }
-emu-intro emu-intro emu-intro h1, emu-clause emu-clause emu-clause h1, emu-annex emu-annex emu-annex h1 { font-size: 1.25em; }
-emu-intro emu-intro emu-intro h2, emu-clause emu-clause emu-clause h2, emu-annex emu-annex emu-annex h2 { font-size: 1.11em; }
-emu-intro emu-intro emu-intro h3, emu-clause emu-clause emu-clause h3, emu-annex emu-annex emu-annex h3 { font-size: 1em; }
-emu-intro emu-intro emu-intro h4, emu-clause emu-clause emu-clause h4, emu-annex emu-annex emu-annex h4 { font-size: 0.9em; }
-emu-intro emu-intro emu-intro emu-intro h1, emu-clause emu-clause emu-clause emu-clause h1, emu-annex emu-annex emu-annex emu-annex h1 { font-size: 1.11em; }
-emu-intro emu-intro emu-intro emu-intro h2, emu-clause emu-clause emu-clause emu-clause h2, emu-annex emu-annex emu-annex emu-annex h2 { font-size: 1em; }
-emu-intro emu-intro emu-intro emu-intro h3, emu-clause emu-clause emu-clause emu-clause h3, emu-annex emu-annex emu-annex emu-annex h3 { font-size: 0.9em; }
-emu-intro emu-intro emu-intro emu-intro emu-intro h1, emu-clause emu-clause emu-clause emu-clause emu-clause h1, emu-annex emu-annex emu-annex emu-annex emu-annex h1 { font-size: 1em; }
-emu-intro emu-intro emu-intro emu-intro emu-intro h2, emu-clause emu-clause emu-clause emu-clause emu-clause h2, emu-annex emu-annex emu-annex emu-annex emu-annex h2 { font-size: 0.9em; }
-emu-intro emu-intro emu-intro emu-intro emu-intro emu-intro h1, emu-clause emu-clause emu-clause emu-clause emu-clause emu-clause h1, emu-annex emu-annex emu-annex emu-annex emu-annex emu-annex h1 { font-size: 0.9em }
-
-emu-clause, emu-intro, emu-annex {
-    display: block;
+#spec-container > emu-intro:first-of-type,
+#spec-container > emu-clause:first-of-type,
+#spec-container > emu-annex:first-of-type {
+  margin-top: 0;
 }
 
 /* Figures and tables */
-figure { display: block; margin: 1em 0 3em 0; }
-figure object { display: block; margin: 0 auto; }
-figure table.real-table { margin: 0 auto; }
+figure {
+  display: block;
+  margin: 1em 0 3em 0;
+}
+figure object {
+  display: block;
+  margin: 0 auto;
+}
+figure table.real-table {
+  margin: 0 auto;
+}
 figure figcaption {
-    display: block;
-    color: #555555;
-    font-weight: bold;
-    text-align: center;
+  display: block;
+  color: #555555;
+  font-weight: bold;
+  text-align: center;
 }
 
 emu-table table {
   margin: 0 auto;
 }
 
-emu-table table, table.real-table {
-    border-collapse: collapse;
+emu-table table,
+table.real-table {
+  border-collapse: collapse;
 }
 
-emu-table td, emu-table th, table.real-table td, table.real-table th {
-    border: 1px solid black;
-    padding: 0.4em;
-    vertical-align: baseline;
+emu-table td,
+emu-table th,
+table.real-table td,
+table.real-table th {
+  border: 1px solid black;
+  padding: 0.4em;
+  vertical-align: baseline;
 }
-emu-table th, emu-table thead td, table.real-table th {
-    background-color: #eeeeee;
+emu-table th,
+emu-table thead td,
+table.real-table th {
+  background-color: #eeeeee;
+}
+
+emu-table td {
+  background: #fff;
 }
 
 /* Note: the left content edges of table.lightweight-table >tbody >tr >td
    and div.display line up. */
 table.lightweight-table {
-    border-collapse: collapse;
-    margin: 0 0 0 1.5em;
+  border-collapse: collapse;
+  margin: 0 0 0 1.5em;
 }
-table.lightweight-table td, table.lightweight-table th {
-    border: none;
-    padding: 0 0.5em;
-    vertical-align: baseline;
+table.lightweight-table td,
+table.lightweight-table th {
+  border: none;
+  padding: 0 0.5em;
+  vertical-align: baseline;
 }
 
 /* diff styles */
 ins {
-    background-color: #e0f8e0;
-    text-decoration: none;
-    border-bottom: 1px solid #396;
+  background-color: #e0f8e0;
+  text-decoration: none;
+  border-bottom: 1px solid #396;
 }
 
 del {
-    background-color: #fee;
+  background-color: #fee;
 }
 
-ins.block, del.block,
-emu-production > ins, emu-production > del,
-emu-grammar > ins, emu-grammar > del {
+ins.block,
+del.block,
+emu-production > ins,
+emu-production > del,
+emu-grammar > ins,
+emu-grammar > del {
   display: block;
 }
-emu-rhs > ins, emu-rhs > del { 
+emu-rhs > ins,
+emu-rhs > del {
   display: inline;
 }
 
@@ -1405,7 +2078,7 @@ tr.del > td {
   -khtml-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
-  user-select: none;;
+  user-select: none;
 
   cursor: pointer;
 }
@@ -1413,7 +2086,8 @@ tr.del > td {
 #menu {
   display: flex;
   flex-direction: column;
-  width: 33%; height: 100vh;
+  width: 33%;
+  height: 100vh;
   max-width: 500px;
   box-sizing: border-box;
   background-color: #ddd;
@@ -1421,13 +2095,14 @@ tr.del > td {
   transition: opacity 0.1s linear;
   padding: 0 5px;
   position: fixed;
-  left: 0; top: 0;
+  left: 0;
+  top: 0;
   border-right: 2px solid #bbb;
 
   z-index: 2;
 }
 
-#menu-spacer {
+.menu-spacer {
   flex-basis: 33%;
   max-width: 500px;
   flex-grow: 0;
@@ -1482,7 +2157,8 @@ tr.del > td {
   padding: 0;
 }
 
-#menu-toc > ol , #menu-toc > ol ol {
+#menu-toc > ol,
+#menu-toc > ol ol {
   list-style-type: none;
   margin: 0;
   padding: 0;
@@ -1512,7 +2188,7 @@ tr.del > td {
   -khtml-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
-  user-select: none;;
+  user-select: none;
 
   cursor: pointer;
 }
@@ -1543,7 +2219,7 @@ tr.del > td {
   */
 }
 
-#menu-toc li.revealed-leaf> a {
+#menu-toc li.revealed-leaf > a {
   color: #206ca7;
   /*
   background-color: #222;
@@ -1579,6 +2255,34 @@ tr.del > td {
   font-size: 0.8em;
 }
 
+.menu-pane-header emu-opt,
+.menu-pane-header emu-t,
+.menu-pane-header emu-nt {
+  margin-right: 0px;
+  display: inline;
+  color: inherit;
+}
+
+.menu-pane-header emu-rhs {
+  display: inline;
+  padding-left: 0px;
+  text-indent: 0px;
+}
+
+.menu-pane-header emu-geq {
+  margin-left: 0px;
+}
+
+a.menu-pane-header-production {
+  color: inherit;
+}
+
+.menu-pane-header-production {
+  text-transform: none;
+  letter-spacing: 1.5px;
+  padding-left: 0.5em;
+}
+
 #menu-toc {
   display: flex;
   flex-direction: column;
@@ -1597,10 +2301,10 @@ tr.del > td {
   flex-grow: 0;
   flex-shrink: 0;
   width: 100%;
-  
+
   display: flex;
   flex-direction: column;
-  
+
   max-height: 300px;
 }
 
@@ -1625,43 +2329,42 @@ tr.del > td {
 }
 
 li.menu-search-result-clause:before {
-    content: 'clause';
-    width: 40px;
-    display: inline-block;
-    text-align: right;
-    padding-right: 1ex;
-    color: #666;
-    font-size: 75%;
+  content: 'clause';
+  width: 40px;
+  display: inline-block;
+  text-align: right;
+  padding-right: 1ex;
+  color: #666;
+  font-size: 75%;
 }
 li.menu-search-result-op:before {
-    content: 'op';
-    width: 40px;
-    display: inline-block;
-    text-align: right;
-    padding-right: 1ex;
-    color: #666;
-    font-size: 75%;
+  content: 'op';
+  width: 40px;
+  display: inline-block;
+  text-align: right;
+  padding-right: 1ex;
+  color: #666;
+  font-size: 75%;
 }
 
 li.menu-search-result-prod:before {
-    content: 'prod';
-    width: 40px;
-    display: inline-block;
-    text-align: right;
-    padding-right: 1ex;
-    color: #666;
-    font-size: 75%
+  content: 'prod';
+  width: 40px;
+  display: inline-block;
+  text-align: right;
+  padding-right: 1ex;
+  color: #666;
+  font-size: 75%;
 }
 
-
 li.menu-search-result-term:before {
-    content: 'term';
-    width: 40px;
-    display: inline-block;
-    text-align: right;
-    padding-right: 1ex;
-    color: #666;
-    font-size: 75%
+  content: 'term';
+  width: 40px;
+  display: inline-block;
+  text-align: right;
+  padding-right: 1ex;
+  color: #666;
+  font-size: 75%;
 }
 
 #menu-search-results ul {
@@ -1674,7 +2377,6 @@ li.menu-search-result-term:before {
   text-overflow: ellipsis;
 }
 
-
 #menu-trace-list {
   counter-reset: item;
   margin: 0 0 0 20px;
@@ -1686,19 +2388,19 @@ li.menu-search-result-term:before {
 }
 
 #menu-trace-list li .secnum:after {
-  content: " ";
+  content: ' ';
 }
 #menu-trace-list li:before {
-    content: counter(item) " ";
-    background-color: #222;
-    counter-increment: item;
-    color: #999;
-    width: 20px;
-    height: 20px;
-    line-height: 20px;
-    display: inline-block;
-    text-align: center;
-    margin: 2px 4px 2px 0;
+  content: counter(item) ' ';
+  background-color: #222;
+  counter-increment: item;
+  color: #999;
+  width: 20px;
+  height: 20px;
+  line-height: 20px;
+  display: inline-block;
+  text-align: center;
+  margin: 2px 4px 2px 0;
 }
 
 @media (max-width: 1000px) {
@@ -1740,24 +2442,29 @@ li.menu-search-result-term:before {
   }
 
   h1 .secnum:empty {
-    margin: 0; padding: 0;
+    margin: 0;
+    padding: 0;
   }
 }
 
-
 /* Toolbox */
-.toolbox {
-	position: absolute;
-	background: #ddd;
-	border: 1px solid #aaa;
+.toolbox-container {
+  position: absolute;
   display: none;
+  padding-bottom: 7px;
+}
+
+.toolbox-container.active {
+  display: inline-block;
+}
+
+.toolbox {
+  position: relative;
+  background: #ddd;
+  border: 1px solid #aaa;
   color: #eee;
   padding: 5px;
   border-radius: 3px;
-}
-
-.toolbox.active {
-  display: inline-block;
 }
 
 .toolbox a {
@@ -1769,28 +2476,29 @@ li.menu-search-result-term:before {
   text-decoration: underline;
 }
 
-.toolbox:after, .toolbox:before {
-	top: 100%;
-	left: 15px;
-	border: solid transparent;
-	content: " ";
-	height: 0;
-	width: 0;
-	position: absolute;
-	pointer-events: none;
+.toolbox:after,
+.toolbox:before {
+  top: 100%;
+  left: 15px;
+  border: solid transparent;
+  content: ' ';
+  height: 0;
+  width: 0;
+  position: absolute;
+  pointer-events: none;
 }
 
 .toolbox:after {
-	border-color: rgba(0, 0, 0, 0);
-	border-top-color: #ddd;
-	border-width: 10px;
-	margin-left: -10px;
+  border-color: rgba(0, 0, 0, 0);
+  border-top-color: #ddd;
+  border-width: 10px;
+  margin-left: -10px;
 }
 .toolbox:before {
-	border-color: rgba(204, 204, 204, 0);
-	border-top-color: #aaa;
-	border-width: 12px;
-	margin-left: -12px;
+  border-color: rgba(204, 204, 204, 0);
+  border-top-color: #aaa;
+  border-width: 12px;
+  margin-left: -12px;
 }
 
 #references-pane-container {
@@ -1807,11 +2515,6 @@ li.menu-search-result-term:before {
 #references-pane-table-container {
   overflow-x: hidden;
   overflow-y: auto;
-}
-
-#references-pane-spacer {
-  flex-basis: 33%;
-  max-width: 500px;
 }
 
 #references-pane {
@@ -1831,6 +2534,10 @@ li.menu-search-result-term:before {
   cursor: pointer;
 }
 
+#references-pane table tbody {
+  vertical-align: baseline;
+}
+
 #references-pane table tr td:first-child {
   text-align: right;
   padding-right: 5px;
@@ -1838,17 +2545,84 @@ li.menu-search-result-term:before {
 
 @media print {
   #menu-toggle {
-    display: none; 
+    display: none;
   }
 }
-</style></head><body><div id="menu-toggle">☰</div><div id="menu-spacer"></div><div id="menu"><div id="menu-search"><input type="text" id="menu-search-box" placeholder="Search..."><div id="menu-search-results" class="inactive"></div></div><div id="menu-pins"><div class="menu-pane-header">Pins</div><ul id="menu-pins-list"></ul></div><div class="menu-pane-header">Table of Contents</div><div id="menu-toc"><ol class="toc"><li><span class="item-toggle">◢</span><a href="#numberformat-objects" title="NumberFormat Objects"><span class="secnum">1</span> NumberFormat Objects</a><ol class="toc"><li><span class="item-toggle">◢</span><a href="#sec-intl-numberformat-constructor" title="The Intl.NumberFormat Constructor"><span class="secnum">1.1</span> The Intl.NumberFormat Constructor</a><ol class="toc"><li><span class="item-toggle">◢</span><a href="#sec-intl.numberformat" title="Intl.NumberFormat ( [ locales [ , options ] ] )"><span class="secnum">1.1.1</span> Intl.NumberFormat ( [ <var>locales</var> [ , <var>options</var> ] ] )</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-chainnumberformat" title="ChainNumberFormat ( numberFormat, newTarget, this )"><span class="secnum">1.1.1.1</span> ChainNumberFormat ( <var>numberFormat</var>, <var>newTarget</var>, <var>this</var> )</a></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-initializenumberformat" title="InitializeNumberFormat ( numberFormat, locales, options )"><span class="secnum">1.1.2</span> InitializeNumberFormat ( <var>numberFormat</var>, <var>locales</var>, <var>options</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-setnfdigitoptions" title="SetNumberFormatDigitOptions ( intlObj, options, mnfdDefault, mxfdDefault, notation )"><span class="secnum">1.1.3</span> SetNumberFormatDigitOptions ( <var>intlObj</var>, <var>options</var>, <var>mnfdDefault</var>, <var>mxfdDefault</var>, <var>notation</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-setnumberformatunitoptions" title="SetNumberFormatUnitOptions ( intlObj, options )"><span class="secnum">1.1.4</span> SetNumberFormatUnitOptions ( <var>intlObj</var>, <var>options</var> )</a></li></ol></li><li><span class="item-toggle">◢</span><a href="#sec-properties-of-intl-numberformat-constructor" title="Properties of the Intl.NumberFormat Constructor"><span class="secnum">1.2</span> Properties of the Intl.NumberFormat Constructor</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-intl.numberformat.prototype" title="Intl.NumberFormat.prototype"><span class="secnum">1.2.1</span> Intl.NumberFormat.prototype</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.numberformat.supportedlocalesof" title="Intl.NumberFormat.supportedLocalesOf ( locales [ , options ] )"><span class="secnum">1.2.2</span> Intl.NumberFormat.supportedLocalesOf ( <var>locales</var> [ , <var>options</var> ] )</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.numberformat-internal-slots" title="Internal slots"><span class="secnum">1.2.3</span> Internal slots</a></li></ol></li><li><span class="item-toggle">◢</span><a href="#sec-properties-of-intl-numberformat-prototype-object" title="Properties of the Intl.NumberFormat Prototype Object"><span class="secnum">1.3</span> Properties of the Intl.NumberFormat Prototype Object</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-intl.numberformat.prototype.constructor" title="Intl.NumberFormat.prototype.constructor"><span class="secnum">1.3.1</span> Intl.NumberFormat.prototype.constructor</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.numberformat.prototype-@@tostringtag" title="Intl.NumberFormat.prototype [ @@toStringTag ]"><span class="secnum">1.3.2</span> Intl.NumberFormat.prototype [ @@toStringTag ]</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.numberformat.prototype.format" title="get Intl.NumberFormat.prototype.format"><span class="secnum">1.3.3</span> get Intl.NumberFormat.prototype.format</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.numberformat.prototype.formattoparts" title="Intl.NumberFormat.prototype.formatToParts ( value )"><span class="secnum">1.3.4</span> Intl.NumberFormat.prototype.formatToParts ( <var>value</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.numberformat.prototype.formatrange" title="Intl.NumberFormat.prototype.formatRange ( start, end )"><span class="secnum">1.3.5</span> Intl.NumberFormat.prototype.formatRange ( <var>start</var>, <var>end</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.numberformat.prototype.formatrangetoparts" title="Intl.NumberFormat.prototype.formatRangeToParts ( start, end )"><span class="secnum">1.3.6</span> Intl.NumberFormat.prototype.formatRangeToParts ( <var>start</var>, <var>end</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.numberformat.prototype.resolvedoptions" title="Intl.NumberFormat.prototype.resolvedOptions ( )"><span class="secnum">1.3.7</span> Intl.NumberFormat.prototype.resolvedOptions ( )</a></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-properties-of-intl-numberformat-instances" title="Properties of Intl.NumberFormat Instances"><span class="secnum">1.4</span> Properties of Intl.NumberFormat Instances</a></li><li><span class="item-toggle">◢</span><a href="#sec-numberformat-abstracts" title="Abstract Operations for NumberFormat Objects"><span class="secnum">1.5</span> Abstract Operations for NumberFormat Objects</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-currencydigits" title="CurrencyDigits ( currency )"><span class="secnum">1.5.1</span> CurrencyDigits ( <var>currency</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-number-format-functions" title="Number Format Functions"><span class="secnum">1.5.2</span> Number Format Functions</a></li><li><span class="item-toggle-none"></span><a href="#sec-formatnumberstring" title="FormatNumericToString ( intlObject, x )"><span class="secnum">1.5.3</span> FormatNumericToString ( <var>intlObject</var>, <var>x</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-partitionnumberpattern" title="PartitionNumberPattern ( numberFormat, x )"><span class="secnum">1.5.4</span> PartitionNumberPattern ( <var>numberFormat</var>, <var>x</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-partitionnotationsubpattern" title="PartitionNotationSubPattern ( numberFormat, x, n, exponent )"><span class="secnum">1.5.5</span> PartitionNotationSubPattern ( <var>numberFormat</var>, <var>x</var>, <var>n</var>, <var>exponent</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-formatnumber" title="FormatNumeric ( numberFormat, x )"><span class="secnum">1.5.6</span> FormatNumeric ( <var>numberFormat</var>, <var>x</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-formatnumbertoparts" title="FormatNumericToParts ( numberFormat, x )"><span class="secnum">1.5.7</span> FormatNumericToParts ( <var>numberFormat</var>, <var>x</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-torawprecision" title="ToRawPrecision ( x, minPrecision, maxPrecision, unsignedRoundingMode )"><span class="secnum">1.5.8</span> ToRawPrecision ( <var>x</var>, <var>minPrecision</var>, <var>maxPrecision</var><ins>, <var>unsignedRoundingMode</var></ins> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-torawfixed" title="ToRawFixed ( x, minInteger, minFraction, maxFraction, roundingIncrement, unsignedRoundingMode )"><span class="secnum">1.5.9</span> ToRawFixed ( <var>x</var>, <del><var>minInteger</var>,</del> <var>minFraction</var>, <var>maxFraction</var><ins>, <var>roundingIncrement</var>, <var>unsignedRoundingMode</var></ins> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-unwrapnumberformat" title="UnwrapNumberFormat ( nf )"><span class="secnum">1.5.10</span> UnwrapNumberFormat ( <var>nf</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-getnumberformatpattern" title="GetNumberFormatPattern ( numberFormat, x )"><span class="secnum">1.5.11</span> GetNumberFormatPattern ( <var>numberFormat</var>, <var>x</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-getnotationsubpattern" title="GetNotationSubPattern ( numberFormat, exponent )"><span class="secnum">1.5.12</span> GetNotationSubPattern ( <var>numberFormat</var>, <var>exponent</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-computeexponent" title="ComputeExponent ( numberFormat, x )"><span class="secnum">1.5.13</span> ComputeExponent ( <var>numberFormat</var>, <var>x</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-computeexponentformagnitude" title="ComputeExponentForMagnitude ( numberFormat, magnitude )"><span class="secnum">1.5.14</span> ComputeExponentForMagnitude ( <var>numberFormat</var>, <var>magnitude</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-runtime-semantics-stringintlmv" title="Runtime Semantics: StringIntlMV"><span class="secnum">1.5.15</span> RS: StringIntlMV</a></li><li><span class="item-toggle-none"></span><a href="#sec-tointlmathematicalvalue" title="ToIntlMathematicalValue ( value )"><span class="secnum">1.5.16</span> ToIntlMathematicalValue ( <var>value</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-getunsignedroundingmode" title="GetUnsignedRoundingMode ( roundingMode, isNegative )"><span class="secnum">1.5.17</span> GetUnsignedRoundingMode ( <var>roundingMode</var>, <var>isNegative</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-applyunsignedroundingmode" title="ApplyUnsignedRoundingMode ( x, r1, r2, unsignedRoundingMode )"><span class="secnum">1.5.18</span> ApplyUnsignedRoundingMode ( <var>x</var>, <var>r1</var>, <var>r2</var>, <var>unsignedRoundingMode</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-partitionnumberrangepattern" title="PartitionNumberRangePattern ( numberFormat, x, y )"><span class="secnum">1.5.19</span> PartitionNumberRangePattern ( <var>numberFormat</var>, <var>x</var>, <var>y</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-formatapproximately" title="FormatApproximately ( numberFormat, result )"><span class="secnum">1.5.20</span> FormatApproximately ( <var>numberFormat</var>, <var>result</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-collapsenumberrange" title="CollapseNumberRange ( result )"><span class="secnum">1.5.21</span> CollapseNumberRange ( <var>result</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-formatnumericrange" title="FormatNumericRange( numberFormat, x, y )"><span class="secnum">1.5.22</span> FormatNumericRange( <var>numberFormat</var>, <var>x</var>, <var>y</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-formatnumericrangetoparts" title="FormatNumericRangeToParts( numberFormat, x, y )"><span class="secnum">1.5.23</span> FormatNumericRangeToParts( <var>numberFormat</var>, <var>x</var>, <var>y</var> )</a></li></ol></li></ol></li></ol></div></div><div id="spec-container"><emu-clause id="numberformat-objects">
-  <h1 class="first"><span class="secnum">1</span> NumberFormat Objects</h1>
+
+[normative-optional],
+[legacy] {
+  border-left: 5px solid #ff6600;
+  padding: 0.5em;
+  display: block;
+  background: #ffeedd;
+}
+
+.clause-attributes-tag {
+  text-transform: uppercase;
+  color: #884400;
+}
+
+.clause-attributes-tag a {
+  color: #884400;
+}
+
+/* Shortcuts help dialog */
+
+#shortcuts-help {
+  position: fixed;
+  left: 5%;
+  margin: 0 auto;
+  right: 5%;
+  z-index: 10;
+  top: 10%;
+  top: calc(5vw + 5vh);
+  padding: 30px 90px;
+  max-width: 500px;
+  outline: solid 10000px rgba(255, 255, 255, 0.6);
+  border-radius: 5px;
+  border-width: 1px 1px 0 1px;
+  background-color: #ddd;
+  display: none;
+}
+
+#shortcuts-help.active {
+  display: block;
+}
+
+#shortcuts-help ul {
+  padding: 0;
+}
+
+#shortcuts-help li {
+  display: flex;
+  justify-content: space-between;
+}
+
+#shortcuts-help code {
+  padding: 3px 10px;
+  border-radius: 3px;
+  border-width: 1px 1px 0 1px;
+  border-color: #bbb;
+  background-color: #eee;
+  box-shadow: inset 0 -1px 0 #ccc;
+}
+</style></head><body><div id="shortcuts-help">
+<ul>
+  <li><span>Toggle shortcuts help</span><code>?</code></li>
+  <li><span>Toggle "can call user code" annotations</span><code>u</code></li>
+
+  <li><span>Jump to search box</span><code>/</code></li>
+</ul></div><div id="menu-toggle"><svg xmlns="http://www.w3.org/2000/svg" style="width:100%; height:100%; stroke:currentColor" viewBox="0 0 120 120">
+      <title>Menu</title>
+      <path stroke-width="10" stroke-linecap="round" d="M30,60 h60  M30,30 m0,5 h60  M30,90 m0,-5 h60"></path>
+    </svg></div><div id="menu-spacer" class="menu-spacer"></div><div id="menu"><div id="menu-search"><input type="text" id="menu-search-box" placeholder="Search..."><div id="menu-search-results" class="inactive"></div></div><div id="menu-pins"><div class="menu-pane-header">Pins</div><ul id="menu-pins-list"></ul></div><div class="menu-pane-header">Table of Contents</div><div id="menu-toc"><ol class="toc"><li><span class="item-toggle">◢</span><a href="#numberformat-objects" title="NumberFormat Objects"><span class="secnum">1</span> NumberFormat Objects</a><ol class="toc"><li><span class="item-toggle">◢</span><a href="#sec-intl-numberformat-constructor" title="The Intl.NumberFormat Constructor"><span class="secnum">1.1</span> The Intl.NumberFormat Constructor</a><ol class="toc"><li><span class="item-toggle">◢</span><a href="#sec-intl.numberformat" title="Intl.NumberFormat ( [ locales [ , options ] ] )"><span class="secnum">1.1.1</span> Intl.NumberFormat ( [ <var>locales</var> [ , <var>options</var> ] ] )</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-chainnumberformat" title="ChainNumberFormat ( numberFormat, newTarget, this )"><span class="secnum">1.1.1.1</span> ChainNumberFormat ( <var>numberFormat</var>, <var>newTarget</var>, <var>this</var> )</a></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-initializenumberformat" title="InitializeNumberFormat ( numberFormat, locales, options )"><span class="secnum">1.1.2</span> InitializeNumberFormat ( <var>numberFormat</var>, <var>locales</var>, <var>options</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-setnfdigitoptions" title="SetNumberFormatDigitOptions ( intlObj, options, mnfdDefault, mxfdDefault, notation )"><span class="secnum">1.1.3</span> SetNumberFormatDigitOptions ( <var>intlObj</var>, <var>options</var>, <var>mnfdDefault</var>, <var>mxfdDefault</var>, <var>notation</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-setnumberformatunitoptions" title="SetNumberFormatUnitOptions ( intlObj, options )"><span class="secnum">1.1.4</span> SetNumberFormatUnitOptions ( <var>intlObj</var>, <var>options</var> )</a></li></ol></li><li><span class="item-toggle">◢</span><a href="#sec-properties-of-intl-numberformat-constructor" title="Properties of the Intl.NumberFormat Constructor"><span class="secnum">1.2</span> Properties of the Intl.NumberFormat Constructor</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-intl.numberformat.prototype" title="Intl.NumberFormat.prototype"><span class="secnum">1.2.1</span> Intl.NumberFormat.prototype</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.numberformat.supportedlocalesof" title="Intl.NumberFormat.supportedLocalesOf ( locales [ , options ] )"><span class="secnum">1.2.2</span> Intl.NumberFormat.supportedLocalesOf ( <var>locales</var> [ , <var>options</var> ] )</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.numberformat-internal-slots" title="Internal slots"><span class="secnum">1.2.3</span> Internal slots</a></li></ol></li><li><span class="item-toggle">◢</span><a href="#sec-properties-of-intl-numberformat-prototype-object" title="Properties of the Intl.NumberFormat Prototype Object"><span class="secnum">1.3</span> Properties of the Intl.NumberFormat Prototype Object</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-intl.numberformat.prototype.constructor" title="Intl.NumberFormat.prototype.constructor"><span class="secnum">1.3.1</span> Intl.NumberFormat.prototype.constructor</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.numberformat.prototype-@@tostringtag" title="Intl.NumberFormat.prototype [ @@toStringTag ]"><span class="secnum">1.3.2</span> Intl.NumberFormat.prototype [ @@toStringTag ]</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.numberformat.prototype.format" title="get Intl.NumberFormat.prototype.format"><span class="secnum">1.3.3</span> get Intl.NumberFormat.prototype.format</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.numberformat.prototype.formattoparts" title="Intl.NumberFormat.prototype.formatToParts ( value )"><span class="secnum">1.3.4</span> Intl.NumberFormat.prototype.formatToParts ( <var>value</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.numberformat.prototype.formatrange" title="Intl.NumberFormat.prototype.formatRange ( start, end )"><span class="secnum">1.3.5</span> Intl.NumberFormat.prototype.formatRange ( <var>start</var>, <var>end</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.numberformat.prototype.formatrangetoparts" title="Intl.NumberFormat.prototype.formatRangeToParts ( start, end )"><span class="secnum">1.3.6</span> Intl.NumberFormat.prototype.formatRangeToParts ( <var>start</var>, <var>end</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.numberformat.prototype.resolvedoptions" title="Intl.NumberFormat.prototype.resolvedOptions ( )"><span class="secnum">1.3.7</span> Intl.NumberFormat.prototype.resolvedOptions ( )</a></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-properties-of-intl-numberformat-instances" title="Properties of Intl.NumberFormat Instances"><span class="secnum">1.4</span> Properties of Intl.NumberFormat Instances</a></li><li><span class="item-toggle">◢</span><a href="#sec-numberformat-abstracts" title="Abstract Operations for NumberFormat Objects"><span class="secnum">1.5</span> Abstract Operations for NumberFormat Objects</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-currencydigits" title="CurrencyDigits ( currency )"><span class="secnum">1.5.1</span> CurrencyDigits ( <var>currency</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-number-format-functions" title="Number Format Functions"><span class="secnum">1.5.2</span> Number Format Functions</a></li><li><span class="item-toggle-none"></span><a href="#sec-formatnumberstring" title="FormatNumericToString ( intlObject, x )"><span class="secnum">1.5.3</span> FormatNumericToString ( <var>intlObject</var>, <var>x</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-partitionnumberpattern" title="PartitionNumberPattern ( numberFormat, x )"><span class="secnum">1.5.4</span> PartitionNumberPattern ( <var>numberFormat</var>, <var>x</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-partitionnotationsubpattern" title="PartitionNotationSubPattern ( numberFormat, x, n, exponent )"><span class="secnum">1.5.5</span> PartitionNotationSubPattern ( <var>numberFormat</var>, <var>x</var>, <var>n</var>, <var>exponent</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-formatnumber" title="FormatNumeric ( numberFormat, x )"><span class="secnum">1.5.6</span> FormatNumeric ( <var>numberFormat</var>, <var>x</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-formatnumbertoparts" title="FormatNumericToParts ( numberFormat, x )"><span class="secnum">1.5.7</span> FormatNumericToParts ( <var>numberFormat</var>, <var>x</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-torawprecision" title="ToRawPrecision ( x, minPrecision, maxPrecision, unsignedRoundingMode )"><span class="secnum">1.5.8</span> ToRawPrecision ( <var>x</var>, <var>minPrecision</var>, <var>maxPrecision</var><ins>, <var>unsignedRoundingMode</var></ins> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-torawfixed" title="ToRawFixed ( x, minInteger, minFraction, maxFraction, roundingIncrement, unsignedRoundingMode )"><span class="secnum">1.5.9</span> ToRawFixed ( <var>x</var>, <del><var>minInteger</var>,</del> <var>minFraction</var>, <var>maxFraction</var><ins>, <var>roundingIncrement</var>, <var>unsignedRoundingMode</var></ins> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-unwrapnumberformat" title="UnwrapNumberFormat ( nf )"><span class="secnum">1.5.10</span> UnwrapNumberFormat ( <var>nf</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-getnumberformatpattern" title="GetNumberFormatPattern ( numberFormat, x )"><span class="secnum">1.5.11</span> GetNumberFormatPattern ( <var>numberFormat</var>, <var>x</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-getnotationsubpattern" title="GetNotationSubPattern ( numberFormat, exponent )"><span class="secnum">1.5.12</span> GetNotationSubPattern ( <var>numberFormat</var>, <var>exponent</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-computeexponent" title="ComputeExponent ( numberFormat, x )"><span class="secnum">1.5.13</span> ComputeExponent ( <var>numberFormat</var>, <var>x</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-computeexponentformagnitude" title="ComputeExponentForMagnitude ( numberFormat, magnitude )"><span class="secnum">1.5.14</span> ComputeExponentForMagnitude ( <var>numberFormat</var>, <var>magnitude</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-runtime-semantics-stringintlmv" title="Runtime Semantics: StringIntlMV"><span class="secnum">1.5.15</span> RS: StringIntlMV</a></li><li><span class="item-toggle-none"></span><a href="#sec-tointlmathematicalvalue" title="ToIntlMathematicalValue ( value )"><span class="secnum">1.5.16</span> ToIntlMathematicalValue ( <var>value</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-getunsignedroundingmode" title="GetUnsignedRoundingMode ( roundingMode, isNegative )"><span class="secnum">1.5.17</span> GetUnsignedRoundingMode ( <var>roundingMode</var>, <var>isNegative</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-applyunsignedroundingmode" title="ApplyUnsignedRoundingMode ( x, r1, r2, unsignedRoundingMode )"><span class="secnum">1.5.18</span> ApplyUnsignedRoundingMode ( <var>x</var>, <var>r1</var>, <var>r2</var>, <var>unsignedRoundingMode</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-partitionnumberrangepattern" title="PartitionNumberRangePattern ( numberFormat, x, y )"><span class="secnum">1.5.19</span> PartitionNumberRangePattern ( <var>numberFormat</var>, <var>x</var>, <var>y</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-formatapproximately" title="FormatApproximately ( numberFormat, result )"><span class="secnum">1.5.20</span> FormatApproximately ( <var>numberFormat</var>, <var>result</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-collapsenumberrange" title="CollapseNumberRange ( result )"><span class="secnum">1.5.21</span> CollapseNumberRange ( <var>result</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-formatnumericrange" title="FormatNumericRange( numberFormat, x, y )"><span class="secnum">1.5.22</span> FormatNumericRange( <var>numberFormat</var>, <var>x</var>, <var>y</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-formatnumericrangetoparts" title="FormatNumericRangeToParts( numberFormat, x, y )"><span class="secnum">1.5.23</span> FormatNumericRangeToParts( <var>numberFormat</var>, <var>x</var>, <var>y</var> )</a></li></ol></li></ol></li></ol></div></div><div id="spec-container"><emu-clause id="numberformat-objects">
+  <h1><span class="secnum">1</span> NumberFormat Objects</h1>
 
   <emu-clause id="sec-intl-numberformat-constructor">
     <h1><span class="secnum">1.1</span> The Intl.NumberFormat Constructor</h1>
 
     <p>
-      The NumberFormat <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> is the <dfn>%NumberFormat%</dfn> intrinsic object and a standard built-in property of the Intl object. Behaviour common to all service <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> properties of the Intl object is specified in <emu-xref href="#sec-internal-slots"></emu-xref>.
+      The NumberFormat constructor is the <dfn>%NumberFormat%</dfn> intrinsic object and a standard built-in property of the Intl object. Behaviour common to all service constructor properties of the Intl object is specified in <emu-xref href="#sec-internal-slots"></emu-xref>.
     </p>
 
     <emu-clause id="sec-intl.numberformat">
@@ -1858,12 +2632,12 @@ li.menu-search-result-term:before {
         When the <code>Intl.NumberFormat</code> function is called with optional arguments <var>locales</var> and <var>options</var>, the following steps are taken:
       </p>
 
-      <emu-alg><ol><li>If NewTarget is <emu-val>undefined</emu-val>, let <var>newTarget</var> be the <emu-xref href="#active-function-object"><a href="https://tc39.es/ecma262/#active-function-object">active function object</a></emu-xref>, else let <var>newTarget</var> be NewTarget.</li><li>Let <var>numberFormat</var> be ?&nbsp;<emu-xref aoid="OrdinaryCreateFromConstructor" id="_ref_17"><a href="https://tc39.es/ecma262/#sec-ordinarycreatefromconstructor">OrdinaryCreateFromConstructor</a></emu-xref>(<var>newTarget</var>, <emu-val>"%NumberFormat.prototype%"</emu-val>, « [[InitializedNumberFormat]], [[Locale]], [[DataLocale]], [[NumberingSystem]], [[Style]], [[Unit]], [[UnitDisplay]], [[Currency]], [[CurrencyDisplay]], [[CurrencySign]], [[MinimumIntegerDigits]], [[MinimumFractionDigits]], [[MaximumFractionDigits]], [[MinimumSignificantDigits]], [[MaximumSignificantDigits]], [[RoundingType]], [[Notation]], [[CompactDisplay]], [[UseGrouping]], [[SignDisplay]], <ins>[[RoundingMode]], [[RoundingIncrement]], [[TrailingZeroDisplay]],</ins> [[BoundFormat]] »).</li><li>Perform ?&nbsp;<emu-xref aoid="InitializeNumberFormat" id="_ref_18"><a href="#sec-initializenumberformat">InitializeNumberFormat</a></emu-xref>(<var>numberFormat</var>, <var>locales</var>, <var>options</var>).</li><li>If the implementation supports the normative optional <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> mode of <emu-xref href="#legacy-constructor"></emu-xref>, then<ol><li>Let <var>this</var> be the <emu-val>this</emu-val> value.</li><li>Return ?&nbsp;<emu-xref aoid="ChainNumberFormat" id="_ref_19"><a href="#sec-chainnumberformat">ChainNumberFormat</a></emu-xref>(<var>numberFormat</var>, NewTarget, <var>this</var>).</li></ol></li><li>Return <var>numberFormat</var>.</li></ol></emu-alg>
+      <emu-alg><ol><li>If NewTarget is <emu-val>undefined</emu-val>, let <var>newTarget</var> be the active function object, else let <var>newTarget</var> be NewTarget.</li><li>Let <var>numberFormat</var> be ?&nbsp;OrdinaryCreateFromConstructor(<var>newTarget</var>, <emu-val>"%NumberFormat.prototype%"</emu-val>, « [[InitializedNumberFormat]], [[Locale]], [[DataLocale]], [[NumberingSystem]], [[Style]], [[Unit]], [[UnitDisplay]], [[Currency]], [[CurrencyDisplay]], [[CurrencySign]], [[MinimumIntegerDigits]], [[MinimumFractionDigits]], [[MaximumFractionDigits]], [[MinimumSignificantDigits]], [[MaximumSignificantDigits]], [[RoundingType]], [[Notation]], [[CompactDisplay]], [[UseGrouping]], [[SignDisplay]], <ins>[[RoundingMode]], [[RoundingIncrement]], [[TrailingZeroDisplay]],</ins> [[BoundFormat]] »).</li><li>Perform ?&nbsp;<emu-xref aoid="InitializeNumberFormat" id="_ref_17"><a href="#sec-initializenumberformat">InitializeNumberFormat</a></emu-xref>(<var>numberFormat</var>, <var>locales</var>, <var>options</var>).</li><li>If the implementation supports the normative optional constructor mode of <emu-xref href="#legacy-constructor"></emu-xref>, then<ol><li>Let <var>this</var> be the <emu-val>this</emu-val> value.</li><li>Return ?&nbsp;<emu-xref aoid="ChainNumberFormat" id="_ref_18"><a href="#sec-chainnumberformat">ChainNumberFormat</a></emu-xref>(<var>numberFormat</var>, NewTarget, <var>this</var>).</li></ol></li><li>Return <var>numberFormat</var>.</li></ol></emu-alg>
 
       <emu-normative-optional>
       <emu-clause id="sec-chainnumberformat" aoid="ChainNumberFormat">
         <h1><span class="secnum">1.1.1.1</span> ChainNumberFormat ( <var>numberFormat</var>, <var>newTarget</var>, <var>this</var> )</h1>
-        <emu-alg><ol><li>If <var>newTarget</var> is <emu-val>undefined</emu-val> and ?&nbsp;<emu-xref aoid="OrdinaryHasInstance" id="_ref_20"><a href="https://tc39.es/ecma262/#sec-ordinaryhasinstance">OrdinaryHasInstance</a></emu-xref>(<emu-xref href="#sec-intl-numberformat-constructor" id="_ref_21"><a href="#sec-intl-numberformat-constructor">%NumberFormat%</a></emu-xref>, <var>this</var>) is <emu-val>true</emu-val>, then<ol><li>Perform ?&nbsp;<emu-xref aoid="DefinePropertyOrThrow" id="_ref_22"><a href="https://tc39.es/ecma262/#sec-definepropertyorthrow">DefinePropertyOrThrow</a></emu-xref>(<var>this</var>, %Intl%.[[FallbackSymbol]], PropertyDescriptor{ [[Value]]: <var>numberFormat</var>, [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>false</emu-val> }).</li><li>Return <var>this</var>.</li></ol></li><li>Return <var>numberFormat</var>.</li></ol></emu-alg>
+        <emu-alg><ol><li>If <var>newTarget</var> is <emu-val>undefined</emu-val> and ?&nbsp;OrdinaryHasInstance(<emu-xref href="#sec-intl-numberformat-constructor" id="_ref_19"><a href="#sec-intl-numberformat-constructor">%NumberFormat%</a></emu-xref>, <var>this</var>) is <emu-val>true</emu-val>, then<ol><li>Perform ?&nbsp;DefinePropertyOrThrow(<var>this</var>, %Intl%.[[FallbackSymbol]], PropertyDescriptor{ [[Value]]: <var>numberFormat</var>, [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>false</emu-val> }).</li><li>Return <var>this</var>.</li></ol></li><li>Return <var>numberFormat</var>.</li></ol></emu-alg>
       </emu-clause>
       </emu-normative-optional>
     </emu-clause>
@@ -1879,7 +2653,7 @@ li.menu-search-result-term:before {
         The following algorithm refers to the <code>type</code> nonterminal from <a href="https://www.unicode.org/reports/tr35/#Unicode_locale_identifier">UTS 35's Unicode Locale Identifier grammar</a>.
       </p>
 
-      <emu-alg><ol><li>Let <var>requestedLocales</var> be ?&nbsp;CanonicalizeLocaleList(<var>locales</var>).</li><li>Set <var>options</var> to ?&nbsp;CoerceOptionsToObject(<var>options</var>).</li><li>Let <var>opt</var> be a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref>.</li><li>Let <var>matcher</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"localeMatcher"</emu-val>, <emu-const>string</emu-const>, « <emu-val>"lookup"</emu-val>, <emu-val>"best fit"</emu-val> », <emu-val>"best fit"</emu-val>).</li><li>Set <var>opt</var>.[[localeMatcher]] to <var>matcher</var>.</li><li>Let <var>numberingSystem</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"numberingSystem"</emu-val>, <emu-const>string</emu-const>, <emu-const>empty</emu-const>, <emu-val>undefined</emu-val>).</li><li>If <var>numberingSystem</var> is not <emu-val>undefined</emu-val>, then<ol><li>If <var>numberingSystem</var> does not match the Unicode Locale Identifier <code>type</code> nonterminal, throw a <emu-val>RangeError</emu-val> exception.</li></ol></li><li>Set <var>opt</var>.[[nu]] to <var>numberingSystem</var>.</li><li>Let <var>localeData</var> be <emu-xref href="#sec-intl-numberformat-constructor" id="_ref_23"><a href="#sec-intl-numberformat-constructor">%NumberFormat%</a></emu-xref>.[[LocaleData]].</li><li>Let <var>r</var> be ResolveLocale(<emu-xref href="#sec-intl-numberformat-constructor" id="_ref_24"><a href="#sec-intl-numberformat-constructor">%NumberFormat%</a></emu-xref>.[[AvailableLocales]], <var>requestedLocales</var>, <var>opt</var>, <emu-xref href="#sec-intl-numberformat-constructor" id="_ref_25"><a href="#sec-intl-numberformat-constructor">%NumberFormat%</a></emu-xref>.[[RelevantExtensionKeys]], <var>localeData</var>).</li><li>Set <var>numberFormat</var>.[[Locale]] to <var>r</var>.[[locale]].</li><li>Set <var>numberFormat</var>.[[DataLocale]] to <var>r</var>.[[dataLocale]].</li><li>Set <var>numberFormat</var>.[[NumberingSystem]] to <var>r</var>.[[nu]].</li><li>Perform ?&nbsp;<emu-xref aoid="SetNumberFormatUnitOptions" id="_ref_26"><a href="#sec-setnumberformatunitoptions">SetNumberFormatUnitOptions</a></emu-xref>(<var>numberFormat</var>, <var>options</var>).</li><li>Let <var>style</var> be <var>numberFormat</var>.[[Style]].</li><li>If <var>style</var> is <emu-val>"currency"</emu-val>, then<ol><li>Let <var>currency</var> be <var>numberFormat</var>.[[Currency]].</li><li>Let <var>cDigits</var> be <emu-xref aoid="CurrencyDigits" id="_ref_27"><a href="#sec-currencydigits">CurrencyDigits</a></emu-xref>(<var>currency</var>).</li><li>Let <var>mnfdDefault</var> be <var>cDigits</var>.</li><li>Let <var>mxfdDefault</var> be <var>cDigits</var>.</li></ol></li><li>Else,<ol><li>Let <var>mnfdDefault</var> be 0.</li><li>If <var>style</var> is <emu-val>"percent"</emu-val>, then<ol><li>Let <var>mxfdDefault</var> be 0.</li></ol></li><li>Else,<ol><li>Let <var>mxfdDefault</var> be 3.</li></ol></li></ol></li><li><ins class="block">Let <var>roundingIncrement</var> be ?&nbsp;GetNumberOption(<var>options</var>, <emu-val>"roundingIncrement"</emu-val>, 1, 5000, 1).</ins></li><li><ins class="block">If <var>roundingIncrement</var> is not in « 1, 2, 5, 10, 20, 25, 50, 100, 200, 250, 500, 1000, 2000, 2500, 5000 », throw a <emu-val>RangeError</emu-val> exception.</ins></li><li><ins class="block">If <var>roundingIncrement</var> is not 1, set <var>mxfdDefault</var> to <var>mnfdDefault</var>.</ins></li><li>Let <var>notation</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"notation"</emu-val>, <emu-const>string</emu-const>, « <emu-val>"standard"</emu-val>, <emu-val>"scientific"</emu-val>, <emu-val>"engineering"</emu-val>, <emu-val>"compact"</emu-val> », <emu-val>"standard"</emu-val>).</li><li>Set <var>numberFormat</var>.[[Notation]] to <var>notation</var>.</li><li>Perform ?&nbsp;<emu-xref aoid="SetNumberFormatDigitOptions" id="_ref_28"><a href="#sec-setnfdigitoptions">SetNumberFormatDigitOptions</a></emu-xref>(<var>numberFormat</var>, <var>options</var>, <var>mnfdDefault</var>, <var>mxfdDefault</var>, <var>notation</var>).</li><li><ins class="block">If <var>roundingIncrement</var> is not 1, then</ins><ol><li><ins class="block">If <var>numberFormat</var>.[[RoundingType]] is not <emu-const>fractionDigits</emu-const>, throw a <emu-val>TypeError</emu-val> exception.</ins></li><li><ins class="block">If <var>numberFormat</var>.[[MaximumFractionDigits]] is not equal to <var>numberFormat</var>.[[MinimumFractionDigits]], throw a <emu-val>RangeError</emu-val> exception.</ins></li></ol></li><li><ins class="block">Set <var>numberFormat</var>.[[RoundingIncrement]] to <var>roundingIncrement</var>.</ins></li><li><ins class="block">Let <var>trailingZeroDisplay</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"trailingZeroDisplay"</emu-val>, <emu-const>string</emu-const>, « <emu-val>"auto"</emu-val>, <emu-val>"stripIfInteger"</emu-val> », <emu-val>"auto"</emu-val>).</ins></li><li><ins class="block">Set <var>numberFormat</var>.[[TrailingZeroDisplay]] to <var>trailingZeroDisplay</var>.</ins></li><li>Let <var>compactDisplay</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"compactDisplay"</emu-val>, <emu-const>string</emu-const>, « <emu-val>"short"</emu-val>, <emu-val>"long"</emu-val> », <emu-val>"short"</emu-val>).</li><li><ins class="block">Let <var>defaultUseGrouping</var> be <emu-val>"auto"</emu-val>.</ins></li><li>If <var>notation</var> is <emu-val>"compact"</emu-val>, then<ol><li>Set <var>numberFormat</var>.[[CompactDisplay]] to <var>compactDisplay</var>.</li><li><ins class="block">Set <var>defaultUseGrouping</var> to <emu-val>"min2"</emu-val>.</ins></li></ol></li><li>Let <var>useGrouping</var> be ? <emu-xref aoid="Get" id="_ref_29"><a href="https://tc39.es/ecma262/#sec-get-o-p">Get</a></emu-xref><ins>StringOrBoolean</ins>Option(<var>options</var>, <emu-val>"useGrouping"</emu-val>, <del><emu-val>"boolean"</emu-val>, <emu-val>undefined</emu-val>, <emu-val>true</emu-val></del> <ins>« <emu-val>"min2"</emu-val>, <emu-val>"auto"</emu-val>, <emu-val>"always"</emu-val> », <emu-val>"always"</emu-val>, <emu-val>false</emu-val>, <var>defaultUseGrouping</var></ins>).</li><li>Set <var>numberFormat</var>.[[UseGrouping]] to <var>useGrouping</var>.</li><li>Let <var>signDisplay</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"signDisplay"</emu-val>, <emu-const>string</emu-const>, « <emu-val>"auto"</emu-val>, <emu-val>"never"</emu-val>, <emu-val>"always"</emu-val>, <emu-val>"exceptZero"</emu-val><ins>, <emu-val>"negative"</emu-val></ins> », <emu-val>"auto"</emu-val>).</li><li>Set <var>numberFormat</var>.[[SignDisplay]] to <var>signDisplay</var>.</li><li><ins class="block">Let <var>roundingMode</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"roundingMode"</emu-val>, <emu-const>string</emu-const>, « <emu-val>"ceil"</emu-val>, <emu-val>"floor"</emu-val>, <emu-val>"expand"</emu-val>, <emu-val>"trunc"</emu-val>, <emu-val>"halfCeil"</emu-val>, <emu-val>"halfFloor"</emu-val>, <emu-val>"halfExpand"</emu-val>, <emu-val>"halfTrunc"</emu-val>, <emu-val>"halfEven"</emu-val> », <emu-val>"halfExpand"</emu-val>).</ins></li><li><ins class="block">Set <var>numberFormat</var>.[[RoundingMode]] to <var>roundingMode</var>.</ins></li><li>Return <var>numberFormat</var>.</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>requestedLocales</var> be ?&nbsp;CanonicalizeLocaleList(<var>locales</var>).</li><li>Set <var>options</var> to ?&nbsp;CoerceOptionsToObject(<var>options</var>).</li><li>Let <var>opt</var> be a new Record.</li><li>Let <var>matcher</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"localeMatcher"</emu-val>, <emu-const>string</emu-const>, « <emu-val>"lookup"</emu-val>, <emu-val>"best fit"</emu-val> », <emu-val>"best fit"</emu-val>).</li><li>Set <var>opt</var>.[[localeMatcher]] to <var>matcher</var>.</li><li>Let <var>numberingSystem</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"numberingSystem"</emu-val>, <emu-const>string</emu-const>, <emu-const>empty</emu-const>, <emu-val>undefined</emu-val>).</li><li>If <var>numberingSystem</var> is not <emu-val>undefined</emu-val>, then<ol><li>If <var>numberingSystem</var> does not match the Unicode Locale Identifier <code>type</code> nonterminal, throw a <emu-val>RangeError</emu-val> exception.</li></ol></li><li>Set <var>opt</var>.[[nu]] to <var>numberingSystem</var>.</li><li>Let <var>localeData</var> be <emu-xref href="#sec-intl-numberformat-constructor" id="_ref_20"><a href="#sec-intl-numberformat-constructor">%NumberFormat%</a></emu-xref>.[[LocaleData]].</li><li>Let <var>r</var> be ResolveLocale(<emu-xref href="#sec-intl-numberformat-constructor" id="_ref_21"><a href="#sec-intl-numberformat-constructor">%NumberFormat%</a></emu-xref>.[[AvailableLocales]], <var>requestedLocales</var>, <var>opt</var>, <emu-xref href="#sec-intl-numberformat-constructor" id="_ref_22"><a href="#sec-intl-numberformat-constructor">%NumberFormat%</a></emu-xref>.[[RelevantExtensionKeys]], <var>localeData</var>).</li><li>Set <var>numberFormat</var>.[[Locale]] to <var>r</var>.[[locale]].</li><li>Set <var>numberFormat</var>.[[DataLocale]] to <var>r</var>.[[dataLocale]].</li><li>Set <var>numberFormat</var>.[[NumberingSystem]] to <var>r</var>.[[nu]].</li><li>Perform ?&nbsp;<emu-xref aoid="SetNumberFormatUnitOptions" id="_ref_23"><a href="#sec-setnumberformatunitoptions">SetNumberFormatUnitOptions</a></emu-xref>(<var>numberFormat</var>, <var>options</var>).</li><li>Let <var>style</var> be <var>numberFormat</var>.[[Style]].</li><li>If <var>style</var> is <emu-val>"currency"</emu-val>, then<ol><li>Let <var>currency</var> be <var>numberFormat</var>.[[Currency]].</li><li>Let <var>cDigits</var> be <emu-xref aoid="CurrencyDigits" id="_ref_24"><a href="#sec-currencydigits">CurrencyDigits</a></emu-xref>(<var>currency</var>).</li><li>Let <var>mnfdDefault</var> be <var>cDigits</var>.</li><li>Let <var>mxfdDefault</var> be <var>cDigits</var>.</li></ol></li><li>Else,<ol><li>Let <var>mnfdDefault</var> be 0.</li><li>If <var>style</var> is <emu-val>"percent"</emu-val>, then<ol><li>Let <var>mxfdDefault</var> be 0.</li></ol></li><li>Else,<ol><li>Let <var>mxfdDefault</var> be 3.</li></ol></li></ol></li><li>Let <var>notation</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"notation"</emu-val>, <emu-const>string</emu-const>, « <emu-val>"standard"</emu-val>, <emu-val>"scientific"</emu-val>, <emu-val>"engineering"</emu-val>, <emu-val>"compact"</emu-val> », <emu-val>"standard"</emu-val>).</li><li>Set <var>numberFormat</var>.[[Notation]] to <var>notation</var>.</li><li>Perform ?&nbsp;<emu-xref aoid="SetNumberFormatDigitOptions" id="_ref_25"><a href="#sec-setnfdigitoptions">SetNumberFormatDigitOptions</a></emu-xref>(<var>numberFormat</var>, <var>options</var>, <var>mnfdDefault</var>, <var>mxfdDefault</var>, <var>notation</var>).</li><li>Let <var>compactDisplay</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"compactDisplay"</emu-val>, <emu-const>string</emu-const>, « <emu-val>"short"</emu-val>, <emu-val>"long"</emu-val> », <emu-val>"short"</emu-val>).</li><li><ins class="block">Let <var>defaultUseGrouping</var> be <emu-val>"auto"</emu-val>.</ins></li><li>If <var>notation</var> is <emu-val>"compact"</emu-val>, then<ol><li>Set <var>numberFormat</var>.[[CompactDisplay]] to <var>compactDisplay</var>.</li><li><ins class="block">Set <var>defaultUseGrouping</var> to <emu-val>"min2"</emu-val>.</ins></li></ol></li><li><del class="block">Let <var>useGrouping</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"useGrouping"</emu-val>, <emu-const>boolean</emu-const>, <emu-const>empty</emu-const>, <emu-val>true</emu-val>).</del></li><li><ins class="block">NOTE: For historical reasons, the strings <emu-val>"true"</emu-val> and <emu-val>"false"</emu-val> are accepted and replaced with the default value.</ins></li><li><ins class="block">Let <var>useGrouping</var> be ?&nbsp;GetBooleanOrStringNumberFormatOption(<var>options</var>, <emu-val>"useGrouping"</emu-val>, « <emu-val>"min2"</emu-val>, <emu-val>"auto"</emu-val>, <emu-val>"always"</emu-val>, <emu-val>"true"</emu-val>, <emu-val>"false"</emu-val> », <var>defaultUseGrouping</var>).</ins></li><li><ins class="block">If <var>useGrouping</var> is <emu-val>"true"</emu-val> or <var>useGrouping</var> is <emu-val>"false"</emu-val>, set <var>useGrouping</var> to <var>defaultUseGrouping</var>.</ins></li><li><ins class="block">If <var>useGrouping</var> is <emu-val>true</emu-val>, set <var>useGrouping</var> to <emu-val>"always"</emu-val>.</ins></li><li>Set <var>numberFormat</var>.[[UseGrouping]] to <var>useGrouping</var>.</li><li>Let <var>signDisplay</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"signDisplay"</emu-val>, <emu-const>string</emu-const>, « <emu-val>"auto"</emu-val>, <emu-val>"never"</emu-val>, <emu-val>"always"</emu-val>, <emu-val>"exceptZero"</emu-val><ins>, <emu-val>"negative"</emu-val></ins> », <emu-val>"auto"</emu-val>).</li><li>Set <var>numberFormat</var>.[[SignDisplay]] to <var>signDisplay</var>.</li><li>Return <var>numberFormat</var>.</li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-setnfdigitoptions" aoid="SetNumberFormatDigitOptions">
@@ -1888,8 +2662,9 @@ li.menu-search-result-term:before {
       <p>
         The abstract operation SetNumberFormatDigitOptions applies digit
         options used for number formatting onto the intl object.
+        <ins>It is used by both Intl.NumberFormat and Intl.PluralRules.</ins>
       </p>
-      <emu-alg><ol><li>Let <var>mnid</var> be ?&nbsp;GetNumberOption(<var>options</var>, <emu-val>"minimumIntegerDigits,"</emu-val>, 1, 21, 1).</li><li>Let <var>mnfd</var> be ?&nbsp;<emu-xref aoid="Get" id="_ref_30"><a href="https://tc39.es/ecma262/#sec-get-o-p">Get</a></emu-xref>(<var>options</var>, <emu-val>"minimumFractionDigits"</emu-val>).</li><li>Let <var>mxfd</var> be ?&nbsp;<emu-xref aoid="Get" id="_ref_31"><a href="https://tc39.es/ecma262/#sec-get-o-p">Get</a></emu-xref>(<var>options</var>, <emu-val>"maximumFractionDigits"</emu-val>).</li><li>Let <var>mnsd</var> be ?&nbsp;<emu-xref aoid="Get" id="_ref_32"><a href="https://tc39.es/ecma262/#sec-get-o-p">Get</a></emu-xref>(<var>options</var>, <emu-val>"minimumSignificantDigits"</emu-val>).</li><li>Let <var>mxsd</var> be ?&nbsp;<emu-xref aoid="Get" id="_ref_33"><a href="https://tc39.es/ecma262/#sec-get-o-p">Get</a></emu-xref>(<var>options</var>, <emu-val>"maximumSignificantDigits"</emu-val>).</li><li>Set <var>intlObj</var>.[[MinimumIntegerDigits]] to <var>mnid</var>.</li><li><ins class="block">Let <var>roundingPriority</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"roundingPriority"</emu-val>, <emu-const>string</emu-const>, « <emu-val>"auto"</emu-val>, <emu-val>"morePrecision"</emu-val>, <emu-val>"lessPrecision"</emu-val> », <emu-val>"auto"</emu-val>).</ins></li><li>If <var>mnsd</var> is not <emu-val>undefined</emu-val> or <var>mxsd</var> is not <emu-val>undefined</emu-val>, then<ol><li>Let <var>hasSd</var> be <emu-val>true</emu-val>.</li></ol></li><li>Else,<ol><li>Let <var>hasSd</var> be <emu-val>false</emu-val>.</li></ol></li><li>If <var>mnfd</var> is not <emu-val>undefined</emu-val> or <var>mxfd</var> is not <emu-val>undefined</emu-val>, then<ol><li>Let <var>hasFd</var> be <emu-val>true</emu-val>.</li></ol></li><li>Else,<ol><li>Let <var>hasFd</var> be <emu-val>false</emu-val>.</li></ol></li><li><del class="block">Let <var>needSd</var> be <var>hasSd</var>.</del></li><li><del class="block">If <var>hasSd</var> is <emu-val>true</emu-val>, or <var>hasFd</var> is <emu-val>false</emu-val> and <var>notation</var> is <emu-val>"compact"</emu-val>, then</del><ol><li><del class="block">Let <var>needFd</var> be <emu-val>false</emu-val>.</del></li></ol></li><li><del class="block">Else,</del><ol><li><del class="block">Let <var>needFd</var> be <emu-val>true</emu-val>.</del></li></ol></li><li><ins class="block">Let <var>needSd</var> be <emu-val>true</emu-val>.</ins></li><li><ins class="block">Let <var>needFd</var> be <emu-val>true</emu-val>.</ins></li><li><ins class="block">If <var>roundingPriority</var> is <emu-val>"auto"</emu-val>, then</ins><ol><li><ins class="block">Set <var>needSd</var> to <var>hasSd</var>.</ins></li><li><ins class="block">If <var>hasSd</var> is <emu-val>true</emu-val>, or <var>hasFd</var> is <emu-val>false</emu-val> and <var>notation</var> is <emu-val>"compact"</emu-val>, then</ins><ol><li><ins class="block">Set <var>needFd</var> to <emu-val>false</emu-val>.</ins></li></ol></li></ol></li><li>If <var>needSd</var> is <emu-val>true</emu-val>, then<ol><li><del class="block"><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>hasSd</var> is <emu-val>true</emu-val>.</del></li><li><ins class="block">If <var>hasSd</var> is <emu-val>true</emu-val>, then</ins><ol><li>Set <var>mnsd</var> to ?&nbsp;DefaultNumberOption(<var>mnsd</var>, 1, 21, 1).</li><li>Set <var>mxsd</var> to ?&nbsp;DefaultNumberOption(<var>mxsd</var>, <var>mnsd</var>, 21, 21).</li><li>Set <var>intlObj</var>.[[MinimumSignificantDigits]] to <var>mnsd</var>.</li><li>Set <var>intlObj</var>.[[MaximumSignificantDigits]] to <var>mxsd</var>.</li></ol></li><li><ins class="block">Else,</ins><ol><li><ins class="block">Set <var>intlObj</var>.[[MinimumSignificantDigits]] to 1.</ins></li><li><ins class="block">Set <var>intlObj</var>.[[MaximumSignificantDigits]] to 21.</ins></li></ol></li></ol></li><li>If <var>needFd</var> is <emu-val>true</emu-val>, then<ol><li>If <var>hasFd</var> is <emu-val>true</emu-val>, then<ol><li>Set <var>mnfd</var> to ?&nbsp;DefaultNumberOption(<var>mnfd</var>, 0, 20, <emu-val>undefined</emu-val>).</li><li>Set <var>mxfd</var> to ?&nbsp;DefaultNumberOption(<var>mxfd</var>, 0, 20, <emu-val>undefined</emu-val>).</li><li>If <var>mnfd</var> is <emu-val>undefined</emu-val>, set <var>mnfd</var> to <emu-xref aoid="min"><a href="https://tc39.es/ecma262/#eqn-min">min</a></emu-xref>(<var>mnfdDefault</var>, <var>mxfd</var>).</li><li>Else if <var>mxfd</var> is <emu-val>undefined</emu-val>, set <var>mxfd</var> to <emu-xref aoid="max"><a href="https://tc39.es/ecma262/#eqn-max">max</a></emu-xref>(<var>mxfdDefault</var>, <var>mnfd</var>).</li><li>Else if <var>mnfd</var> is greater than <var>mxfd</var>, throw a <emu-val>RangeError</emu-val> exception.</li><li>Set <var>intlObj</var>.[[MinimumFractionDigits]] to <var>mnfd</var>.</li><li>Set <var>intlObj</var>.[[MaximumFractionDigits]] to <var>mxfd</var>.</li></ol></li><li>Else,<ol><li>Set <var>intlObj</var>.[[MinimumFractionDigits]] to <var>mnfdDefault</var>.</li><li>Set <var>intlObj</var>.[[MaximumFractionDigits]] to <var>mxfdDefault</var>.</li></ol></li></ol></li><li><del class="block">If <var>needSd</var> is <emu-val>false</emu-val> and <var>needFd</var> is <emu-val>false</emu-val>, then</del><ol><li><del class="block">Set <var>intlObj</var>.[[RoundingType]] to <emu-const>compactRounding</emu-const>.</del></li></ol></li><li><del class="block">Else if <var>hasSd</var> is <emu-val>true</emu-val>, then</del><ol><li><del class="block">Set <var>intlObj</var>.[[RoundingType]] to <emu-const>significantDigits</emu-const>.</del></li></ol></li><li><del class="block">Else,</del><ol><li><del class="block">Set <var>intlObj</var>.[[RoundingType]] to <emu-const>fractionDigits</emu-const>.</del></li></ol></li><li><ins class="block">If <var>needSd</var> is <emu-val>true</emu-val> or <var>needFd</var> is <emu-val>true</emu-val>, then</ins><ol><li><ins class="block">If <var>roundingPriority</var> is <emu-val>"morePrecision"</emu-val>, then</ins><ol><li><ins class="block">Set <var>intlObj</var>.[[RoundingType]] to <emu-const>morePrecision</emu-const>.</ins></li></ol></li><li><ins class="block">Else if <var>roundingPriority</var> is <emu-val>"lessPrecision"</emu-val>, then</ins><ol><li><ins class="block">Set <var>intlObj</var>.[[RoundingType]] to <emu-const>lessPrecision</emu-const>.</ins></li></ol></li><li><ins class="block">Else if <var>hasSd</var> is <emu-val>true</emu-val>, then</ins><ol><li><ins class="block">Set <var>intlObj</var>.[[RoundingType]] to <emu-const>significantDigits</emu-const>.</ins></li></ol></li><li><ins class="block">Else,</ins><ol><li><ins class="block">Set <var>intlObj</var>.[[RoundingType]] to <emu-const>fractionDigits</emu-const>.</ins></li></ol></li></ol></li><li><ins class="block">Else,</ins><ol><li><ins class="block">Set <var>intlObj</var>.[[RoundingType]] to <emu-const>morePrecision</emu-const>.</ins></li><li><ins class="block">Set <var>intlObj</var>.[[MinimumFractionDigits]] to 0.</ins></li><li><ins class="block">Set <var>intlObj</var>.[[MaximumFractionDigits]] to 0.</ins></li><li><ins class="block">Set <var>intlObj</var>.[[MinimumSignificantDigits]] to 1.</ins></li><li><ins class="block">Set <var>intlObj</var>.[[MaximumSignificantDigits]] to 2.</ins></li></ol></li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>mnid</var> be ?&nbsp;GetNumberOption(<var>options</var>, <emu-val>"minimumIntegerDigits,"</emu-val>, 1, 21, 1).</li><li>Let <var>mnfd</var> be ?&nbsp;Get(<var>options</var>, <emu-val>"minimumFractionDigits"</emu-val>).</li><li>Let <var>mxfd</var> be ?&nbsp;Get(<var>options</var>, <emu-val>"maximumFractionDigits"</emu-val>).</li><li>Let <var>mnsd</var> be ?&nbsp;Get(<var>options</var>, <emu-val>"minimumSignificantDigits"</emu-val>).</li><li>Let <var>mxsd</var> be ?&nbsp;Get(<var>options</var>, <emu-val>"maximumSignificantDigits"</emu-val>).</li><li>Set <var>intlObj</var>.[[MinimumIntegerDigits]] to <var>mnid</var>.</li><li><ins class="block">Let <var>roundingPriority</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"roundingPriority"</emu-val>, <emu-const>string</emu-const>, « <emu-val>"auto"</emu-val>, <emu-val>"morePrecision"</emu-val>, <emu-val>"lessPrecision"</emu-val> », <emu-val>"auto"</emu-val>).</ins></li><li><ins class="block">Let <var>roundingIncrement</var> be ?&nbsp;GetNumberOption(<var>options</var>, <emu-val>"roundingIncrement"</emu-val>, 1, 5000, 1).</ins></li><li><ins class="block">If <var>roundingIncrement</var> is not in « 1, 2, 5, 10, 20, 25, 50, 100, 200, 250, 500, 1000, 2000, 2500, 5000 », throw a <emu-val>RangeError</emu-val> exception.</ins></li><li><ins class="block">Let <var>roundingMode</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"roundingMode"</emu-val>, <emu-const>string</emu-const>, « <emu-val>"ceil"</emu-val>, <emu-val>"floor"</emu-val>, <emu-val>"expand"</emu-val>, <emu-val>"trunc"</emu-val>, <emu-val>"halfCeil"</emu-val>, <emu-val>"halfFloor"</emu-val>, <emu-val>"halfExpand"</emu-val>, <emu-val>"halfTrunc"</emu-val>, <emu-val>"halfEven"</emu-val> », <emu-val>"halfExpand"</emu-val>).</ins></li><li><ins class="block">Let <var>trailingZeroDisplay</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"trailingZeroDisplay"</emu-val>, <emu-const>string</emu-const>, « <emu-val>"auto"</emu-val>, <emu-val>"stripIfInteger"</emu-val> », <emu-val>"auto"</emu-val>).</ins></li><li><ins class="block">NOTE: All fields required by <emu-xref aoid="SetNumberFormatDigitOptions" id="_ref_26"><a href="#sec-setnfdigitoptions">SetNumberFormatDigitOptions</a></emu-xref> have now been read from <var>options</var>. The remainder of this AO interprets the options and may throw exceptions.</ins></li><li><ins class="block">If <var>roundingIncrement</var> is not 1, set <var>mxfdDefault</var> to <var>mnfdDefault</var>.</ins></li><li><ins class="block">Set <var>intlObj</var>.[[RoundingIncrement]] to <var>roundingIncrement</var>.</ins></li><li><ins class="block">Set <var>intlObj</var>.[[RoundingMode]] to <var>roundingMode</var>.</ins></li><li><ins class="block">Set <var>intlObj</var>.[[TrailingZeroDisplay]] to <var>trailingZeroDisplay</var>.</ins></li><li>If <var>mnsd</var> is not <emu-val>undefined</emu-val> or <var>mxsd</var> is not <emu-val>undefined</emu-val>, then<ol><li>Let <var>hasSd</var> be <emu-val>true</emu-val>.</li></ol></li><li>Else,<ol><li>Let <var>hasSd</var> be <emu-val>false</emu-val>.</li></ol></li><li>If <var>mnfd</var> is not <emu-val>undefined</emu-val> or <var>mxfd</var> is not <emu-val>undefined</emu-val>, then<ol><li>Let <var>hasFd</var> be <emu-val>true</emu-val>.</li></ol></li><li>Else,<ol><li>Let <var>hasFd</var> be <emu-val>false</emu-val>.</li></ol></li><li><del class="block">Let <var>needSd</var> be <var>hasSd</var>.</del></li><li><del class="block">If <var>hasSd</var> is <emu-val>true</emu-val>, or <var>hasFd</var> is <emu-val>false</emu-val> and <var>notation</var> is <emu-val>"compact"</emu-val>, then</del><ol><li><del class="block">Let <var>needFd</var> be <emu-val>false</emu-val>.</del></li></ol></li><li><del class="block">Else,</del><ol><li><del class="block">Let <var>needFd</var> be <emu-val>true</emu-val>.</del></li></ol></li><li><ins class="block">Let <var>needSd</var> be <emu-val>true</emu-val>.</ins></li><li><ins class="block">Let <var>needFd</var> be <emu-val>true</emu-val>.</ins></li><li><ins class="block">If <var>roundingPriority</var> is <emu-val>"auto"</emu-val>, then</ins><ol><li><ins class="block">Set <var>needSd</var> to <var>hasSd</var>.</ins></li><li><ins class="block">If <var>hasSd</var> is <emu-val>true</emu-val>, or <var>hasFd</var> is <emu-val>false</emu-val> and <var>notation</var> is <emu-val>"compact"</emu-val>, then</ins><ol><li><ins class="block">Set <var>needFd</var> to <emu-val>false</emu-val>.</ins></li></ol></li></ol></li><li>If <var>needSd</var> is <emu-val>true</emu-val>, then<ol><li><del class="block">Assert: <var>hasSd</var> is <emu-val>true</emu-val>.</del></li><li><ins class="block">If <var>hasSd</var> is <emu-val>true</emu-val>, then</ins><ol><li>Set <var>mnsd</var> to ?&nbsp;DefaultNumberOption(<var>mnsd</var>, 1, 21, 1).</li><li>Set <var>mxsd</var> to ?&nbsp;DefaultNumberOption(<var>mxsd</var>, <var>mnsd</var>, 21, 21).</li><li>Set <var>intlObj</var>.[[MinimumSignificantDigits]] to <var>mnsd</var>.</li><li>Set <var>intlObj</var>.[[MaximumSignificantDigits]] to <var>mxsd</var>.</li></ol></li><li><ins class="block">Else,</ins><ol><li><ins class="block">Set <var>intlObj</var>.[[MinimumSignificantDigits]] to 1.</ins></li><li><ins class="block">Set <var>intlObj</var>.[[MaximumSignificantDigits]] to 21.</ins></li></ol></li></ol></li><li>If <var>needFd</var> is <emu-val>true</emu-val>, then<ol><li>If <var>hasFd</var> is <emu-val>true</emu-val>, then<ol><li>Set <var>mnfd</var> to ?&nbsp;DefaultNumberOption(<var>mnfd</var>, 0, 20, <emu-val>undefined</emu-val>).</li><li>Set <var>mxfd</var> to ?&nbsp;DefaultNumberOption(<var>mxfd</var>, 0, 20, <emu-val>undefined</emu-val>).</li><li>If <var>mnfd</var> is <emu-val>undefined</emu-val>, set <var>mnfd</var> to min(<var>mnfdDefault</var>, <var>mxfd</var>).</li><li>Else if <var>mxfd</var> is <emu-val>undefined</emu-val>, set <var>mxfd</var> to max(<var>mxfdDefault</var>, <var>mnfd</var>).</li><li>Else if <var>mnfd</var> is greater than <var>mxfd</var>, throw a <emu-val>RangeError</emu-val> exception.</li><li>Set <var>intlObj</var>.[[MinimumFractionDigits]] to <var>mnfd</var>.</li><li>Set <var>intlObj</var>.[[MaximumFractionDigits]] to <var>mxfd</var>.</li></ol></li><li>Else,<ol><li>Set <var>intlObj</var>.[[MinimumFractionDigits]] to <var>mnfdDefault</var>.</li><li>Set <var>intlObj</var>.[[MaximumFractionDigits]] to <var>mxfdDefault</var>.</li></ol></li></ol></li><li><del class="block">If <var>needSd</var> is <emu-val>false</emu-val> and <var>needFd</var> is <emu-val>false</emu-val>, then</del><ol><li><del class="block">Set <var>intlObj</var>.[[RoundingType]] to <emu-const>compactRounding</emu-const>.</del></li></ol></li><li><del class="block">Else if <var>hasSd</var> is <emu-val>true</emu-val>, then</del><ol><li><del class="block">Set <var>intlObj</var>.[[RoundingType]] to <emu-const>significantDigits</emu-const>.</del></li></ol></li><li><del class="block">Else,</del><ol><li><del class="block">Set <var>intlObj</var>.[[RoundingType]] to <emu-const>fractionDigits</emu-const>.</del></li></ol></li><li><ins class="block">If <var>needSd</var> is <emu-val>true</emu-val> or <var>needFd</var> is <emu-val>true</emu-val>, then</ins><ol><li><ins class="block">If <var>roundingPriority</var> is <emu-val>"morePrecision"</emu-val>, then</ins><ol><li><ins class="block">Set <var>intlObj</var>.[[RoundingType]] to <emu-const>morePrecision</emu-const>.</ins></li></ol></li><li><ins class="block">Else if <var>roundingPriority</var> is <emu-val>"lessPrecision"</emu-val>, then</ins><ol><li><ins class="block">Set <var>intlObj</var>.[[RoundingType]] to <emu-const>lessPrecision</emu-const>.</ins></li></ol></li><li><ins class="block">Else if <var>hasSd</var> is <emu-val>true</emu-val>, then</ins><ol><li><ins class="block">Set <var>intlObj</var>.[[RoundingType]] to <emu-const>significantDigits</emu-const>.</ins></li></ol></li><li><ins class="block">Else,</ins><ol><li><ins class="block">Set <var>intlObj</var>.[[RoundingType]] to <emu-const>fractionDigits</emu-const>.</ins></li></ol></li></ol></li><li><ins class="block">Else,</ins><ol><li><ins class="block">Set <var>intlObj</var>.[[RoundingType]] to <emu-const>morePrecision</emu-const>.</ins></li><li><ins class="block">Set <var>intlObj</var>.[[MinimumFractionDigits]] to 0.</ins></li><li><ins class="block">Set <var>intlObj</var>.[[MaximumFractionDigits]] to 0.</ins></li><li><ins class="block">Set <var>intlObj</var>.[[MinimumSignificantDigits]] to 1.</ins></li><li><ins class="block">Set <var>intlObj</var>.[[MaximumSignificantDigits]] to 2.</ins></li></ol></li><li><ins class="block">If <var>roundingIncrement</var> is not 1, then</ins><ol><li><ins class="block">If <var>intlObj</var>.[[RoundingType]] is not <emu-const>fractionDigits</emu-const>, throw a <emu-val>TypeError</emu-val> exception.</ins></li><li><ins class="block">If <var>intlObj</var>.[[MaximumFractionDigits]] is not equal to <var>intlObj</var>.[[MinimumFractionDigits]], throw a <emu-val>RangeError</emu-val> exception.</ins></li></ol></li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-setnumberformatunitoptions" aoid="SetNumberFormatUnitOptions">
@@ -1897,7 +2672,7 @@ li.menu-search-result-term:before {
       <p>
         The abstract operation SetNumberFormatUnitOptions resolves the user-specified options relating to units onto the intl object.
       </p>
-      <emu-alg><ol><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <emu-xref aoid="Type" id="_ref_34"><a href="https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>intlObj</var>) is Object.</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <emu-xref aoid="Type" id="_ref_35"><a href="https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>options</var>) is Object.</li><li>Let <var>style</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"style"</emu-val>, <emu-const>string</emu-const>, « <emu-val>"decimal"</emu-val>, <emu-val>"percent"</emu-val>, <emu-val>"currency"</emu-val>, <emu-val>"unit"</emu-val> », <emu-val>"decimal"</emu-val>).</li><li>Set <var>intlObj</var>.[[Style]] to <var>style</var>.</li><li>Let <var>currency</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"currency"</emu-val>, <emu-const>string</emu-const>, <emu-const>empty</emu-const>, <emu-val>undefined</emu-val>).</li><li>If <var>currency</var> is <emu-val>undefined</emu-val>, then<ol><li>If <var>style</var> is <emu-val>"currency"</emu-val>, throw a <emu-val>TypeError</emu-val> exception.</li></ol></li><li>Else,<ol><li>If the result of IsWellFormedCurrencyCode(<var>currency</var>) is <emu-val>false</emu-val>, throw a <emu-val>RangeError</emu-val> exception.</li></ol></li><li>Let <var>currencyDisplay</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"currencyDisplay"</emu-val>, <emu-const>string</emu-const>, « <emu-val>"code"</emu-val>, <emu-val>"symbol"</emu-val>, <emu-val>"narrowSymbol"</emu-val>, <emu-val>"name"</emu-val> », <emu-val>"symbol"</emu-val>).</li><li>Let <var>currencySign</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"currencySign"</emu-val>, <emu-const>string</emu-const>, « <emu-val>"standard"</emu-val>, <emu-val>"accounting"</emu-val> », <emu-val>"standard"</emu-val>).</li><li>Let <var>unit</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"unit"</emu-val>, <emu-const>string</emu-const>, <emu-const>empty</emu-const>, <emu-val>undefined</emu-val>).</li><li>If <var>unit</var> is <emu-val>undefined</emu-val>, then<ol><li>If <var>style</var> is <emu-val>"unit"</emu-val>, throw a <emu-val>TypeError</emu-val> exception.</li></ol></li><li>Else,<ol><li>If !&nbsp;IsWellFormedUnitIdentifier(<var>unit</var>) is <emu-val>false</emu-val>, throw a <emu-val>RangeError</emu-val> exception.</li></ol></li><li>Let <var>unitDisplay</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"unitDisplay"</emu-val>, <emu-const>string</emu-const>, « <emu-val>"short"</emu-val>, <emu-val>"narrow"</emu-val>, <emu-val>"long"</emu-val> », <emu-val>"short"</emu-val>).</li><li>If <var>style</var> is <emu-val>"currency"</emu-val>, then<ol><li>Set <var>intlObj</var>.[[Currency]] to the ASCII-uppercase of <var>currency</var>.</li><li>Set <var>intlObj</var>.[[CurrencyDisplay]] to <var>currencyDisplay</var>.</li><li>Set <var>intlObj</var>.[[CurrencySign]] to <var>currencySign</var>.</li></ol></li><li>If <var>style</var> is <emu-val>"unit"</emu-val>, then<ol><li>Set <var>intlObj</var>.[[Unit]] to <var>unit</var>.</li><li>Set <var>intlObj</var>.[[UnitDisplay]] to <var>unitDisplay</var>.</li></ol></li></ol></emu-alg>
+      <emu-alg><ol><li>Assert: Type(<var>intlObj</var>) is Object.</li><li>Assert: Type(<var>options</var>) is Object.</li><li>Let <var>style</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"style"</emu-val>, <emu-const>string</emu-const>, « <emu-val>"decimal"</emu-val>, <emu-val>"percent"</emu-val>, <emu-val>"currency"</emu-val>, <emu-val>"unit"</emu-val> », <emu-val>"decimal"</emu-val>).</li><li>Set <var>intlObj</var>.[[Style]] to <var>style</var>.</li><li>Let <var>currency</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"currency"</emu-val>, <emu-const>string</emu-const>, <emu-const>empty</emu-const>, <emu-val>undefined</emu-val>).</li><li>If <var>currency</var> is <emu-val>undefined</emu-val>, then<ol><li>If <var>style</var> is <emu-val>"currency"</emu-val>, throw a <emu-val>TypeError</emu-val> exception.</li></ol></li><li>Else,<ol><li>If the result of IsWellFormedCurrencyCode(<var>currency</var>) is <emu-val>false</emu-val>, throw a <emu-val>RangeError</emu-val> exception.</li></ol></li><li>Let <var>currencyDisplay</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"currencyDisplay"</emu-val>, <emu-const>string</emu-const>, « <emu-val>"code"</emu-val>, <emu-val>"symbol"</emu-val>, <emu-val>"narrowSymbol"</emu-val>, <emu-val>"name"</emu-val> », <emu-val>"symbol"</emu-val>).</li><li>Let <var>currencySign</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"currencySign"</emu-val>, <emu-const>string</emu-const>, « <emu-val>"standard"</emu-val>, <emu-val>"accounting"</emu-val> », <emu-val>"standard"</emu-val>).</li><li>Let <var>unit</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"unit"</emu-val>, <emu-const>string</emu-const>, <emu-const>empty</emu-const>, <emu-val>undefined</emu-val>).</li><li>If <var>unit</var> is <emu-val>undefined</emu-val>, then<ol><li>If <var>style</var> is <emu-val>"unit"</emu-val>, throw a <emu-val>TypeError</emu-val> exception.</li></ol></li><li>Else,<ol><li>If !&nbsp;IsWellFormedUnitIdentifier(<var>unit</var>) is <emu-val>false</emu-val>, throw a <emu-val>RangeError</emu-val> exception.</li></ol></li><li>Let <var>unitDisplay</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"unitDisplay"</emu-val>, <emu-const>string</emu-const>, « <emu-val>"short"</emu-val>, <emu-val>"narrow"</emu-val>, <emu-val>"long"</emu-val> », <emu-val>"short"</emu-val>).</li><li>If <var>style</var> is <emu-val>"currency"</emu-val>, then<ol><li>Set <var>intlObj</var>.[[Currency]] to the ASCII-uppercase of <var>currency</var>.</li><li>Set <var>intlObj</var>.[[CurrencyDisplay]] to <var>currencyDisplay</var>.</li><li>Set <var>intlObj</var>.[[CurrencySign]] to <var>currencySign</var>.</li></ol></li><li>If <var>style</var> is <emu-val>"unit"</emu-val>, then<ol><li>Set <var>intlObj</var>.[[Unit]] to <var>unit</var>.</li><li>Set <var>intlObj</var>.[[UnitDisplay]] to <var>unitDisplay</var>.</li></ol></li></ol></emu-alg>
     </emu-clause>
   </emu-clause>
 
@@ -1905,14 +2680,14 @@ li.menu-search-result-term:before {
     <h1><span class="secnum">1.2</span> Properties of the Intl.NumberFormat Constructor</h1>
 
     <p>
-      The Intl.NumberFormat <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> has the following properties:
+      The Intl.NumberFormat constructor has the following properties:
     </p>
 
     <emu-clause id="sec-intl.numberformat.prototype">
       <h1><span class="secnum">1.2.1</span> Intl.NumberFormat.prototype</h1>
 
       <p>
-        The value of <code>Intl.NumberFormat.prototype</code> is <emu-xref href="#sec-properties-of-intl-numberformat-prototype-object" id="_ref_36"><a href="#sec-properties-of-intl-numberformat-prototype-object">%NumberFormat.prototype%</a></emu-xref>.
+        The value of <code>Intl.NumberFormat.prototype</code> is <emu-xref href="#sec-properties-of-intl-numberformat-prototype-object" id="_ref_27"><a href="#sec-properties-of-intl-numberformat-prototype-object">%NumberFormat.prototype%</a></emu-xref>.
       </p>
       <p>
         This property has the attributes { [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>false</emu-val> }.
@@ -1926,7 +2701,7 @@ li.menu-search-result-term:before {
         When the <code>supportedLocalesOf</code> method is called with arguments <var>locales</var> and <var>options</var>, the following steps are taken:
       </p>
 
-      <emu-alg><ol><li>Let <var>availableLocales</var> be <emu-xref href="#sec-intl-numberformat-constructor" id="_ref_37"><a href="#sec-intl-numberformat-constructor">%NumberFormat%</a></emu-xref>.[[AvailableLocales]].</li><li>Let <var>requestedLocales</var> be ?&nbsp;CanonicalizeLocaleList(<var>locales</var>).</li><li>Return ?&nbsp;SupportedLocales(<var>availableLocales</var>, <var>requestedLocales</var>, <var>options</var>).</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>availableLocales</var> be <emu-xref href="#sec-intl-numberformat-constructor" id="_ref_28"><a href="#sec-intl-numberformat-constructor">%NumberFormat%</a></emu-xref>.[[AvailableLocales]].</li><li>Let <var>requestedLocales</var> be ?&nbsp;CanonicalizeLocaleList(<var>locales</var>).</li><li>Return ?&nbsp;SupportedLocales(<var>availableLocales</var>, <var>requestedLocales</var>, <var>options</var>).</li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-intl.numberformat-internal-slots">
@@ -1950,22 +2725,22 @@ li.menu-search-result-term:before {
 
       <ul>
         <li>The list that is the value of the <emu-val>"nu"</emu-val> field of any locale field of [[LocaleData]] must not include the values <emu-val>"native"</emu-val>, <emu-val>"traditio"</emu-val>, or <emu-val>"finance"</emu-val>.</li>
-        <li>[[LocaleData]].[[&lt;<var>locale</var>&gt;]] must have a [[patterns]] field for all locale values <var>locale</var>. The value of this field must be a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref>, which must have fields with the names of the four number format styles: <emu-val>"decimal"</emu-val>, <emu-val>"percent"</emu-val>, <emu-val>"currency"</emu-val>, and <emu-val>"unit"</emu-val>.</li>
+        <li>[[LocaleData]].[[&lt;<var>locale</var>&gt;]] must have a [[patterns]] field for all locale values <var>locale</var>. The value of this field must be a Record, which must have fields with the names of the four number format styles: <emu-val>"decimal"</emu-val>, <emu-val>"percent"</emu-val>, <emu-val>"currency"</emu-val>, and <emu-val>"unit"</emu-val>.</li>
         <li>
           The two fields <emu-val>"currency"</emu-val> and <emu-val>"unit"</emu-val> noted above must be Records with at least one field, <emu-val>"fallback"</emu-val>.
           The <emu-val>"currency"</emu-val> may have additional fields with keys corresponding to currency codes according to <emu-xref href="#sec-currency-codes"></emu-xref>.
-          Each field of <emu-val>"currency"</emu-val> must be a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> with fields corresponding to the possible currencyDisplay values: <emu-val>"code"</emu-val>, <emu-val>"symbol"</emu-val>, <emu-val>"narrowSymbol"</emu-val>, and <emu-val>"name"</emu-val>.
-          Each of those fields must contain a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> with fields corresponding to the possible currencySign values: <emu-val>"standard"</emu-val> or <emu-val>"accounting"</emu-val>. The <emu-val>"unit"</emu-val> field (of [[LocaleData]].[[&lt;<var>locale</var>&gt;]]) may have additional fields beyond the required field <emu-val>"fallback"</emu-val> with keys corresponding to core measurement unit identifiers corresponding to <emu-xref href="#sec-measurement-unit-identifiers"></emu-xref>.
-          Each field of <emu-val>"unit"</emu-val> must be a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> with fields corresponding to the possible unitDisplay values: <emu-val>"narrow"</emu-val>, <emu-val>"short"</emu-val>, and <emu-val>"long"</emu-val>.
+          Each field of <emu-val>"currency"</emu-val> must be a Record with fields corresponding to the possible currencyDisplay values: <emu-val>"code"</emu-val>, <emu-val>"symbol"</emu-val>, <emu-val>"narrowSymbol"</emu-val>, and <emu-val>"name"</emu-val>.
+          Each of those fields must contain a Record with fields corresponding to the possible currencySign values: <emu-val>"standard"</emu-val> or <emu-val>"accounting"</emu-val>. The <emu-val>"unit"</emu-val> field (of [[LocaleData]].[[&lt;<var>locale</var>&gt;]]) may have additional fields beyond the required field <emu-val>"fallback"</emu-val> with keys corresponding to core measurement unit identifiers corresponding to <emu-xref href="#sec-measurement-unit-identifiers"></emu-xref>.
+          Each field of <emu-val>"unit"</emu-val> must be a Record with fields corresponding to the possible unitDisplay values: <emu-val>"narrow"</emu-val>, <emu-val>"short"</emu-val>, and <emu-val>"long"</emu-val>.
         </li>
         <li>All of the leaf fields so far described for the patterns tree (<emu-val>"decimal"</emu-val>, <emu-val>"percent"</emu-val>, great-grandchildren of <emu-val>"currency"</emu-val>, and grandchildren of <emu-val>"unit"</emu-val>) must be Records with the keys <emu-val>"positivePattern"</emu-val>, <emu-val>"zeroPattern"</emu-val>, and <emu-val>"negativePattern"</emu-val>.</li>
         <li>
           The value of the aforementioned fields (the sign-dependent pattern fields) must be string values that must contain the substring <emu-val>"{number}"</emu-val>.
           <emu-val>"positivePattern"</emu-val> must contain the substring <emu-val>"{plusSign}"</emu-val> but not <emu-val>"{minusSign}"</emu-val>; <emu-val>"negativePattern"</emu-val> must contain the substring <emu-val>"{minusSign}"</emu-val> but not <emu-val>"{plusSign}"</emu-val>; and <emu-val>"zeroPattern"</emu-val> must not contain either <emu-val>"{plusSign}"</emu-val> or <emu-val>"{minusSign}"</emu-val>.
           Additionally, the values within the <emu-val>"percent"</emu-val> field must also contain the substring <emu-val>"{percentSign}"</emu-val>; the values within the <emu-val>"currency"</emu-val> field must also contain one or more of the following substrings: <emu-val>"{currencyCode}"</emu-val>, <emu-val>"{currencyPrefix}"</emu-val>, or <emu-val>"{currencySuffix}"</emu-val>; and the values within the <emu-val>"unit"</emu-val> field must also contain one or more of the following substrings: <emu-val>"{unitPrefix}"</emu-val> or <emu-val>"{unitSuffix}"</emu-val>.
-          The pattern strings, when interpreted as a sequence of UTF-16 encoded code points as described in es2023, <emu-xref href="#sec-ecmascript-language-types-string-type"><a href="https://tc39.es/ecma262/#sec-ecmascript-language-types-string-type">6.1.4</a></emu-xref>, must not contain any code points in the General Category "Number, decimal digit" as specified by the Unicode Standard.
+          The pattern strings, when interpreted as a sequence of UTF-16 encoded code points as described in es2023, <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>, must not contain any code points in the General Category "Number, decimal digit" as specified by the Unicode Standard.
         </li>
-        <li>[[LocaleData]].[[&lt;<var>locale</var>&gt;]] must also have a [[notationSubPatterns]] field for all locale values <var>locale</var>. The value of this field must be a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref>, which must have two fields: [[scientific]] and [[compact]]. The [[scientific]] field must be a string value containing the substrings <emu-val>"{number}"</emu-val>, <emu-val>"{scientificSeparator}"</emu-val>, and <emu-val>"{scientificExponent}"</emu-val>. The [[compact]] field must be a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> with two fields: <emu-val>"short"</emu-val> and <emu-val>"long"</emu-val>. Each of these fields must be a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> with <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref> keys corresponding to all discrete magnitudes the implementation supports for compact notation. Each of these fields must be a string value which may contain the substring <emu-val>"{number}"</emu-val>. Strings descended from <emu-val>"short"</emu-val> must contain the substring <emu-val>"{compactSymbol}"</emu-val>, and strings descended from <emu-val>"long"</emu-val> must contain the substring <emu-val>"{compactName}"</emu-val>.</li>
+        <li>[[LocaleData]].[[&lt;<var>locale</var>&gt;]] must also have a [[notationSubPatterns]] field for all locale values <var>locale</var>. The value of this field must be a Record, which must have two fields: [[scientific]] and [[compact]]. The [[scientific]] field must be a string value containing the substrings <emu-val>"{number}"</emu-val>, <emu-val>"{scientificSeparator}"</emu-val>, and <emu-val>"{scientificExponent}"</emu-val>. The [[compact]] field must be a Record with two fields: <emu-val>"short"</emu-val> and <emu-val>"long"</emu-val>. Each of these fields must be a Record with integer keys corresponding to all discrete magnitudes the implementation supports for compact notation. Each of these fields must be a string value which may contain the substring <emu-val>"{number}"</emu-val>. Strings descended from <emu-val>"short"</emu-val> must contain the substring <emu-val>"{compactSymbol}"</emu-val>, and strings descended from <emu-val>"long"</emu-val> must contain the substring <emu-val>"{compactName}"</emu-val>.</li>
       </ul>
 
       <emu-note><span class="note">Note 2</span><div class="note-contents">
@@ -1985,7 +2760,7 @@ li.menu-search-result-term:before {
       <h1><span class="secnum">1.3.1</span> Intl.NumberFormat.prototype.constructor</h1>
 
       <p>
-        The initial value of <code>Intl.NumberFormat.prototype.constructor</code> is <emu-xref href="#sec-intl-numberformat-constructor" id="_ref_38"><a href="#sec-intl-numberformat-constructor">%NumberFormat%</a></emu-xref>.
+        The initial value of <code>Intl.NumberFormat.prototype.constructor</code> is <emu-xref href="#sec-intl-numberformat-constructor" id="_ref_29"><a href="#sec-intl-numberformat-constructor">%NumberFormat%</a></emu-xref>.
       </p>
     </emu-clause>
 
@@ -2004,10 +2779,10 @@ li.menu-search-result-term:before {
       <h1><span class="secnum">1.3.3</span> get Intl.NumberFormat.prototype.format</h1>
 
       <p>
-        Intl.NumberFormat.prototype.format is an <emu-xref href="#sec-object-type"><a href="https://tc39.es/ecma262/#sec-object-type">accessor property</a></emu-xref> whose set accessor function is <emu-val>undefined</emu-val>. Its get accessor function performs the following steps:
+        Intl.NumberFormat.prototype.format is an accessor property whose set accessor function is <emu-val>undefined</emu-val>. Its get accessor function performs the following steps:
       </p>
 
-      <emu-alg><ol><li>Let <var>nf</var> be the <emu-val>this</emu-val> value.</li><li>If the implementation supports the normative optional <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> mode of <emu-xref href="#legacy-constructor"></emu-xref>, then<ol><li>Set <var>nf</var> to ?&nbsp;<emu-xref aoid="UnwrapNumberFormat" id="_ref_39"><a href="#sec-unwrapnumberformat">UnwrapNumberFormat</a></emu-xref>(<var>nf</var>).</li></ol></li><li>Perform ?&nbsp;<emu-xref aoid="RequireInternalSlot" id="_ref_40"><a href="https://tc39.es/ecma262/#sec-requireinternalslot">RequireInternalSlot</a></emu-xref>(<var>nf</var>, [[InitializedNumberFormat]]).</li><li>If <var>nf</var>.[[BoundFormat]] is <emu-val>undefined</emu-val>, then<ol><li>Let <var>F</var> be a new built-in <emu-xref href="#function-object"><a href="https://tc39.es/ecma262/#function-object">function object</a></emu-xref> as defined in Number Format Functions (<emu-xref href="#sec-number-format-functions" id="_ref_0"><a href="#sec-number-format-functions">1.5.2</a></emu-xref>).</li><li>Set <var>F</var>.[[NumberFormat]] to <var>nf</var>.</li><li>Set <var>nf</var>.[[BoundFormat]] to <var>F</var>.</li></ol></li><li>Return <var>nf</var>.[[BoundFormat]].</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>nf</var> be the <emu-val>this</emu-val> value.</li><li>If the implementation supports the normative optional constructor mode of <emu-xref href="#legacy-constructor"></emu-xref>, then<ol><li>Set <var>nf</var> to ?&nbsp;<emu-xref aoid="UnwrapNumberFormat" id="_ref_30"><a href="#sec-unwrapnumberformat">UnwrapNumberFormat</a></emu-xref>(<var>nf</var>).</li></ol></li><li>Perform ?&nbsp;RequireInternalSlot(<var>nf</var>, [[InitializedNumberFormat]]).</li><li>If <var>nf</var>.[[BoundFormat]] is <emu-val>undefined</emu-val>, then<ol><li>Let <var>F</var> be a new built-in function object as defined in Number Format Functions (<emu-xref href="#sec-number-format-functions" id="_ref_0"><a href="#sec-number-format-functions">1.5.2</a></emu-xref>).</li><li>Set <var>F</var>.[[NumberFormat]] to <var>nf</var>.</li><li>Set <var>nf</var>.[[BoundFormat]] to <var>F</var>.</li></ol></li><li>Return <var>nf</var>.[[BoundFormat]].</li></ol></emu-alg>
 
       <emu-note><span class="note">Note</span><div class="note-contents">
         The returned function is bound to <var>nf</var> so that it can be passed directly to <code>Array.prototype.map</code> or other functions.
@@ -2022,7 +2797,7 @@ li.menu-search-result-term:before {
         When the <code>formatToParts</code> method is called with an optional argument <var>value</var>, the following steps are taken:
       </p>
 
-      <emu-alg><ol><li>Let <var>nf</var> be the <emu-val>this</emu-val> value.</li><li>Perform ?&nbsp;<emu-xref aoid="RequireInternalSlot" id="_ref_41"><a href="https://tc39.es/ecma262/#sec-requireinternalslot">RequireInternalSlot</a></emu-xref>(<var>nf</var>, [[InitializedNumberFormat]]).</li><li>Let <var>x</var> be ? <del><emu-xref aoid="ToNumeric" id="_ref_42"><a href="https://tc39.es/ecma262/#sec-tonumeric">ToNumeric</a></emu-xref></del><ins><emu-xref aoid="ToIntlMathematicalValue" id="_ref_43"><a href="#sec-tointlmathematicalvalue">ToIntlMathematicalValue</a></emu-xref></ins>(<var>value</var>).</li><li>Return ?&nbsp;<emu-xref aoid="FormatNumericToParts" id="_ref_44"><a href="#sec-formatnumbertoparts">FormatNumericToParts</a></emu-xref>(<var>nf</var>, <var>x</var>).</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>nf</var> be the <emu-val>this</emu-val> value.</li><li>Perform ?&nbsp;RequireInternalSlot(<var>nf</var>, [[InitializedNumberFormat]]).</li><li>Let <var>x</var> be ?&nbsp;<del>ToNumeric</del><ins><emu-xref aoid="ToIntlMathematicalValue" id="_ref_31"><a href="#sec-tointlmathematicalvalue">ToIntlMathematicalValue</a></emu-xref></ins>(<var>value</var>).</li><li>Return ?&nbsp;<emu-xref aoid="FormatNumericToParts" id="_ref_32"><a href="#sec-formatnumbertoparts">FormatNumericToParts</a></emu-xref>(<var>nf</var>, <var>x</var>).</li></ol></emu-alg>
     </emu-clause>
 
     <ins class="block">
@@ -2033,7 +2808,7 @@ li.menu-search-result-term:before {
         When the <code>formatRange</code> method is called with arguments <var>start</var> and <var>end</var>, the following steps are taken:
       </p>
 
-      <emu-alg><ol><li>Let <var>nf</var> be the <emu-val>this</emu-val> value.</li><li>Perform ?&nbsp;<emu-xref aoid="RequireInternalSlot" id="_ref_45"><a href="https://tc39.es/ecma262/#sec-requireinternalslot">RequireInternalSlot</a></emu-xref>(<var>nf</var>, [[InitializedNumberFormat]]).</li><li>If <var>start</var> is <emu-val>undefined</emu-val> or <var>end</var> is <emu-val>undefined</emu-val>, throw a <emu-val>TypeError</emu-val> exception.</li><li>Let <var>x</var> be ?&nbsp;<emu-xref aoid="ToIntlMathematicalValue" id="_ref_46"><a href="#sec-tointlmathematicalvalue">ToIntlMathematicalValue</a></emu-xref>(<var>start</var>).</li><li>Let <var>y</var> be ?&nbsp;<emu-xref aoid="ToIntlMathematicalValue" id="_ref_47"><a href="#sec-tointlmathematicalvalue">ToIntlMathematicalValue</a></emu-xref>(<var>end</var>).</li><li>Return ?&nbsp;<emu-xref aoid="FormatNumericRange" id="_ref_48"><a href="#sec-formatnumericrange">FormatNumericRange</a></emu-xref>(<var>nf</var>, <var>x</var>, <var>y</var>).</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>nf</var> be the <emu-val>this</emu-val> value.</li><li>Perform ?&nbsp;RequireInternalSlot(<var>nf</var>, [[InitializedNumberFormat]]).</li><li>If <var>start</var> is <emu-val>undefined</emu-val> or <var>end</var> is <emu-val>undefined</emu-val>, throw a <emu-val>TypeError</emu-val> exception.</li><li>Let <var>x</var> be ?&nbsp;<emu-xref aoid="ToIntlMathematicalValue" id="_ref_33"><a href="#sec-tointlmathematicalvalue">ToIntlMathematicalValue</a></emu-xref>(<var>start</var>).</li><li>Let <var>y</var> be ?&nbsp;<emu-xref aoid="ToIntlMathematicalValue" id="_ref_34"><a href="#sec-tointlmathematicalvalue">ToIntlMathematicalValue</a></emu-xref>(<var>end</var>).</li><li>Return ?&nbsp;<emu-xref aoid="FormatNumericRange" id="_ref_35"><a href="#sec-formatnumericrange">FormatNumericRange</a></emu-xref>(<var>nf</var>, <var>x</var>, <var>y</var>).</li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-intl.numberformat.prototype.formatrangetoparts">
@@ -2043,7 +2818,7 @@ li.menu-search-result-term:before {
         When the <code>formatRangeToParts</code> method is called with arguments <var>start</var> and <var>end</var>, the following steps are taken:
       </p>
 
-      <emu-alg><ol><li>Let <var>nf</var> be the <emu-val>this</emu-val> value.</li><li>Perform ?&nbsp;<emu-xref aoid="RequireInternalSlot" id="_ref_49"><a href="https://tc39.es/ecma262/#sec-requireinternalslot">RequireInternalSlot</a></emu-xref>(<var>nf</var>, [[InitializedNumberFormat]]).</li><li>If <var>start</var> is <emu-val>undefined</emu-val> or <var>end</var> is <emu-val>undefined</emu-val>, throw a <emu-val>TypeError</emu-val> exception.</li><li>Let <var>x</var> be ?&nbsp;<emu-xref aoid="ToIntlMathematicalValue" id="_ref_50"><a href="#sec-tointlmathematicalvalue">ToIntlMathematicalValue</a></emu-xref>(<var>start</var>).</li><li>Let <var>y</var> be ?&nbsp;<emu-xref aoid="ToIntlMathematicalValue" id="_ref_51"><a href="#sec-tointlmathematicalvalue">ToIntlMathematicalValue</a></emu-xref>(<var>end</var>).</li><li>Return ?&nbsp;<emu-xref aoid="FormatNumericRangeToParts" id="_ref_52"><a href="#sec-formatnumericrangetoparts">FormatNumericRangeToParts</a></emu-xref>(<var>nf</var>, <var>x</var>, <var>y</var>).</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>nf</var> be the <emu-val>this</emu-val> value.</li><li>Perform ?&nbsp;RequireInternalSlot(<var>nf</var>, [[InitializedNumberFormat]]).</li><li>If <var>start</var> is <emu-val>undefined</emu-val> or <var>end</var> is <emu-val>undefined</emu-val>, throw a <emu-val>TypeError</emu-val> exception.</li><li>Let <var>x</var> be ?&nbsp;<emu-xref aoid="ToIntlMathematicalValue" id="_ref_36"><a href="#sec-tointlmathematicalvalue">ToIntlMathematicalValue</a></emu-xref>(<var>start</var>).</li><li>Let <var>y</var> be ?&nbsp;<emu-xref aoid="ToIntlMathematicalValue" id="_ref_37"><a href="#sec-tointlmathematicalvalue">ToIntlMathematicalValue</a></emu-xref>(<var>end</var>).</li><li>Return ?&nbsp;<emu-xref aoid="FormatNumericRangeToParts" id="_ref_38"><a href="#sec-formatnumericrangetoparts">FormatNumericRangeToParts</a></emu-xref>(<var>nf</var>, <var>x</var>, <var>y</var>).</li></ol></emu-alg>
     </emu-clause>
     </ins>
 
@@ -2054,7 +2829,7 @@ li.menu-search-result-term:before {
         This function provides access to the locale and options computed during initialization of the object.
       </p>
 
-      <emu-alg><ol><li>Let <var>nf</var> be the <emu-val>this</emu-val> value.</li><li>If the implementation supports the normative optional <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> mode of <emu-xref href="#legacy-constructor"></emu-xref>, then<ol><li>Set <var>nf</var> to ?&nbsp;<emu-xref aoid="UnwrapNumberFormat" id="_ref_53"><a href="#sec-unwrapnumberformat">UnwrapNumberFormat</a></emu-xref>(<var>nf</var>).</li></ol></li><li>Perform ?&nbsp;<emu-xref aoid="RequireInternalSlot" id="_ref_54"><a href="https://tc39.es/ecma262/#sec-requireinternalslot">RequireInternalSlot</a></emu-xref>(<var>nf</var>, [[InitializedNumberFormat]]).</li><li>Let <var>options</var> be OrdinaryObjectCreate(%Object.prototype%).</li><li>For each row of <emu-xref href="#table-numberformat-resolvedoptions-properties" id="_ref_1"><a href="#table-numberformat-resolvedoptions-properties">Table 1</a></emu-xref>, except the header row, in table order, do<ol><li>Let <var>p</var> be the Property value of the current row.</li><li>Let <var>v</var> be the value of <var>nf</var>'s internal slot whose name is the Internal Slot value of the current row.</li><li>If <var>v</var> is not <emu-val>undefined</emu-val>, then<ol><li>Perform !&nbsp;<emu-xref aoid="CreateDataPropertyOrThrow" id="_ref_55"><a href="https://tc39.es/ecma262/#sec-createdatapropertyorthrow">CreateDataPropertyOrThrow</a></emu-xref>(<var>options</var>, <var>p</var>, <var>v</var>).</li></ol></li></ol></li><li><ins class="block">If <var>nf</var>.[[RoundingType]] is <emu-const>morePrecision</emu-const>, then</ins><ol><li><ins class="block">Perform !&nbsp;<emu-xref aoid="CreateDataPropertyOrThrow" id="_ref_56"><a href="https://tc39.es/ecma262/#sec-createdatapropertyorthrow">CreateDataPropertyOrThrow</a></emu-xref>(<var>options</var>, <emu-val>"roundingPriority"</emu-val>, <emu-val>"morePrecision"</emu-val>).</ins></li></ol></li><li><ins class="block">Else if <var>nf</var>.[[RoundingType]] is <emu-const>lessPrecision</emu-const>, then</ins><ol><li><ins class="block">Perform !&nbsp;<emu-xref aoid="CreateDataPropertyOrThrow" id="_ref_57"><a href="https://tc39.es/ecma262/#sec-createdatapropertyorthrow">CreateDataPropertyOrThrow</a></emu-xref>(<var>options</var>, <emu-val>"roundingPriority"</emu-val>, <emu-val>"lessPrecision"</emu-val>).</ins></li></ol></li><li><ins class="block">Else,</ins><ol><li><ins class="block">Perform !&nbsp;<emu-xref aoid="CreateDataPropertyOrThrow" id="_ref_58"><a href="https://tc39.es/ecma262/#sec-createdatapropertyorthrow">CreateDataPropertyOrThrow</a></emu-xref>(<var>options</var>, <emu-val>"roundingPriority"</emu-val>, <emu-val>"auto"</emu-val>).</ins></li></ol></li><li>Return <var>options</var>.</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>nf</var> be the <emu-val>this</emu-val> value.</li><li>If the implementation supports the normative optional constructor mode of <emu-xref href="#legacy-constructor"></emu-xref>, then<ol><li>Set <var>nf</var> to ?&nbsp;<emu-xref aoid="UnwrapNumberFormat" id="_ref_39"><a href="#sec-unwrapnumberformat">UnwrapNumberFormat</a></emu-xref>(<var>nf</var>).</li></ol></li><li>Perform ?&nbsp;RequireInternalSlot(<var>nf</var>, [[InitializedNumberFormat]]).</li><li>Let <var>options</var> be OrdinaryObjectCreate(%Object.prototype%).</li><li>For each row of <emu-xref href="#table-numberformat-resolvedoptions-properties" id="_ref_1"><a href="#table-numberformat-resolvedoptions-properties">Table 1</a></emu-xref>, except the header row, in table order, do<ol><li>Let <var>p</var> be the Property value of the current row.</li><li>Let <var>v</var> be the value of <var>nf</var>'s internal slot whose name is the Internal Slot value of the current row.</li><li>If <var>v</var> is not <emu-val>undefined</emu-val>, then<ol><li>Perform !&nbsp;CreateDataPropertyOrThrow(<var>options</var>, <var>p</var>, <var>v</var>).</li></ol></li></ol></li><li><ins class="block">If <var>nf</var>.[[RoundingType]] is <emu-const>morePrecision</emu-const>, then</ins><ol><li><ins class="block">Perform !&nbsp;CreateDataPropertyOrThrow(<var>options</var>, <emu-val>"roundingPriority"</emu-val>, <emu-val>"morePrecision"</emu-val>).</ins></li></ol></li><li><ins class="block">Else if <var>nf</var>.[[RoundingType]] is <emu-const>lessPrecision</emu-const>, then</ins><ol><li><ins class="block">Perform !&nbsp;CreateDataPropertyOrThrow(<var>options</var>, <emu-val>"roundingPriority"</emu-val>, <emu-val>"lessPrecision"</emu-val>).</ins></li></ol></li><li><ins class="block">Else,</ins><ol><li><ins class="block">Perform !&nbsp;CreateDataPropertyOrThrow(<var>options</var>, <emu-val>"roundingPriority"</emu-val>, <emu-val>"auto"</emu-val>).</ins></li></ol></li><li>Return <var>options</var>.</li></ol></emu-alg>
 
       <emu-table id="table-numberformat-resolvedoptions-properties"><figure><figcaption>Table 1: Resolved Options of NumberFormat Instances</figcaption>
         
@@ -2154,7 +2929,7 @@ li.menu-search-result-term:before {
     <h1><span class="secnum">1.4</span> Properties of Intl.NumberFormat Instances</h1>
 
     <p>
-      Intl.NumberFormat instances are ordinary objects that inherit properties from <emu-xref href="#sec-properties-of-intl-numberformat-prototype-object" id="_ref_59"><a href="#sec-properties-of-intl-numberformat-prototype-object">%NumberFormat.prototype%</a></emu-xref>.
+      Intl.NumberFormat instances are ordinary objects that inherit properties from <emu-xref href="#sec-properties-of-intl-numberformat-prototype-object" id="_ref_40"><a href="#sec-properties-of-intl-numberformat-prototype-object">%NumberFormat.prototype%</a></emu-xref>.
     </p>
 
     <p>
@@ -2162,7 +2937,7 @@ li.menu-search-result-term:before {
     </p>
 
     <p>
-      Intl.NumberFormat instances also have several internal slots that are computed by the <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref>:
+      Intl.NumberFormat instances also have several internal slots that are computed by the constructor:
     </p>
 
     <ul>
@@ -2175,9 +2950,9 @@ li.menu-search-result-term:before {
       <li>[[CurrencySign]] is one of the String values <emu-val>"standard"</emu-val> or <emu-val>"accounting"</emu-val>, specifying whether to render negative numbers in accounting format, often signified by parenthesis. It is only used when [[Style]] has the value <emu-val>"currency"</emu-val> and when [[SignDisplay]] is not <emu-val>"never"</emu-val>.</li>
       <li>[[Unit]] is a core unit identifier. It is only used when [[Style]] has the value <emu-val>"unit"</emu-val>.</li>
       <li>[[UnitDisplay]] is one of the String values <emu-val>"short"</emu-val>, <emu-val>"narrow"</emu-val>, or <emu-val>"long"</emu-val>, specifying whether to display the unit as a symbol, narrow symbol, or localized long name if formatting with the <emu-val>"unit"</emu-val> style. It is only used when [[Style]] has the value <emu-val>"unit"</emu-val>.</li>
-      <li>[[MinimumIntegerDigits]] is a non-negative <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref> <emu-xref href="#number-value"><a href="https://tc39.es/ecma262/#number-value">Number value</a></emu-xref> indicating the minimum <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref> digits to be used. Numbers will be padded with leading zeroes if necessary.</li>
-      <li>[[MinimumFractionDigits]] and [[MaximumFractionDigits]] are non-negative <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref> Number values indicating the minimum and maximum fraction digits to be used. Numbers will be rounded or padded with trailing zeroes if necessary. These properties are only used when [[RoundingType]] is <emu-const>fractionDigits</emu-const><ins>, <emu-const>morePrecision</emu-const>, or <emu-const>lessPrecision</emu-const></ins>.</li>
-      <li>[[MinimumSignificantDigits]] and [[MaximumSignificantDigits]] are positive <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref> Number values indicating the minimum and maximum fraction digits to be shown. If present, the formatter uses however many fraction digits are required to display the specified number of significant digits. These properties are only used when [[RoundingType]] is <emu-const>significantDigits</emu-const><ins>, <emu-const>morePrecision</emu-const>, or <emu-const>lessPrecision</emu-const></ins>.</li>
+      <li>[[MinimumIntegerDigits]] is a non-negative integer Number value indicating the minimum integer digits to be used. Numbers will be padded with leading zeroes if necessary.</li>
+      <li>[[MinimumFractionDigits]] and [[MaximumFractionDigits]] are non-negative integer Number values indicating the minimum and maximum fraction digits to be used. Numbers will be rounded or padded with trailing zeroes if necessary. These properties are only used when [[RoundingType]] is <emu-const>fractionDigits</emu-const><ins>, <emu-const>morePrecision</emu-const>, or <emu-const>lessPrecision</emu-const></ins>.</li>
+      <li>[[MinimumSignificantDigits]] and [[MaximumSignificantDigits]] are positive integer Number values indicating the minimum and maximum fraction digits to be shown. If present, the formatter uses however many fraction digits are required to display the specified number of significant digits. These properties are only used when [[RoundingType]] is <emu-const>significantDigits</emu-const><ins>, <emu-const>morePrecision</emu-const>, or <emu-const>lessPrecision</emu-const></ins>.</li>
       <li>[[UseGrouping]] is a Boolean <ins>or String</ins> value indicating <del>whether</del> <ins>the conditions under which</ins> a grouping separator should be used. <ins>The positions of grouping separators, and whether to display grouping separators for a given number, is implementation-defined. A value <emu-val>"always"</emu-val> hints the implementation to display grouping separators if possible; <emu-val>"min2"</emu-val>, if there are at least 2 digits in a group; <emu-val>"auto"</emu-val>, if the locale prefers to use grouping separators for the number. A value <emu-val>false</emu-val> disables grouping separators.</ins></li>
       <li>[[RoundingType]] is one of the values <emu-const>fractionDigits</emu-const>, <emu-const>significantDigits</emu-const>, <del>or <emu-const>compactRounding</emu-const></del> <ins><emu-const>morePrecision</emu-const>, or <emu-const>lessPrecision</emu-const></ins>, indicating which rounding strategy to use. If <emu-const>fractionDigits</emu-const>, the number is rounded according to [[MinimumFractionDigits]] and [[MaximumFractionDigits]], as described above. If <emu-const>significantDigits</emu-const>, the number is rounded according to [[MinimumSignificantDigits]] and [[MaximumSignificantDigits]] as described above. <del>If <emu-const>compactRounding</emu-const>, the number is rounded to 1 maximum fraction digit if there is 1 digit before the decimal separator, and otherwise round to 0 fraction digits.</del> <ins>If <emu-const>morePrecision</emu-const> or <emu-const>lessPrecision</emu-const>, all four of those settings are used, with specific rules for disambiguating when to use one set versus the other. [[RoundingType]] is derived from the <emu-val>"roundingPriority"</emu-val> option and is converted back to <emu-val>"roundingPriority"</emu-val> in <emu-xref href="#sec-intl.numberformat.prototype.resolvedoptions" id="_ref_2"><a href="#sec-intl.numberformat.prototype.resolvedoptions">1.3.7</a></emu-xref>.</ins></li>
       <li>[[Notation]] is one of the String values <emu-val>"standard"</emu-val>, <emu-val>"scientific"</emu-val>, <emu-val>"engineering"</emu-val>, or <emu-val>"compact"</emu-val>, specifying whether the number should be displayed without scaling, scaled to the units place with the power of ten in scientific notation, scaled to the nearest thousand with the power of ten in scientific notation, or scaled to the nearest locale-dependent compact decimal notation power of ten with the corresponding compact decimal notation affix.</li>
@@ -2186,9 +2961,9 @@ li.menu-search-result-term:before {
         [[SignDisplay]] is one of the String values <emu-val>"auto"</emu-val>, <emu-val>"always"</emu-val>, <emu-val>"never"</emu-val>, <del>or</del> <emu-val>"exceptZero"</emu-val>, <ins>or <emu-val>"negative"</emu-val></ins>, specifying <del>whether to show the sign on negative numbers only, positive and negative numbers including zero, neither positive nor negative numbers, or positive and negative numbers but not zero</del> <ins>when to include a sign (with non-<emu-val>"auto"</emu-val> options respectively corresponding with inclusion always, never, only for nonzero numbers, or only for nonzero negative numbers)</ins>.
         In scientific notation, this slot affects the sign display of the mantissa but not the exponent.
       </li>
-      <li><ins class="block">[[RoundingMode]] is one of the String values in the <emu-val>Identifier</emu-val> column of <emu-xref href="#table-intl-rounding-modes" id="_ref_3"><a href="#table-intl-rounding-modes">Table 2</a></emu-xref>, specifying the rounding strategy for the number.</ins></li>
-      <li><ins class="block">[[RoundingIncrement]] is an <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref>-valued Number that evenly divides 10, 100, 1000, or 10000 into tenths, fifths, quarters, or halves. It indicates the increment at which rounding should take place relative to the calculated rounding magnitude. For example, if [[MaximumFractionDigits]] is 2 and [[RoundingIncrement]] is 5, then the number is rounded to the nearest 0.05 ("nickel rounding").</ins></li>
-      <li><ins class="block">[[TrailingZeroDisplay]] is one of the String values <emu-val>"auto"</emu-val> or <emu-val>"stripIfInteger"</emu-val>, indicating whether to strip trailing zeros if the formatted number is an <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref> (i.e., has no nonzero fraction digit).</ins></li>
+      <li><ins class="block">[[RoundingMode]] is one of the String values in the Identifier column of <emu-xref href="#table-intl-rounding-modes" id="_ref_3"><a href="#table-intl-rounding-modes">Table 2</a></emu-xref>, specifying which rounding mode to use.</ins></li>
+      <li><ins class="block">[[RoundingIncrement]] is an integer-valued Number that evenly divides 10, 100, 1000, or 10000 into tenths, fifths, quarters, or halves. It indicates the increment at which rounding should take place relative to the calculated rounding magnitude. For example, if [[MaximumFractionDigits]] is 2 and [[RoundingIncrement]] is 5, then the number is rounded to the nearest 0.05 ("nickel rounding").</ins></li>
+      <li><ins class="block">[[TrailingZeroDisplay]] is one of the String values <emu-val>"auto"</emu-val> or <emu-val>"stripIfInteger"</emu-val>, indicating whether to strip trailing zeros if the formatted number is an integer (i.e., has no nonzero fraction digit).</ins></li>
     </ul>
 
     <ins class="block">
@@ -2320,7 +3095,7 @@ li.menu-search-result-term:before {
       <p>A Number format function is an anonymous built-in function that has a [[NumberFormat]] internal slot.</p>
       <p>When a Number format function <var>F</var> is called with optional argument <var>value</var>, the following steps are taken:</p>
 
-      <emu-alg><ol><li>Let <var>nf</var> be <var>F</var>.[[NumberFormat]].</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <emu-xref aoid="Type" id="_ref_60"><a href="https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>nf</var>) is Object and <var>nf</var> has an [[InitializedNumberFormat]] internal slot.</li><li>If <var>value</var> is not provided, let <var>value</var> be <emu-val>undefined</emu-val>.</li><li>Let <var>x</var> be ? <del><emu-xref aoid="ToNumeric" id="_ref_61"><a href="https://tc39.es/ecma262/#sec-tonumeric">ToNumeric</a></emu-xref></del><ins><emu-xref aoid="ToIntlMathematicalValue" id="_ref_62"><a href="#sec-tointlmathematicalvalue">ToIntlMathematicalValue</a></emu-xref></ins>(<var>value</var>).</li><li>Return ?&nbsp;<emu-xref aoid="FormatNumeric" id="_ref_63"><a href="#sec-formatnumber">FormatNumeric</a></emu-xref>(<var>nf</var>, <var>x</var>).</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>nf</var> be <var>F</var>.[[NumberFormat]].</li><li>Assert: Type(<var>nf</var>) is Object and <var>nf</var> has an [[InitializedNumberFormat]] internal slot.</li><li>If <var>value</var> is not provided, let <var>value</var> be <emu-val>undefined</emu-val>.</li><li>Let <var>x</var> be ?&nbsp;<del>ToNumeric</del><ins><emu-xref aoid="ToIntlMathematicalValue" id="_ref_41"><a href="#sec-tointlmathematicalvalue">ToIntlMathematicalValue</a></emu-xref></ins>(<var>value</var>).</li><li>Return ?&nbsp;<emu-xref aoid="FormatNumeric" id="_ref_42"><a href="#sec-formatnumber">FormatNumeric</a></emu-xref>(<var>nf</var>, <var>x</var>).</li></ol></emu-alg>
 
       <p>
         The <emu-val>"length"</emu-val> property of a Number format function is 1.
@@ -2331,10 +3106,11 @@ li.menu-search-result-term:before {
       <h1><span class="secnum">1.5.3</span> FormatNumericToString ( <var>intlObject</var>, <var>x</var> )</h1>
 
       <p>
-        The FormatNumericToString abstract operation is called with arguments <var>intlObject</var> (which must be an object with [[RoundingType]], [[MinimumSignificantDigits]], [[MaximumSignificantDigits]], [[MinimumIntegerDigits]], [[MinimumFractionDigits]], <del>and</del> [[MaximumFractionDigits]]<ins>, [[RoundingIncrement]], and [[TrailingZeroDisplay]]</ins> internal slots), and <var>x</var> (which must be a <del>Number or BigInt value</del><ins><emu-xref href="#mathematical-value"><a href="https://tc39.es/ecma262/#mathematical-value">mathematical value</a></emu-xref> or <emu-const>negative-zero</emu-const></ins>), and returns a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> containing two values: <var>x</var> as a String value with digits formatted according to the five formatting parameters in the field [[FormattedString]], and the final <del>floating decimal value</del> <ins><emu-xref href="#mathematical-value"><a href="https://tc39.es/ecma262/#mathematical-value">mathematical value</a></emu-xref> (or <emu-val>-0</emu-val><sub>𝔽</sub>)</ins> of <var>x</var> after rounding has been performed in the field [[RoundedNumber]].
+        <del class="block">The FormatNumericToString abstract operation is called with arguments <var>intlObject</var> (which must be an object with [[RoundingType]], [[MinimumSignificantDigits]], [[MaximumSignificantDigits]], [[MinimumIntegerDigits]], [[MinimumFractionDigits]], and [[MaximumFractionDigits]] internal slots), and <var>x</var> (which must be a Number or BigInt value), and returns a Record containing two values: <var>x</var> as a String value with digits formatted according to the five formatting parameters in the field [[FormattedString]], and the final floating decimal value of <var>x</var> after rounding has been performed in the field [[RoundedNumber]].</del>
+        <ins class="block">The FormatNumericToString abstract operation is called with arguments <var>intlObject</var> (which must be an object with [[RoundingMode]], [[RoundingType]], [[MinimumSignificantDigits]], [[MaximumSignificantDigits]], [[MinimumIntegerDigits]], [[MinimumFractionDigits]], [[MaximumFractionDigits]], [[RoundingIncrement]], and [[TrailingZeroDisplay]] internal slots), and <var>x</var> (which must be a mathematical value or <emu-const>negative-zero</emu-const>). It rounds <var>x</var> to an <emu-xref href="#intl-mathematical-value" id="_ref_43"><a href="#intl-mathematical-value">Intl mathematical value</a></emu-xref> according to the internal slots of <var>intlObject</var> and returns a Record with a [[RoundedNumber]] field containing containing that result and a [[FormattedString]] field containing a String value representation of that result formatted according to the internal slots of <var>intlObject</var>.</ins>
       </p>
 
-      <emu-alg><ol><li><ins class="block">If <var>x</var> is <emu-const>negative-zero</emu-const>, then</ins><ol><li><ins class="block">Let <var>isNegative</var> be <emu-val>true</emu-val>.</ins></li><li><ins class="block">Let <var>x</var> be the <emu-xref href="#mathematical-value"><a href="https://tc39.es/ecma262/#mathematical-value">mathematical value</a></emu-xref> 0.</ins></li></ol></li><li><ins class="block"><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>x</var> is a <emu-xref href="#mathematical-value"><a href="https://tc39.es/ecma262/#mathematical-value">mathematical value</a></emu-xref>.</ins></li><li>If <emu-xref href="#ℝ"><a href="https://tc39.es/ecma262/#ℝ">ℝ</a></emu-xref>(<var>x</var>) &lt; 0 <del>or <var>x</var> is <emu-val>-0</emu-val><sub>𝔽</sub></del>, let <var>isNegative</var> be <emu-val>true</emu-val>; else let <var>isNegative</var> be <emu-val>false</emu-val>.</li><li>If <var>isNegative</var>, then<ol><li>Let <var>x</var> be -<var>x</var>.</li></ol></li><li><ins class="block">Let <var>unsignedRoundingMode</var> be <emu-xref aoid="GetUnsignedRoundingMode" id="_ref_64"><a href="#sec-getunsignedroundingmode">GetUnsignedRoundingMode</a></emu-xref>(<var>intlObject</var>.[[RoundingMode]], <var>isNegative</var>).</ins></li><li>If <var>intlObject</var>.[[RoundingType]] is <emu-const>significantDigits</emu-const>, then<ol><li>Let <var>result</var> be <emu-xref aoid="ToRawPrecision" id="_ref_65"><a href="#sec-torawprecision">ToRawPrecision</a></emu-xref>(<var>x</var>, <var>intlObject</var>.[[MinimumSignificantDigits]], <var>intlObject</var>.[[MaximumSignificantDigits]]<ins>, <var>unsignedRoundingMode</var></ins>).</li></ol></li><li>Else if <var>intlObject</var>.[[RoundingType]] is <emu-const>fractionDigits</emu-const>, then<ol><li>Let <var>result</var> be <emu-xref aoid="ToRawFixed" id="_ref_66"><a href="#sec-torawfixed">ToRawFixed</a></emu-xref>(<var>x</var>, <var>intlObject</var>.[[MinimumFractionDigits]], <var>intlObject</var>.[[MaximumFractionDigits]]<ins>, <var>intlObj</var>.[[RoundingIncrement]], <var>unsignedRoundingMode</var></ins>).</li></ol></li><li>Else,<ol><li><del class="block"><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>intlObject</var>.[[RoundingType]] is <emu-const>compactRounding</emu-const>.</del></li><li><del class="block">Let <var>result</var> be <emu-xref aoid="ToRawPrecision" id="_ref_67"><a href="#sec-torawprecision">ToRawPrecision</a></emu-xref>(<var>x</var>, 1, 2).</del></li><li><del class="block">If <var>result</var>.[[IntegerDigitsCount]] &gt; 1, then</del><ol><li><del class="block">Let <var>result</var> be <emu-xref aoid="ToRawFixed" id="_ref_68"><a href="#sec-torawfixed">ToRawFixed</a></emu-xref>(<var>x</var>, 0, 0).</del></li></ol></li><li><ins class="block">Let <var>sResult</var> be <emu-xref aoid="ToRawPrecision" id="_ref_69"><a href="#sec-torawprecision">ToRawPrecision</a></emu-xref>(<var>x</var>, <var>intlObject</var>.[[MinimumSignificantDigits]], <var>intlObject</var>.[[MaximumSignificantDigits]], <var>unsignedRoundingMode</var>).</ins></li><li><ins class="block">Let <var>fResult</var> be <emu-xref aoid="ToRawFixed" id="_ref_70"><a href="#sec-torawfixed">ToRawFixed</a></emu-xref>(<var>x</var>, <var>intlObject</var>.[[MinimumFractionDigits]], <var>intlObject</var>.[[MaximumFractionDigits]], <var>intlObj</var>.[[RoundingIncrement]], <var>unsignedRoundingMode</var>).</ins></li><li><ins class="block">If <var>intlObj</var>.[[RoundingType]] is <emu-const>morePrecision</emu-const>, then</ins><ol><li><ins class="block">If <var>sResult</var>.[[RoundingMagnitude]] ≤ <var>fResult</var>.[[RoundingMagnitude]], then</ins><ol><li><ins class="block">Let <var>result</var> be <var>sResult</var>.</ins></li></ol></li><li><ins class="block">Else,</ins><ol><li><ins class="block">Let <var>result</var> be <var>fResult</var>.</ins></li></ol></li></ol></li><li><ins class="block">Else,</ins><ol><li><ins class="block"><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>intlObj</var>.[[RoundingType]] is <emu-const>lessPrecision</emu-const>.</ins></li><li><ins class="block">If <var>sResult</var>.[[RoundingMagnitude]] ≤ <var>fResult</var>.[[RoundingMagnitude]], then</ins><ol><li><ins class="block">Let <var>result</var> be <var>fResult</var>.</ins></li></ol></li><li><ins class="block">Else,</ins><ol><li><ins class="block">Let <var>result</var> be <var>sResult</var>.</ins></li></ol></li></ol></li></ol></li><li>Let <var>x</var> be <var>result</var>.[[RoundedNumber]].</li><li>Let <var>string</var> be <var>result</var>.[[FormattedString]].</li><li><ins class="block">If <var>intlObject</var>.[[TrailingZeroDisplay]] is <emu-val>"stripIfInteger"</emu-val> and <emu-eqn class="inline"><var>x</var> <emu-xref aoid="modulo"><a href="https://tc39.es/ecma262/#eqn-modulo">modulo</a></emu-xref> 1 = 0</emu-eqn>, then</ins><ol><li><ins class="block">If <var>string</var> contains <emu-val>"."</emu-val>, then</ins><ol><li><ins class="block">Set <var>string</var> to the substring of <var>string</var> from index 0 to the index of <emu-val>"."</emu-val>.</ins></li></ol></li></ol></li><li>Let <var>int</var> be <var>result</var>.[[IntegerDigitsCount]].</li><li>Let <var>minInteger</var> be <var>intlObject</var>.[[MinimumIntegerDigits]].</li><li>If <var>int</var> &lt; <var>minInteger</var>, then<ol><li>Let <var>forwardZeros</var> be the String consisting of <var>minInteger</var> - <var>int</var> occurrences of the code unit 0x0030 (DIGIT ZERO).</li><li>Set <var>string</var> to the <emu-xref href="#sec-ecmascript-language-types-string-type"><a href="https://tc39.es/ecma262/#sec-ecmascript-language-types-string-type">string-concatenation</a></emu-xref> of <var>forwardZeros</var> and <var>string</var>.</li></ol></li><li>If <var>isNegative</var> and <var>x</var> is 0, then<ol><li>Let <var>x</var> be <emu-val>-0</emu-val>.</li></ol></li><li>Else if <var>isNegative</var>, then<ol><li>Let <var>x</var> be -<var>x</var>.</li></ol></li><li>Return the <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[RoundedNumber]]: <var>x</var>, [[FormattedString]]: <var>string</var> }.</li></ol></emu-alg>
+      <emu-alg><ol><li><ins class="block">If <var>x</var> is <emu-const>negative-zero</emu-const>, then</ins><ol><li><ins class="block">Let <var>isNegative</var> be <emu-val>true</emu-val>.</ins></li><li><ins class="block">Set <var>x</var> to 0.</ins></li></ol></li><li><ins class="block">Else,</ins><ol><li><ins class="block">Assert: <var>x</var> is a mathematical value.</ins></li><li>If <del>ℝ(<var>x</var>) &lt; 0 or <var>x</var> is <emu-val>-0</emu-val><sub>𝔽</sub></del><ins><var>x</var> &lt; 0</ins>, let <var>isNegative</var> be <emu-val>true</emu-val>; else let <var>isNegative</var> be <emu-val>false</emu-val>.</li><li>If <var>isNegative</var> <ins>is <emu-val>true</emu-val></ins>, then<ol><li><del>Let <var>x</var> be</del><ins>Set <var>x</var> to</ins> -<var>x</var>.</li></ol></li></ol></li><li><ins class="block">Let <var>unsignedRoundingMode</var> be <emu-xref aoid="GetUnsignedRoundingMode" id="_ref_44"><a href="#sec-getunsignedroundingmode">GetUnsignedRoundingMode</a></emu-xref>(<var>intlObject</var>.[[RoundingMode]], <var>isNegative</var>).</ins></li><li>If <var>intlObject</var>.[[RoundingType]] is <emu-const>significantDigits</emu-const>, then<ol><li>Let <var>result</var> be <emu-xref aoid="ToRawPrecision" id="_ref_45"><a href="#sec-torawprecision">ToRawPrecision</a></emu-xref>(<var>x</var>, <var>intlObject</var>.[[MinimumSignificantDigits]], <var>intlObject</var>.[[MaximumSignificantDigits]]<ins>, <var>unsignedRoundingMode</var></ins>).</li></ol></li><li>Else if <var>intlObject</var>.[[RoundingType]] is <emu-const>fractionDigits</emu-const>, then<ol><li>Let <var>result</var> be <emu-xref aoid="ToRawFixed" id="_ref_46"><a href="#sec-torawfixed">ToRawFixed</a></emu-xref>(<var>x</var>, <var>intlObject</var>.[[MinimumFractionDigits]], <var>intlObject</var>.[[MaximumFractionDigits]]<ins>, <var>intlObj</var>.[[RoundingIncrement]], <var>unsignedRoundingMode</var></ins>).</li></ol></li><li>Else,<ol><li><del class="block">Assert: <var>intlObject</var>.[[RoundingType]] is <emu-const>compactRounding</emu-const>.</del></li><li><del class="block">Let <var>result</var> be <emu-xref aoid="ToRawPrecision" id="_ref_47"><a href="#sec-torawprecision">ToRawPrecision</a></emu-xref>(<var>x</var>, 1, 2).</del></li><li><del class="block">If <var>result</var>.[[IntegerDigitsCount]] &gt; 1, then</del><ol><li><del class="block">Let <var>result</var> be <emu-xref aoid="ToRawFixed" id="_ref_48"><a href="#sec-torawfixed">ToRawFixed</a></emu-xref>(<var>x</var>, 0, 0).</del></li></ol></li><li><ins class="block">Let <var>sResult</var> be <emu-xref aoid="ToRawPrecision" id="_ref_49"><a href="#sec-torawprecision">ToRawPrecision</a></emu-xref>(<var>x</var>, <var>intlObject</var>.[[MinimumSignificantDigits]], <var>intlObject</var>.[[MaximumSignificantDigits]], <var>unsignedRoundingMode</var>).</ins></li><li><ins class="block">Let <var>fResult</var> be <emu-xref aoid="ToRawFixed" id="_ref_50"><a href="#sec-torawfixed">ToRawFixed</a></emu-xref>(<var>x</var>, <var>intlObject</var>.[[MinimumFractionDigits]], <var>intlObject</var>.[[MaximumFractionDigits]], <var>intlObj</var>.[[RoundingIncrement]], <var>unsignedRoundingMode</var>).</ins></li><li><ins class="block">If <var>intlObj</var>.[[RoundingType]] is <emu-const>morePrecision</emu-const>, then</ins><ol><li><ins class="block">If <var>sResult</var>.[[RoundingMagnitude]] ≤ <var>fResult</var>.[[RoundingMagnitude]], then</ins><ol><li><ins class="block">Let <var>result</var> be <var>sResult</var>.</ins></li></ol></li><li><ins class="block">Else,</ins><ol><li><ins class="block">Let <var>result</var> be <var>fResult</var>.</ins></li></ol></li></ol></li><li><ins class="block">Else,</ins><ol><li><ins class="block">Assert: <var>intlObj</var>.[[RoundingType]] is <emu-const>lessPrecision</emu-const>.</ins></li><li><ins class="block">If <var>sResult</var>.[[RoundingMagnitude]] ≤ <var>fResult</var>.[[RoundingMagnitude]], then</ins><ol><li><ins class="block">Let <var>result</var> be <var>fResult</var>.</ins></li></ol></li><li><ins class="block">Else,</ins><ol><li><ins class="block">Let <var>result</var> be <var>sResult</var>.</ins></li></ol></li></ol></li></ol></li><li><del>Let <var>x</var> be</del> <ins>Set <var>x</var> to</ins> <var>result</var>.[[RoundedNumber]].</li><li>Let <var>string</var> be <var>result</var>.[[FormattedString]].</li><li><ins class="block">If <var>intlObject</var>.[[TrailingZeroDisplay]] is <emu-val>"stripIfInteger"</emu-val> and <emu-eqn class="inline"><var>x</var> modulo 1 = 0</emu-eqn>, then</ins><ol><li><ins class="block">Let <var>i</var> be StringIndexOf(<var>string</var>, <emu-val>"."</emu-val>, 0).</ins></li><li><ins class="block">If <var>i</var> ≠ -1, set <var>string</var> to the substring of <var>string</var> from 0 to <var>i</var>.</ins></li></ol></li><li>Let <var>int</var> be <var>result</var>.[[IntegerDigitsCount]].</li><li>Let <var>minInteger</var> be <var>intlObject</var>.[[MinimumIntegerDigits]].</li><li>If <var>int</var> &lt; <var>minInteger</var>, then<ol><li>Let <var>forwardZeros</var> be the String consisting of <var>minInteger</var> - <var>int</var> occurrences of the code unit 0x0030 (DIGIT ZERO).</li><li>Set <var>string</var> to the string-concatenation of <var>forwardZeros</var> and <var>string</var>.</li></ol></li><li><del class="block">If <var>isNegative</var> and <var>x</var> is 0, then</del><ol><li><del class="block">Let <var>x</var> be <emu-val>-0</emu-val>.</del></li></ol></li><li><del class="block">Else if <var>isNegative</var>, then</del><ol><li><del class="block">Let <var>x</var> be -<var>x</var>.</del></li></ol></li><li><ins class="block">If <var>isNegative</var> is <emu-val>true</emu-val>, then</ins><ol><li><ins class="block">If <var>x</var> is 0, set <var>x</var> to <emu-const>negative-zero</emu-const>. Otherwise, set <var>x</var> to -<var>x</var>.</ins></li></ol></li><li>Return the Record { [[RoundedNumber]]: <var>x</var>, [[FormattedString]]: <var>string</var> }.</li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-partitionnumberpattern" aoid="PartitionNumberPattern">
@@ -2347,18 +3123,18 @@ li.menu-search-result-term:before {
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It creates the parts representing the <emu-xref href="#mathematical-value"><a href="https://tc39.es/ecma262/#mathematical-value">mathematical value</a></emu-xref> of <var>x</var> according to the effective locale and the formatting options of <var>numberFormat</var>.</dd>
+        <dd>It creates the parts representing the mathematical value of <var>x</var> according to the effective locale and the formatting options of <var>numberFormat</var>.</dd>
       </dl>
 
-      <emu-alg><ol><li>Let <var>exponent</var> be 0.</li><li>If <var>x</var> is <del><emu-val>NaN</emu-val></del><ins><emu-const>not-a-number</emu-const></ins>, then<ol><li>Let <var>n</var> be an implementation- and locale-dependent (ILD) String value indicating the <emu-val>NaN</emu-val> value.</li></ol></li><li>Else if <var>x</var> is <del><emu-val>+∞</emu-val><sub>𝔽</sub></del><ins><emu-const>positive-infinity</emu-const></ins>, then<ol><li>Let <var>n</var> be an ILD String value indicating positive infinity.</li></ol></li><li>Else if <var>x</var> is <del><emu-val>-∞</emu-val><sub>𝔽</sub></del><ins><emu-const>negative-infinity</emu-const></ins>, then<ol><li>Let <var>n</var> be an ILD String value indicating negative infinity.</li></ol></li><li>Else,<ol><li><del>Set <var>x</var> to <emu-xref href="#ℝ"><a href="https://tc39.es/ecma262/#ℝ">ℝ</a></emu-xref>(<var>x</var>).</del></li><li><del>If <var>numberFormat</var>.[[Style]] is <emu-val>"percent"</emu-val>, set <var>x</var> to 100 × <var>x</var>.</del></li><li><del>Let <var>exponent</var> be <emu-xref aoid="ComputeExponent" id="_ref_71"><a href="#sec-computeexponent">ComputeExponent</a></emu-xref>(<var>numberFormat</var>, <var>x</var>).</del></li><li><del>Set <var>x</var> to <var>x</var> × 10<sup>-<var>exponent</var></sup>.</del></li><li><ins>If <var>x</var> is not <emu-const>negative-zero</emu-const>,</ins><ol><li><ins><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>x</var> is a <emu-xref href="#mathematical-value"><a href="https://tc39.es/ecma262/#mathematical-value">mathematical value</a></emu-xref>.</ins></li><li><ins>If <var>numberFormat</var>.[[Style]] is <emu-val>"percent"</emu-val>, set <var>x</var> to 100 × <var>x</var>.</ins></li><li><ins>Let <var>exponent</var> be <emu-xref aoid="ComputeExponent" id="_ref_72"><a href="#sec-computeexponent">ComputeExponent</a></emu-xref>(<var>numberFormat</var>, <var>x</var>).</ins></li><li><ins>Set <var>x</var> to <var>x</var> × 10<sup>-<var>exponent</var></sup>.</ins></li></ol></li><li>Let <var>formatNumberResult</var> be <emu-xref aoid="FormatNumericToString" id="_ref_73"><a href="#sec-formatnumberstring">FormatNumericToString</a></emu-xref>(<var>numberFormat</var>, <var>x</var>).</li><li>Let <var>n</var> be <var>formatNumberResult</var>.[[FormattedString]].</li><li>Set <var>x</var> to <var>formatNumberResult</var>.[[RoundedNumber]].</li></ol></li><li>Let <var>pattern</var> be <emu-xref aoid="GetNumberFormatPattern" id="_ref_74"><a href="#sec-getnumberformatpattern">GetNumberFormatPattern</a></emu-xref>(<var>numberFormat</var>, <var>x</var>).</li><li>Let <var>result</var> be a new empty <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref>.</li><li>Let <var>patternParts</var> be PartitionPattern(<var>pattern</var>).</li><li>For each <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]], [[Value]] } <var>patternPart</var> of <var>patternParts</var>, do<ol><li>Let <var>p</var> be <var>patternPart</var>.[[Type]].</li><li>If <var>p</var> is <emu-val>"literal"</emu-val>, then<ol><li>Append a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]]: <emu-val>"literal"</emu-val>, [[Value]]: <var>patternPart</var>.[[Value]] } as the last element of <var>result</var>.</li></ol></li><li>Else if <var>p</var> is equal to <emu-val>"number"</emu-val>, then<ol><li>Let <var>notationSubParts</var> be <emu-xref aoid="PartitionNotationSubPattern" id="_ref_75"><a href="#sec-partitionnotationsubpattern">PartitionNotationSubPattern</a></emu-xref>(<var>numberFormat</var>, <var>x</var>, <var>n</var>, <var>exponent</var>).</li><li>Append all elements of <var>notationSubParts</var> to <var>result</var>.</li></ol></li><li>Else if <var>p</var> is equal to <emu-val>"plusSign"</emu-val>, then<ol><li>Let <var>plusSignSymbol</var> be the ILND String representing the plus sign.</li><li>Append a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]]: <emu-val>"plusSign"</emu-val>, [[Value]]: <var>plusSignSymbol</var> } as the last element of <var>result</var>.</li></ol></li><li>Else if <var>p</var> is equal to <emu-val>"minusSign"</emu-val>, then<ol><li>Let <var>minusSignSymbol</var> be the ILND String representing the minus sign.</li><li>Append a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]]: <emu-val>"minusSign"</emu-val>, [[Value]]: <var>minusSignSymbol</var> } as the last element of <var>result</var>.</li></ol></li><li>Else if <var>p</var> is equal to <emu-val>"percentSign"</emu-val> and <var>numberFormat</var>.[[Style]] is <emu-val>"percent"</emu-val>, then<ol><li>Let <var>percentSignSymbol</var> be the ILND String representing the percent sign.</li><li>Append a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]]: <emu-val>"percentSign"</emu-val>, [[Value]]: <var>percentSignSymbol</var> } as the last element of <var>result</var>.</li></ol></li><li>Else if <var>p</var> is equal to <emu-val>"unitPrefix"</emu-val> and <var>numberFormat</var>.[[Style]] is <emu-val>"unit"</emu-val>, then<ol><li>Let <var>unit</var> be <var>numberFormat</var>.[[Unit]].</li><li>Let <var>unitDisplay</var> be <var>numberFormat</var>.[[UnitDisplay]].</li><li>Let <var>mu</var> be an ILD String value representing <var>unit</var> before <var>x</var> in <var>unitDisplay</var> form, which may depend on <var>x</var> in languages having different plural forms.</li><li>Append a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]]: <emu-val>"unit"</emu-val>, [[Value]]: <var>mu</var> } as the last element of <var>result</var>.</li></ol></li><li>Else if <var>p</var> is equal to <emu-val>"unitSuffix"</emu-val> and <var>numberFormat</var>.[[Style]] is <emu-val>"unit"</emu-val>, then<ol><li>Let <var>unit</var> be <var>numberFormat</var>.[[Unit]].</li><li>Let <var>unitDisplay</var> be <var>numberFormat</var>.[[UnitDisplay]].</li><li>Let <var>mu</var> be an ILD String value representing <var>unit</var> after <var>x</var> in <var>unitDisplay</var> form, which may depend on <var>x</var> in languages having different plural forms.</li><li>Append a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]]: <emu-val>"unit"</emu-val>, [[Value]]: <var>mu</var> } as the last element of <var>result</var>.</li></ol></li><li>Else if <var>p</var> is equal to <emu-val>"currencyCode"</emu-val> and <var>numberFormat</var>.[[Style]] is <emu-val>"currency"</emu-val>, then<ol><li>Let <var>currency</var> be <var>numberFormat</var>.[[Currency]].</li><li>Let <var>cd</var> be <var>currency</var>.</li><li>Append a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]]: <emu-val>"currency"</emu-val>, [[Value]]: <var>cd</var> } as the last element of <var>result</var>.</li></ol></li><li>Else if <var>p</var> is equal to <emu-val>"currencyPrefix"</emu-val> and <var>numberFormat</var>.[[Style]] is <emu-val>"currency"</emu-val>, then<ol><li>Let <var>currency</var> be <var>numberFormat</var>.[[Currency]].</li><li>Let <var>currencyDisplay</var> be <var>numberFormat</var>.[[CurrencyDisplay]].</li><li>Let <var>cd</var> be an ILD String value representing <var>currency</var> before <var>x</var> in <var>currencyDisplay</var> form, which may depend on <var>x</var> in languages having different plural forms.</li><li>Append a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]]: <emu-val>"currency"</emu-val>, [[Value]]: <var>cd</var> } as the last element of <var>result</var>.</li></ol></li><li>Else if <var>p</var> is equal to <emu-val>"currencySuffix"</emu-val> and <var>numberFormat</var>.[[Style]] is <emu-val>"currency"</emu-val>, then<ol><li>Let <var>currency</var> be <var>numberFormat</var>.[[Currency]].</li><li>Let <var>currencyDisplay</var> be <var>numberFormat</var>.[[CurrencyDisplay]].</li><li>Let <var>cd</var> be an ILD String value representing <var>currency</var> after <var>x</var> in <var>currencyDisplay</var> form, which may depend on <var>x</var> in languages having different plural forms. If the implementation does not have such a representation of <var>currency</var>, use <var>currency</var> itself.</li><li>Append a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]]: <emu-val>"currency"</emu-val>, [[Value]]: <var>cd</var> } as the last element of <var>result</var>.</li></ol></li><li>Else,<ol><li>Let <var>unknown</var> be an ILND String based on <var>x</var> and <var>p</var>.</li><li>Append a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]]: <emu-val>"unknown"</emu-val>, [[Value]]: <var>unknown</var> } as the last element of <var>result</var>.</li></ol></li></ol></li><li>Return <var>result</var>.</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>exponent</var> be 0.</li><li>If <var>x</var> is <del><emu-val>NaN</emu-val></del><ins><emu-const>not-a-number</emu-const></ins>, then<ol><li>Let <var>n</var> be an implementation- and locale-dependent (ILD) String value indicating the <emu-val>NaN</emu-val> value.</li></ol></li><li>Else if <var>x</var> is <del><emu-val>+∞</emu-val><sub>𝔽</sub></del><ins><emu-const>positive-infinity</emu-const></ins>, then<ol><li>Let <var>n</var> be an ILD String value indicating positive infinity.</li></ol></li><li>Else if <var>x</var> is <del><emu-val>-∞</emu-val><sub>𝔽</sub></del><ins><emu-const>negative-infinity</emu-const></ins>, then<ol><li>Let <var>n</var> be an ILD String value indicating negative infinity.</li></ol></li><li>Else,<ol><li><del>Set <var>x</var> to ℝ(<var>x</var>).</del></li><li><del>If <var>numberFormat</var>.[[Style]] is <emu-val>"percent"</emu-val>, set <var>x</var> to 100 × <var>x</var>.</del></li><li><del>Let <var>exponent</var> be <emu-xref aoid="ComputeExponent" id="_ref_51"><a href="#sec-computeexponent">ComputeExponent</a></emu-xref>(<var>numberFormat</var>, <var>x</var>).</del></li><li><del>Set <var>x</var> to <var>x</var> × 10<sup>-<var>exponent</var></sup>.</del></li><li><ins>If <var>x</var> is not <emu-const>negative-zero</emu-const>,</ins><ol><li><ins>Assert: <var>x</var> is a mathematical value.</ins></li><li><ins>If <var>numberFormat</var>.[[Style]] is <emu-val>"percent"</emu-val>, set <var>x</var> to 100 × <var>x</var>.</ins></li><li><ins>Let <var>exponent</var> be <emu-xref aoid="ComputeExponent" id="_ref_52"><a href="#sec-computeexponent">ComputeExponent</a></emu-xref>(<var>numberFormat</var>, <var>x</var>).</ins></li><li><ins>Set <var>x</var> to <var>x</var> × 10<sup>-<var>exponent</var></sup>.</ins></li></ol></li><li>Let <var>formatNumberResult</var> be <emu-xref aoid="FormatNumericToString" id="_ref_53"><a href="#sec-formatnumberstring">FormatNumericToString</a></emu-xref>(<var>numberFormat</var>, <var>x</var>).</li><li>Let <var>n</var> be <var>formatNumberResult</var>.[[FormattedString]].</li><li>Set <var>x</var> to <var>formatNumberResult</var>.[[RoundedNumber]].</li></ol></li><li>Let <var>pattern</var> be <emu-xref aoid="GetNumberFormatPattern" id="_ref_54"><a href="#sec-getnumberformatpattern">GetNumberFormatPattern</a></emu-xref>(<var>numberFormat</var>, <var>x</var>).</li><li>Let <var>result</var> be a new empty List.</li><li>Let <var>patternParts</var> be PartitionPattern(<var>pattern</var>).</li><li>For each Record { [[Type]], [[Value]] } <var>patternPart</var> of <var>patternParts</var>, do<ol><li>Let <var>p</var> be <var>patternPart</var>.[[Type]].</li><li>If <var>p</var> is <emu-val>"literal"</emu-val>, then<ol><li>Append a new Record { [[Type]]: <emu-val>"literal"</emu-val>, [[Value]]: <var>patternPart</var>.[[Value]] } as the last element of <var>result</var>.</li></ol></li><li>Else if <var>p</var> is equal to <emu-val>"number"</emu-val>, then<ol><li>Let <var>notationSubParts</var> be <emu-xref aoid="PartitionNotationSubPattern" id="_ref_55"><a href="#sec-partitionnotationsubpattern">PartitionNotationSubPattern</a></emu-xref>(<var>numberFormat</var>, <var>x</var>, <var>n</var>, <var>exponent</var>).</li><li>Append all elements of <var>notationSubParts</var> to <var>result</var>.</li></ol></li><li>Else if <var>p</var> is equal to <emu-val>"plusSign"</emu-val>, then<ol><li>Let <var>plusSignSymbol</var> be the ILND String representing the plus sign.</li><li>Append a new Record { [[Type]]: <emu-val>"plusSign"</emu-val>, [[Value]]: <var>plusSignSymbol</var> } as the last element of <var>result</var>.</li></ol></li><li>Else if <var>p</var> is equal to <emu-val>"minusSign"</emu-val>, then<ol><li>Let <var>minusSignSymbol</var> be the ILND String representing the minus sign.</li><li>Append a new Record { [[Type]]: <emu-val>"minusSign"</emu-val>, [[Value]]: <var>minusSignSymbol</var> } as the last element of <var>result</var>.</li></ol></li><li>Else if <var>p</var> is equal to <emu-val>"percentSign"</emu-val> and <var>numberFormat</var>.[[Style]] is <emu-val>"percent"</emu-val>, then<ol><li>Let <var>percentSignSymbol</var> be the ILND String representing the percent sign.</li><li>Append a new Record { [[Type]]: <emu-val>"percentSign"</emu-val>, [[Value]]: <var>percentSignSymbol</var> } as the last element of <var>result</var>.</li></ol></li><li>Else if <var>p</var> is equal to <emu-val>"unitPrefix"</emu-val> and <var>numberFormat</var>.[[Style]] is <emu-val>"unit"</emu-val>, then<ol><li>Let <var>unit</var> be <var>numberFormat</var>.[[Unit]].</li><li>Let <var>unitDisplay</var> be <var>numberFormat</var>.[[UnitDisplay]].</li><li>Let <var>mu</var> be an ILD String value representing <var>unit</var> before <var>x</var> in <var>unitDisplay</var> form, which may depend on <var>x</var> in languages having different plural forms.</li><li>Append a new Record { [[Type]]: <emu-val>"unit"</emu-val>, [[Value]]: <var>mu</var> } as the last element of <var>result</var>.</li></ol></li><li>Else if <var>p</var> is equal to <emu-val>"unitSuffix"</emu-val> and <var>numberFormat</var>.[[Style]] is <emu-val>"unit"</emu-val>, then<ol><li>Let <var>unit</var> be <var>numberFormat</var>.[[Unit]].</li><li>Let <var>unitDisplay</var> be <var>numberFormat</var>.[[UnitDisplay]].</li><li>Let <var>mu</var> be an ILD String value representing <var>unit</var> after <var>x</var> in <var>unitDisplay</var> form, which may depend on <var>x</var> in languages having different plural forms.</li><li>Append a new Record { [[Type]]: <emu-val>"unit"</emu-val>, [[Value]]: <var>mu</var> } as the last element of <var>result</var>.</li></ol></li><li>Else if <var>p</var> is equal to <emu-val>"currencyCode"</emu-val> and <var>numberFormat</var>.[[Style]] is <emu-val>"currency"</emu-val>, then<ol><li>Let <var>currency</var> be <var>numberFormat</var>.[[Currency]].</li><li>Let <var>cd</var> be <var>currency</var>.</li><li>Append a new Record { [[Type]]: <emu-val>"currency"</emu-val>, [[Value]]: <var>cd</var> } as the last element of <var>result</var>.</li></ol></li><li>Else if <var>p</var> is equal to <emu-val>"currencyPrefix"</emu-val> and <var>numberFormat</var>.[[Style]] is <emu-val>"currency"</emu-val>, then<ol><li>Let <var>currency</var> be <var>numberFormat</var>.[[Currency]].</li><li>Let <var>currencyDisplay</var> be <var>numberFormat</var>.[[CurrencyDisplay]].</li><li>Let <var>cd</var> be an ILD String value representing <var>currency</var> before <var>x</var> in <var>currencyDisplay</var> form, which may depend on <var>x</var> in languages having different plural forms.</li><li>Append a new Record { [[Type]]: <emu-val>"currency"</emu-val>, [[Value]]: <var>cd</var> } as the last element of <var>result</var>.</li></ol></li><li>Else if <var>p</var> is equal to <emu-val>"currencySuffix"</emu-val> and <var>numberFormat</var>.[[Style]] is <emu-val>"currency"</emu-val>, then<ol><li>Let <var>currency</var> be <var>numberFormat</var>.[[Currency]].</li><li>Let <var>currencyDisplay</var> be <var>numberFormat</var>.[[CurrencyDisplay]].</li><li>Let <var>cd</var> be an ILD String value representing <var>currency</var> after <var>x</var> in <var>currencyDisplay</var> form, which may depend on <var>x</var> in languages having different plural forms. If the implementation does not have such a representation of <var>currency</var>, use <var>currency</var> itself.</li><li>Append a new Record { [[Type]]: <emu-val>"currency"</emu-val>, [[Value]]: <var>cd</var> } as the last element of <var>result</var>.</li></ol></li><li>Else,<ol><li>Let <var>unknown</var> be an ILND String based on <var>x</var> and <var>p</var>.</li><li>Append a new Record { [[Type]]: <emu-val>"unknown"</emu-val>, [[Value]]: <var>unknown</var> } as the last element of <var>result</var>.</li></ol></li></ol></li><li>Return <var>result</var>.</li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-partitionnotationsubpattern" aoid="PartitionNotationSubPattern">
       <h1><span class="secnum">1.5.5</span> PartitionNotationSubPattern ( <var>numberFormat</var>, <var>x</var>, <var>n</var>, <var>exponent</var> )</h1>
       <p>
-        The PartitionNotationSubPattern abstract operation is called with arguments <var>numberFormat</var> (which must be an object initialized as a NumberFormat), <var>x</var> (which is a numeric value after rounding is applied), <var>n</var> (which is an intermediate formatted string), and <var>exponent</var> (an <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref>), and creates the corresponding parts for the number and notation according to the effective locale and the formatting options of <var>numberFormat</var>. The following steps are taken:
+        The PartitionNotationSubPattern abstract operation is called with arguments <var>numberFormat</var> (which must be an object initialized as a NumberFormat), <var>x</var> (which is <del>a numeric value</del> <ins>an <emu-xref href="#intl-mathematical-value" id="_ref_56"><a href="#intl-mathematical-value">Intl mathematical value</a></emu-xref></ins> after rounding is applied), <var>n</var> (which is an intermediate formatted string), and <var>exponent</var> (an integer), and creates the corresponding parts for the number and notation according to the effective locale and the formatting options of <var>numberFormat</var>. The following steps are taken:
       </p>
-      <emu-alg><ol><li>Let <var>result</var> be a new empty <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref>.</li><li>If <var>x</var> is <emu-val>NaN</emu-val>, then<ol><li>Append a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]]: <emu-val>"nan"</emu-val>, [[Value]]: <var>n</var> } as the last element of <var>result</var>.</li></ol></li><li>Else if <var>x</var> is a non-finite Number, then<ol><li>Append a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]]: <emu-val>"infinity"</emu-val>, [[Value]]: <var>n</var> } as the last element of <var>result</var>.</li></ol></li><li>Else,<ol><li>Let <var>notationSubPattern</var> be <emu-xref aoid="GetNotationSubPattern" id="_ref_76"><a href="#sec-getnotationsubpattern">GetNotationSubPattern</a></emu-xref>(<var>numberFormat</var>, <var>exponent</var>).</li><li>Let <var>patternParts</var> be PartitionPattern(<var>notationSubPattern</var>).</li><li>For each <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]], [[Value]] } <var>patternPart</var> of <var>patternParts</var>, do<ol><li>Let <var>p</var> be <var>patternPart</var>.[[Type]].</li><li>If <var>p</var> is <emu-val>"literal"</emu-val>, then<ol><li>Append a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]]: <emu-val>"literal"</emu-val>, [[Value]]: <var>patternPart</var>.[[Value]] } as the last element of <var>result</var>.</li></ol></li><li>Else if <var>p</var> is equal to <emu-val>"number"</emu-val>, then<ol><li>If the <var>numberFormat</var>.[[NumberingSystem]] matches one of the values in the <emu-val>"Numbering System"</emu-val> column of <emu-xref href="#table-numbering-system-digits" id="_ref_5"><a href="#table-numbering-system-digits">Table 3</a></emu-xref> below, then<ol><li>Let <var>digits</var> be a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> whose elements are the code points specified in the <emu-val>"Digits"</emu-val> column of the matching row in <emu-xref href="#table-numbering-system-digits" id="_ref_6"><a href="#table-numbering-system-digits">Table 3</a></emu-xref>.</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: The length of <var>digits</var> is 10.</li><li>Let <var>transliterated</var> be the empty String.</li><li>Let <var>len</var> be the length of <var>n</var>.</li><li>Let <var>position</var> be 0.</li><li>Repeat, while <var>position</var> &lt; <var>len</var>,<ol><li>Let <var>c</var> be the code unit at index <var>position</var> within <var>n</var>.</li><li>If 0x0030 ≤ <var>c</var> ≤ 0x0039, then<ol><li>NOTE: <var>c</var> is an ASCII digit.</li><li>Let <var>i</var> be <var>c</var> - 0x0030.</li><li>Set <var>c</var> to CodePointsToString(« <var>digits</var>[<var>i</var>] »).</li></ol></li><li>Set <var>transliterated</var> to the <emu-xref href="#sec-ecmascript-language-types-string-type"><a href="https://tc39.es/ecma262/#sec-ecmascript-language-types-string-type">string-concatenation</a></emu-xref> of <var>transliterated</var> and <var>c</var>.</li><li>Set <var>position</var> to <var>position</var> + 1.</li></ol></li><li>Set <var>n</var> to <var>transliterated</var>.</li></ol></li><li>Else use an implementation dependent algorithm to map <var>n</var> to the appropriate representation of <var>n</var> in the given numbering system.</li><li>Let <var>decimalSepIndex</var> be StringIndexOf(<var>n</var>, <emu-val>"."</emu-val>, 0).</li><li>If <var>decimalSepIndex</var> &gt; 0, then<ol><li>Let <var>integer</var> be the substring of <var>n</var> from position 0, inclusive, to position <var>decimalSepIndex</var>, exclusive.</li><li>Let <var>fraction</var> be the substring of <var>n</var> from position <var>decimalSepIndex</var>, exclusive, to the end of <var>n</var>.</li></ol></li><li>Else,<ol><li>Let <var>integer</var> be <var>n</var>.</li><li>Let <var>fraction</var> be <emu-val>undefined</emu-val>.</li></ol></li><li>If the <var>numberFormat</var>.[[UseGrouping]] is <del><emu-val>true</emu-val></del> <ins><emu-val>false</emu-val></ins>, then<ol><li><ins class="block">Append a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]]: <emu-val>"integer"</emu-val>, [[Value]]: <var>integer</var> } as the last element of <var>result</var>.</ins></li></ol></li><li><ins class="block">Else,</ins><ol><li>Let <var>groupSepSymbol</var> be the implementation-, locale-, and numbering system-dependent (ILND) String representing the grouping separator.</li><li>Let <var>groups</var> be a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> whose elements are, in left to right order, the substrings defined by ILND set of locations within the <var>integer</var><ins>, which may depend on the value of <var>numberFormat</var>.[[UseGrouping]]</ins>.</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: The number of elements in <var>groups</var> <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> is greater than 0.</li><li>Repeat, while <var>groups</var> <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> is not empty,<ol><li>Remove the first element from <var>groups</var> and let <var>integerGroup</var> be the value of that element.</li><li>Append a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]]: <emu-val>"integer"</emu-val>, [[Value]]: <var>integerGroup</var> } as the last element of <var>result</var>.</li><li>If <var>groups</var> <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> is not empty, then<ol><li>Append a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]]: <emu-val>"group"</emu-val>, [[Value]]: <var>groupSepSymbol</var> } as the last element of <var>result</var>.</li></ol></li></ol></li></ol></li><li><del class="block">Else,</del><ol><li><del class="block">Append a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]]: <emu-val>"integer"</emu-val>, [[Value]]: <var>integer</var> } as the last element of <var>result</var>.</del></li></ol></li><li>If <var>fraction</var> is not <emu-val>undefined</emu-val>, then<ol><li>Let <var>decimalSepSymbol</var> be the ILND String representing the decimal separator.</li><li>Append a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]]: <emu-val>"decimal"</emu-val>, [[Value]]: <var>decimalSepSymbol</var> } as the last element of <var>result</var>.</li><li>Append a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]]: <emu-val>"fraction"</emu-val>, [[Value]]: <var>fraction</var> } as the last element of <var>result</var>.</li></ol></li></ol></li><li>Else if <var>p</var> is equal to <emu-val>"compactSymbol"</emu-val>, then<ol><li>Let <var>compactSymbol</var> be an ILD string representing <var>exponent</var> in short form, which may depend on <var>x</var> in languages having different plural forms. The implementation must be able to provide this string, or else the pattern would not have a <emu-val>"{compactSymbol}"</emu-val> placeholder.</li><li>Append a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]]: <emu-val>"compact"</emu-val>, [[Value]]: <var>compactSymbol</var> } as the last element of <var>result</var>.</li></ol></li><li>Else if <var>p</var> is equal to <emu-val>"compactName"</emu-val>, then<ol><li>Let <var>compactName</var> be an ILD string representing <var>exponent</var> in long form, which may depend on <var>x</var> in languages having different plural forms. The implementation must be able to provide this string, or else the pattern would not have a <emu-val>"{compactName}"</emu-val> placeholder.</li><li>Append a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]]: <emu-val>"compact"</emu-val>, [[Value]]: <var>compactName</var> } as the last element of <var>result</var>.</li></ol></li><li>Else if <var>p</var> is equal to <emu-val>"scientificSeparator"</emu-val>, then<ol><li>Let <var>scientificSeparator</var> be the ILND String representing the exponent separator.</li><li>Append a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]]: <emu-val>"exponentSeparator"</emu-val>, [[Value]]: <var>scientificSeparator</var> } as the last element of <var>result</var>.</li></ol></li><li>Else if <var>p</var> is equal to <emu-val>"scientificExponent"</emu-val>, then<ol><li>If <var>exponent</var> &lt; 0, then<ol><li>Let <var>minusSignSymbol</var> be the ILND String representing the minus sign.</li><li>Append a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]]: <emu-val>"exponentMinusSign"</emu-val>, [[Value]]: <var>minusSignSymbol</var> } as the last element of <var>result</var>.</li><li>Let <var>exponent</var> be -<var>exponent</var>.</li></ol></li><li>Let <var>exponentResult</var> be <emu-xref aoid="ToRawFixed" id="_ref_77"><a href="#sec-torawfixed">ToRawFixed</a></emu-xref>(<var>exponent</var>, <del>1,</del> 0, 0<ins>, 1, <emu-val>undefined</emu-val></ins>).</li><li>Append a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]]: <emu-val>"exponentInteger"</emu-val>, [[Value]]: <var>exponentResult</var>.[[FormattedString]] } as the last element of <var>result</var>.</li></ol></li><li>Else,<ol><li>Let <var>unknown</var> be an ILND String based on <var>x</var> and <var>p</var>.</li><li>Append a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]]: <emu-val>"unknown"</emu-val>, [[Value]]: <var>unknown</var> } as the last element of <var>result</var>.</li></ol></li></ol></li></ol></li><li>Return <var>result</var>.</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>result</var> be a new empty List.</li><li>If <var>x</var> is <del><emu-val>NaN</emu-val></del><ins><emu-const>not-a-number</emu-const></ins>, then<ol><li>Append a new Record { [[Type]]: <emu-val>"nan"</emu-val>, [[Value]]: <var>n</var> } as the last element of <var>result</var>.</li></ol></li><li>Else if <var>x</var> is <del>a non-finite Number</del><ins><emu-const>positive-infinity</emu-const> or <emu-const>negative-infinity</emu-const></ins>, then<ol><li>Append a new Record { [[Type]]: <emu-val>"infinity"</emu-val>, [[Value]]: <var>n</var> } as the last element of <var>result</var>.</li></ol></li><li>Else,<ol><li>Let <var>notationSubPattern</var> be <emu-xref aoid="GetNotationSubPattern" id="_ref_57"><a href="#sec-getnotationsubpattern">GetNotationSubPattern</a></emu-xref>(<var>numberFormat</var>, <var>exponent</var>).</li><li>Let <var>patternParts</var> be PartitionPattern(<var>notationSubPattern</var>).</li><li>For each Record { [[Type]], [[Value]] } <var>patternPart</var> of <var>patternParts</var>, do<ol><li>Let <var>p</var> be <var>patternPart</var>.[[Type]].</li><li>If <var>p</var> is <emu-val>"literal"</emu-val>, then<ol><li>Append a new Record { [[Type]]: <emu-val>"literal"</emu-val>, [[Value]]: <var>patternPart</var>.[[Value]] } as the last element of <var>result</var>.</li></ol></li><li>Else if <var>p</var> is equal to <emu-val>"number"</emu-val>, then<ol><li>If the <var>numberFormat</var>.[[NumberingSystem]] matches one of the values in the <emu-val>"Numbering System"</emu-val> column of <emu-xref href="#table-numbering-system-digits" id="_ref_5"><a href="#table-numbering-system-digits">Table 3</a></emu-xref> below, then<ol><li>Let <var>digits</var> be a List whose elements are the code points specified in the <emu-val>"Digits"</emu-val> column of the matching row in <emu-xref href="#table-numbering-system-digits" id="_ref_6"><a href="#table-numbering-system-digits">Table 3</a></emu-xref>.</li><li>Assert: The length of <var>digits</var> is 10.</li><li>Let <var>transliterated</var> be the empty String.</li><li>Let <var>len</var> be the length of <var>n</var>.</li><li>Let <var>position</var> be 0.</li><li>Repeat, while <var>position</var> &lt; <var>len</var>,<ol><li>Let <var>c</var> be the code unit at index <var>position</var> within <var>n</var>.</li><li>If 0x0030 ≤ <var>c</var> ≤ 0x0039, then<ol><li>NOTE: <var>c</var> is an ASCII digit.</li><li>Let <var>i</var> be <var>c</var> - 0x0030.</li><li>Set <var>c</var> to CodePointsToString(« <var>digits</var>[<var>i</var>] »).</li></ol></li><li>Set <var>transliterated</var> to the string-concatenation of <var>transliterated</var> and <var>c</var>.</li><li>Set <var>position</var> to <var>position</var> + 1.</li></ol></li><li>Set <var>n</var> to <var>transliterated</var>.</li></ol></li><li>Else use an implementation dependent algorithm to map <var>n</var> to the appropriate representation of <var>n</var> in the given numbering system.</li><li>Let <var>decimalSepIndex</var> be StringIndexOf(<var>n</var>, <emu-val>"."</emu-val>, 0).</li><li>If <var>decimalSepIndex</var> &gt; 0, then<ol><li>Let <var>integer</var> be the substring of <var>n</var> from position 0, inclusive, to position <var>decimalSepIndex</var>, exclusive.</li><li>Let <var>fraction</var> be the substring of <var>n</var> from position <var>decimalSepIndex</var>, exclusive, to the end of <var>n</var>.</li></ol></li><li>Else,<ol><li>Let <var>integer</var> be <var>n</var>.</li><li>Let <var>fraction</var> be <emu-val>undefined</emu-val>.</li></ol></li><li>If the <var>numberFormat</var>.[[UseGrouping]] is <del><emu-val>true</emu-val></del> <ins><emu-val>false</emu-val></ins>, then<ol><li><ins class="block">Append a new Record { [[Type]]: <emu-val>"integer"</emu-val>, [[Value]]: <var>integer</var> } as the last element of <var>result</var>.</ins></li></ol></li><li><ins class="block">Else,</ins><ol><li>Let <var>groupSepSymbol</var> be the implementation-, locale-, and numbering system-dependent (ILND) String representing the grouping separator.</li><li>Let <var>groups</var> be a List whose elements are, in left to right order, the substrings defined by ILND set of locations within the <var>integer</var><ins>, which may depend on the value of <var>numberFormat</var>.[[UseGrouping]]</ins>.</li><li>Assert: The number of elements in <var>groups</var> List is greater than 0.</li><li>Repeat, while <var>groups</var> List is not empty,<ol><li>Remove the first element from <var>groups</var> and let <var>integerGroup</var> be the value of that element.</li><li>Append a new Record { [[Type]]: <emu-val>"integer"</emu-val>, [[Value]]: <var>integerGroup</var> } as the last element of <var>result</var>.</li><li>If <var>groups</var> List is not empty, then<ol><li>Append a new Record { [[Type]]: <emu-val>"group"</emu-val>, [[Value]]: <var>groupSepSymbol</var> } as the last element of <var>result</var>.</li></ol></li></ol></li></ol></li><li><del class="block">Else,</del><ol><li><del class="block">Append a new Record { [[Type]]: <emu-val>"integer"</emu-val>, [[Value]]: <var>integer</var> } as the last element of <var>result</var>.</del></li></ol></li><li>If <var>fraction</var> is not <emu-val>undefined</emu-val>, then<ol><li>Let <var>decimalSepSymbol</var> be the ILND String representing the decimal separator.</li><li>Append a new Record { [[Type]]: <emu-val>"decimal"</emu-val>, [[Value]]: <var>decimalSepSymbol</var> } as the last element of <var>result</var>.</li><li>Append a new Record { [[Type]]: <emu-val>"fraction"</emu-val>, [[Value]]: <var>fraction</var> } as the last element of <var>result</var>.</li></ol></li></ol></li><li>Else if <var>p</var> is equal to <emu-val>"compactSymbol"</emu-val>, then<ol><li>Let <var>compactSymbol</var> be an ILD string representing <var>exponent</var> in short form, which may depend on <var>x</var> in languages having different plural forms. The implementation must be able to provide this string, or else the pattern would not have a <emu-val>"{compactSymbol}"</emu-val> placeholder.</li><li>Append a new Record { [[Type]]: <emu-val>"compact"</emu-val>, [[Value]]: <var>compactSymbol</var> } as the last element of <var>result</var>.</li></ol></li><li>Else if <var>p</var> is equal to <emu-val>"compactName"</emu-val>, then<ol><li>Let <var>compactName</var> be an ILD string representing <var>exponent</var> in long form, which may depend on <var>x</var> in languages having different plural forms. The implementation must be able to provide this string, or else the pattern would not have a <emu-val>"{compactName}"</emu-val> placeholder.</li><li>Append a new Record { [[Type]]: <emu-val>"compact"</emu-val>, [[Value]]: <var>compactName</var> } as the last element of <var>result</var>.</li></ol></li><li>Else if <var>p</var> is equal to <emu-val>"scientificSeparator"</emu-val>, then<ol><li>Let <var>scientificSeparator</var> be the ILND String representing the exponent separator.</li><li>Append a new Record { [[Type]]: <emu-val>"exponentSeparator"</emu-val>, [[Value]]: <var>scientificSeparator</var> } as the last element of <var>result</var>.</li></ol></li><li>Else if <var>p</var> is equal to <emu-val>"scientificExponent"</emu-val>, then<ol><li>If <var>exponent</var> &lt; 0, then<ol><li>Let <var>minusSignSymbol</var> be the ILND String representing the minus sign.</li><li>Append a new Record { [[Type]]: <emu-val>"exponentMinusSign"</emu-val>, [[Value]]: <var>minusSignSymbol</var> } as the last element of <var>result</var>.</li><li>Let <var>exponent</var> be -<var>exponent</var>.</li></ol></li><li>Let <var>exponentResult</var> be <emu-xref aoid="ToRawFixed" id="_ref_58"><a href="#sec-torawfixed">ToRawFixed</a></emu-xref>(<var>exponent</var>, <del>1,</del> 0, 0<ins>, 1, <emu-val>undefined</emu-val></ins>).</li><li>Append a new Record { [[Type]]: <emu-val>"exponentInteger"</emu-val>, [[Value]]: <var>exponentResult</var>.[[FormattedString]] } as the last element of <var>result</var>.</li></ol></li><li>Else,<ol><li>Let <var>unknown</var> be an ILND String based on <var>x</var> and <var>p</var>.</li><li>Append a new Record { [[Type]]: <emu-val>"unknown"</emu-val>, [[Value]]: <var>unknown</var> } as the last element of <var>result</var>.</li></ol></li></ol></li></ol></li><li>Return <var>result</var>.</li></ol></emu-alg>
 
       <emu-table id="table-numbering-system-digits"><figure><figcaption>Table 3: Numbering systems with simple digit mappings</figcaption>
         
@@ -2656,7 +3432,7 @@ li.menu-search-result-term:before {
         The FormatNumeric abstract operation is called with arguments <var>numberFormat</var> (which must be an object initialized as a NumberFormat) and <var>x</var> (which must be a <del>Number or BigInt</del><ins>Intl mathematical</ins> value), and performs the following steps:
       </p>
 
-      <emu-alg><ol><li>Let <var>parts</var> be ?&nbsp;<emu-xref aoid="PartitionNumberPattern" id="_ref_78"><a href="#sec-partitionnumberpattern">PartitionNumberPattern</a></emu-xref>(<var>numberFormat</var>, <var>x</var>).</li><li>Let <var>result</var> be the empty String.</li><li>For each <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]], [[Value]] } <var>part</var> in <var>parts</var>, do<ol><li>Set <var>result</var> to the <emu-xref href="#sec-ecmascript-language-types-string-type"><a href="https://tc39.es/ecma262/#sec-ecmascript-language-types-string-type">string-concatenation</a></emu-xref> of <var>result</var> and <var>part</var>.[[Value]].</li></ol></li><li>Return <var>result</var>.</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>parts</var> be ?&nbsp;<emu-xref aoid="PartitionNumberPattern" id="_ref_59"><a href="#sec-partitionnumberpattern">PartitionNumberPattern</a></emu-xref>(<var>numberFormat</var>, <var>x</var>).</li><li>Let <var>result</var> be the empty String.</li><li>For each Record { [[Type]], [[Value]] } <var>part</var> in <var>parts</var>, do<ol><li>Set <var>result</var> to the string-concatenation of <var>result</var> and <var>part</var>.[[Value]].</li></ol></li><li>Return <var>result</var>.</li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-formatnumbertoparts" aoid="FormatNumericToParts">
@@ -2666,7 +3442,7 @@ li.menu-search-result-term:before {
         The FormatNumericToParts abstract operation is called with arguments <var>numberFormat</var> (which must be an object initialized as a NumberFormat) and <var>x</var> (which must be a <del>Number or BigInt</del><ins>Intl mathematical</ins> value), and performs the following steps:
       </p>
 
-      <emu-alg><ol><li>Let <var>parts</var> be ?&nbsp;<emu-xref aoid="PartitionNumberPattern" id="_ref_79"><a href="#sec-partitionnumberpattern">PartitionNumberPattern</a></emu-xref>(<var>numberFormat</var>, <var>x</var>).</li><li>Let <var>result</var> be !&nbsp;<emu-xref aoid="ArrayCreate" id="_ref_80"><a href="https://tc39.es/ecma262/#sec-arraycreate">ArrayCreate</a></emu-xref>(0).</li><li>Let <var>n</var> be 0.</li><li>For each <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]], [[Value]] } <var>part</var> in <var>parts</var>, do<ol><li>Let <var>O</var> be OrdinaryObjectCreate(%Object.prototype%).</li><li>Perform !&nbsp;<emu-xref aoid="CreateDataPropertyOrThrow" id="_ref_81"><a href="https://tc39.es/ecma262/#sec-createdatapropertyorthrow">CreateDataPropertyOrThrow</a></emu-xref>(<var>O</var>, <emu-val>"type"</emu-val>, <var>part</var>.[[Type]]).</li><li>Perform !&nbsp;<emu-xref aoid="CreateDataPropertyOrThrow" id="_ref_82"><a href="https://tc39.es/ecma262/#sec-createdatapropertyorthrow">CreateDataPropertyOrThrow</a></emu-xref>(<var>O</var>, <emu-val>"value"</emu-val>, <var>part</var>.[[Value]]).</li><li>Perform !&nbsp;<emu-xref aoid="CreateDataPropertyOrThrow" id="_ref_83"><a href="https://tc39.es/ecma262/#sec-createdatapropertyorthrow">CreateDataPropertyOrThrow</a></emu-xref>(<var>result</var>, !&nbsp;<emu-xref aoid="ToString" id="_ref_84"><a href="https://tc39.es/ecma262/#sec-tostring">ToString</a></emu-xref>(<var>n</var>), <var>O</var>).</li><li>Increment <var>n</var> by 1.</li></ol></li><li>Return <var>result</var>.</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>parts</var> be ?&nbsp;<emu-xref aoid="PartitionNumberPattern" id="_ref_60"><a href="#sec-partitionnumberpattern">PartitionNumberPattern</a></emu-xref>(<var>numberFormat</var>, <var>x</var>).</li><li>Let <var>result</var> be !&nbsp;ArrayCreate(0).</li><li>Let <var>n</var> be 0.</li><li>For each Record { [[Type]], [[Value]] } <var>part</var> in <var>parts</var>, do<ol><li>Let <var>O</var> be OrdinaryObjectCreate(%Object.prototype%).</li><li>Perform !&nbsp;CreateDataPropertyOrThrow(<var>O</var>, <emu-val>"type"</emu-val>, <var>part</var>.[[Type]]).</li><li>Perform !&nbsp;CreateDataPropertyOrThrow(<var>O</var>, <emu-val>"value"</emu-val>, <var>part</var>.[[Value]]).</li><li>Perform !&nbsp;CreateDataPropertyOrThrow(<var>result</var>, !&nbsp;ToString(<var>n</var>), <var>O</var>).</li><li>Increment <var>n</var> by 1.</li></ol></li><li>Return <var>result</var>.</li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-torawprecision" aoid="ToRawPrecision">
@@ -2674,17 +3450,17 @@ li.menu-search-result-term:before {
 
       <ins class="block">
       <p>
-        ToRawPrecision is an abstract operation that involves solving the following equation, which returns a valid <emu-xref href="#mathematical-value"><a href="https://tc39.es/ecma262/#mathematical-value">mathematical value</a></emu-xref> given <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref> inputs:
+        ToRawPrecision is an abstract operation that involves solving the following equation, which returns a valid mathematical value given integer inputs:
       </p>
 
       <emu-eqn id="eqn-ToRawPrecisionFn" aoid="ToRawPrecisionFn"><div>        ToRawPrecisionFn(<var>n</var>, <var>e</var>, <var>p</var>) = <var>n</var> × 10<sup><var>e</var>–<var>p</var>+1</sup></div><div>        where 10<sup><var>p</var>–1</sup> ≤ <var>n</var> &lt; 10<sup><var>p</var></sup></div></emu-eqn>
       </ins>
 
       <p>
-        When the ToRawPrecision abstract operation is called with arguments <var>x</var> (which must be a finite non-negative <del>Number or BigInt</del><ins><emu-xref href="#mathematical-value"><a href="https://tc39.es/ecma262/#mathematical-value">mathematical value</a></emu-xref></ins>), <var>minPrecision</var>, <del>and</del> <var>maxPrecision</var> (both must be integers between 1 and 21)<ins>, and <var>unsignedRoundingMode</var> (a specification type from the <emu-val>Unsigned Rounding Mode</emu-val> column of <emu-xref href="#table-intl-unsigned-rounding-modes" id="_ref_7"><a href="#table-intl-unsigned-rounding-modes">Table 4</a></emu-xref> or <emu-val>undefined</emu-val>)</ins>, the following steps are taken:
+        When the ToRawPrecision abstract operation is called with arguments <var>x</var> (which must be a finite non-negative <del>Number or BigInt</del><ins>mathematical value</ins>), <var>minPrecision</var>, <del>and</del> <var>maxPrecision</var> (both must be integers between 1 and 21)<ins>, and <var>unsignedRoundingMode</var> (a specification type from the <emu-val>Unsigned Rounding Mode</emu-val> column of <emu-xref href="#table-intl-unsigned-rounding-modes" id="_ref_7"><a href="#table-intl-unsigned-rounding-modes">Table 4</a></emu-xref> or <emu-val>undefined</emu-val>)</ins>, the following steps are taken:
       </p>
 
-      <emu-alg><ol><li><del class="block">Set x to <emu-xref href="#ℝ"><a href="https://tc39.es/ecma262/#ℝ">ℝ</a></emu-xref>(x).</del></li><li>Let <var>p</var> be <var>maxPrecision</var>.</li><li>If <var>x</var> = 0, then<ol><li>Let <var>m</var> be the String consisting of <var>p</var> occurrences of the code unit 0x0030 (DIGIT ZERO).</li><li>Let <var>e</var> be 0.</li><li>Let <var>xFinal</var> be 0.</li></ol></li><li>Else,<ol><li><del class="block">Let <var>e</var> and <var>n</var> be integers such that 10<sup><var>p</var> - 1</sup> ≤ <var>n</var> &lt; 10<sup><var>p</var></sup> and for which <var>n</var> × 10<sup><var>e</var> - <var>p</var> + 1</sup> - <var>x</var> is as close to zero as possible. If there are two such sets of <var>e</var> and <var>n</var>, pick the <var>e</var> and <var>n</var> for which <var>n</var> × 10<sup><var>e</var> - <var>p</var> + 1</sup> is larger.</del></li><li><ins class="block">Let <var>n1</var> and <var>e1</var> each be an <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref> and <var>r1</var> a <emu-xref href="#mathematical-value"><a href="https://tc39.es/ecma262/#mathematical-value">mathematical value</a></emu-xref>, with <emu-eqn class="inline"><var>r1</var> = <emu-xref aoid="ToRawPrecisionFn" id="_ref_85"><a href="#eqn-ToRawPrecisionFn">ToRawPrecisionFn</a></emu-xref>(<var>n1</var>, <var>e1</var>, <var>p</var>)</emu-eqn>, such that <emu-eqn class="inline"><var>r1</var> ≤ <var>x</var></emu-eqn> and <var>r1</var> is maximized.</ins></li><li><ins class="block">Let <var>n2</var> and <var>e2</var> each be an <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref> and <var>r2</var> a <emu-xref href="#mathematical-value"><a href="https://tc39.es/ecma262/#mathematical-value">mathematical value</a></emu-xref>, with <emu-eqn class="inline"><var>r2</var> = <emu-xref aoid="ToRawPrecisionFn" id="_ref_86"><a href="#eqn-ToRawPrecisionFn">ToRawPrecisionFn</a></emu-xref>(<var>n2</var>, <var>e2</var>, <var>p</var>)</emu-eqn>, such that <emu-eqn class="inline"><var>r2</var> ≥ <var>x</var></emu-eqn> and <var>r2</var> is minimized.</ins></li><li><ins class="block">Let <var>r</var> be <emu-xref aoid="ApplyUnsignedRoundingMode" id="_ref_87"><a href="#sec-applyunsignedroundingmode">ApplyUnsignedRoundingMode</a></emu-xref>(<var>x</var>, <var>r1</var>, <var>r2</var>, <var>unsignedRoundingMode</var>).</ins></li><li><ins class="block">If <var>r</var> is <var>r1</var>, then</ins><ol><li><ins class="block">Let <var>n</var> be <var>n1</var>.</ins></li><li><ins class="block">Let <var>e</var> be <var>e1</var>.</ins></li><li><ins class="block">Let <var>xFinal</var> be <var>r1</var>.</ins></li></ol></li><li><ins class="block">Else,</ins><ol><li><ins class="block">Let <var>n</var> be <var>n2</var>.</ins></li><li><ins class="block">Let <var>e</var> be <var>e2</var>.</ins></li><li><ins class="block">Let <var>xFinal</var> be <var>r2</var>.</ins></li></ol></li><li>Let <var>m</var> be the String consisting of the digits of the decimal representation of <var>n</var> (in order, with no leading zeroes).</li><li><del class="block">Let <var>xFinal</var> be <var>n</var> × 10<sup><var>e</var> - <var>p</var> + 1</sup>.</del></li></ol></li><li>If <var>e</var> ≥ (<var>p</var> - 1), then<ol><li>Set <var>m</var> to the <emu-xref href="#sec-ecmascript-language-types-string-type"><a href="https://tc39.es/ecma262/#sec-ecmascript-language-types-string-type">string-concatenation</a></emu-xref> of <var>m</var> and <var>e</var> - <var>p</var> + 1 occurrences of the code unit 0x0030 (DIGIT ZERO).</li><li>Let <var>int</var> be <var>e</var> + 1.</li></ol></li><li>Else if <var>e</var> ≥ 0, then<ol><li>Set <var>m</var> to the <emu-xref href="#sec-ecmascript-language-types-string-type"><a href="https://tc39.es/ecma262/#sec-ecmascript-language-types-string-type">string-concatenation</a></emu-xref> of the first <var>e</var> + 1 code units of <var>m</var>, the code unit 0x002E (FULL STOP), and the remaining <var>p</var> - (<var>e</var> + 1) code units of <var>m</var>.</li><li>Let <var>int</var> be <var>e</var> + 1.</li></ol></li><li>Else,<ol><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>e</var> &lt; 0.</li><li>Set <var>m</var> to the <emu-xref href="#sec-ecmascript-language-types-string-type"><a href="https://tc39.es/ecma262/#sec-ecmascript-language-types-string-type">string-concatenation</a></emu-xref> of <emu-val>"0."</emu-val>, -(<var>e</var> + 1) occurrences of the code unit 0x0030 (DIGIT ZERO), and <var>m</var>.</li><li>Let <var>int</var> be 1.</li></ol></li><li>If <var>m</var> contains the code unit 0x002E (FULL STOP) and <var>maxPrecision</var> &gt; <var>minPrecision</var>, then<ol><li>Let <var>cut</var> be <var>maxPrecision</var> - <var>minPrecision</var>.</li><li>Repeat, while <var>cut</var> &gt; 0 and the last code unit of <var>m</var> is 0x0030 (DIGIT ZERO),<ol><li>Remove the last code unit from <var>m</var>.</li><li>Decrease <var>cut</var> by 1.</li></ol></li><li>If the last code unit of <var>m</var> is 0x002E (FULL STOP), then<ol><li>Remove the last code unit from <var>m</var>.</li></ol></li></ol></li><li>Return the <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[FormattedString]]: <var>m</var>, [[RoundedNumber]]: <var>xFinal</var>, [[IntegerDigitsCount]]: <var>int</var><ins>, [[RoundingMagnitude]]: <var>e</var>–<var>p</var>+1</ins> }.</li></ol></emu-alg>
+      <emu-alg><ol><li><del class="block">Set x to ℝ(x).</del></li><li>Let <var>p</var> be <var>maxPrecision</var>.</li><li>If <var>x</var> = 0, then<ol><li>Let <var>m</var> be the String consisting of <var>p</var> occurrences of the code unit 0x0030 (DIGIT ZERO).</li><li>Let <var>e</var> be 0.</li><li>Let <var>xFinal</var> be 0.</li></ol></li><li>Else,<ol><li><del class="block">Let <var>e</var> and <var>n</var> be integers such that 10<sup><var>p</var> - 1</sup> ≤ <var>n</var> &lt; 10<sup><var>p</var></sup> and for which <var>n</var> × 10<sup><var>e</var> - <var>p</var> + 1</sup> - <var>x</var> is as close to zero as possible. If there are two such sets of <var>e</var> and <var>n</var>, pick the <var>e</var> and <var>n</var> for which <var>n</var> × 10<sup><var>e</var> - <var>p</var> + 1</sup> is larger.</del></li><li><ins class="block">Let <var>n1</var> and <var>e1</var> each be an integer and <var>r1</var> a mathematical value, with <emu-eqn class="inline"><var>r1</var> = <emu-xref aoid="ToRawPrecisionFn" id="_ref_61"><a href="#eqn-ToRawPrecisionFn">ToRawPrecisionFn</a></emu-xref>(<var>n1</var>, <var>e1</var>, <var>p</var>)</emu-eqn>, such that <emu-eqn class="inline"><var>r1</var> ≤ <var>x</var></emu-eqn> and <var>r1</var> is maximized.</ins></li><li><ins class="block">Let <var>n2</var> and <var>e2</var> each be an integer and <var>r2</var> a mathematical value, with <emu-eqn class="inline"><var>r2</var> = <emu-xref aoid="ToRawPrecisionFn" id="_ref_62"><a href="#eqn-ToRawPrecisionFn">ToRawPrecisionFn</a></emu-xref>(<var>n2</var>, <var>e2</var>, <var>p</var>)</emu-eqn>, such that <emu-eqn class="inline"><var>r2</var> ≥ <var>x</var></emu-eqn> and <var>r2</var> is minimized.</ins></li><li><ins class="block">Let <var>r</var> be <emu-xref aoid="ApplyUnsignedRoundingMode" id="_ref_63"><a href="#sec-applyunsignedroundingmode">ApplyUnsignedRoundingMode</a></emu-xref>(<var>x</var>, <var>r1</var>, <var>r2</var>, <var>unsignedRoundingMode</var>).</ins></li><li><ins class="block">If <var>r</var> is <var>r1</var>, then</ins><ol><li><ins class="block">Let <var>n</var> be <var>n1</var>.</ins></li><li><ins class="block">Let <var>e</var> be <var>e1</var>.</ins></li><li><ins class="block">Let <var>xFinal</var> be <var>r1</var>.</ins></li></ol></li><li><ins class="block">Else,</ins><ol><li><ins class="block">Let <var>n</var> be <var>n2</var>.</ins></li><li><ins class="block">Let <var>e</var> be <var>e2</var>.</ins></li><li><ins class="block">Let <var>xFinal</var> be <var>r2</var>.</ins></li></ol></li><li>Let <var>m</var> be the String consisting of the digits of the decimal representation of <var>n</var> (in order, with no leading zeroes).</li><li><del class="block">Let <var>xFinal</var> be <var>n</var> × 10<sup><var>e</var> - <var>p</var> + 1</sup>.</del></li></ol></li><li>If <var>e</var> ≥ (<var>p</var> - 1), then<ol><li>Set <var>m</var> to the string-concatenation of <var>m</var> and <var>e</var> - <var>p</var> + 1 occurrences of the code unit 0x0030 (DIGIT ZERO).</li><li>Let <var>int</var> be <var>e</var> + 1.</li></ol></li><li>Else if <var>e</var> ≥ 0, then<ol><li>Set <var>m</var> to the string-concatenation of the first <var>e</var> + 1 code units of <var>m</var>, the code unit 0x002E (FULL STOP), and the remaining <var>p</var> - (<var>e</var> + 1) code units of <var>m</var>.</li><li>Let <var>int</var> be <var>e</var> + 1.</li></ol></li><li>Else,<ol><li>Assert: <var>e</var> &lt; 0.</li><li>Set <var>m</var> to the string-concatenation of <emu-val>"0."</emu-val>, -(<var>e</var> + 1) occurrences of the code unit 0x0030 (DIGIT ZERO), and <var>m</var>.</li><li>Let <var>int</var> be 1.</li></ol></li><li>If <var>m</var> contains the code unit 0x002E (FULL STOP) and <var>maxPrecision</var> &gt; <var>minPrecision</var>, then<ol><li>Let <var>cut</var> be <var>maxPrecision</var> - <var>minPrecision</var>.</li><li>Repeat, while <var>cut</var> &gt; 0 and the last code unit of <var>m</var> is 0x0030 (DIGIT ZERO),<ol><li>Remove the last code unit from <var>m</var>.</li><li>Decrease <var>cut</var> by 1.</li></ol></li><li>If the last code unit of <var>m</var> is 0x002E (FULL STOP), then<ol><li>Remove the last code unit from <var>m</var>.</li></ol></li></ol></li><li>Return the Record { [[FormattedString]]: <var>m</var>, [[RoundedNumber]]: <var>xFinal</var>, [[IntegerDigitsCount]]: <var>int</var><ins>, [[RoundingMagnitude]]: <var>e</var>–<var>p</var>+1</ins> }.</li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-torawfixed" aoid="ToRawFixed">
@@ -2692,17 +3468,17 @@ li.menu-search-result-term:before {
 
       <ins class="block">
       <p>
-        ToRawFixed is an abstract operation that involves solving the following equation, which returns a valid <emu-xref href="#mathematical-value"><a href="https://tc39.es/ecma262/#mathematical-value">mathematical value</a></emu-xref> given <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref> inputs:
+        ToRawFixed is an abstract operation that involves solving the following equation, which returns a valid mathematical value given integer inputs:
       </p>
 
       <emu-eqn id="eqn-ToRawFixedFn" aoid="ToRawFixedFn"><div>        ToRawFixedFn(<var>n</var>, <var>f</var>) = <var>n</var> × 10<sup>–<var>f</var></sup></div></emu-eqn>
       </ins>
 
       <p>
-        When the ToRawFixed abstract operation is called with arguments <var>x</var> (which must be a finite non-negative <del>Number or BigInt</del><ins><emu-xref href="#mathematical-value"><a href="https://tc39.es/ecma262/#mathematical-value">mathematical value</a></emu-xref></ins>), <var>minFraction</var>, <del>and</del> <var>maxFraction</var> (which must be integers between 0 and 20)<ins>, <var>roundingIncrement</var> (an <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref>), and <var>unsignedRoundingMode</var> (a specification type from the <emu-val>Unsigned Rounding Mode</emu-val> column of <emu-xref href="#table-intl-unsigned-rounding-modes" id="_ref_8"><a href="#table-intl-unsigned-rounding-modes">Table 4</a></emu-xref> or <emu-val>undefined</emu-val>)</ins>, the following steps are taken:
+        When the ToRawFixed abstract operation is called with arguments <var>x</var> (which must be a finite non-negative <del>Number or BigInt</del><ins>mathematical value</ins>), <var>minFraction</var>, <del>and</del> <var>maxFraction</var> (which must be integers between 0 and 20)<ins>, <var>roundingIncrement</var> (an integer), and <var>unsignedRoundingMode</var> (a specification type from the <emu-val>Unsigned Rounding Mode</emu-val> column of <emu-xref href="#table-intl-unsigned-rounding-modes" id="_ref_8"><a href="#table-intl-unsigned-rounding-modes">Table 4</a></emu-xref> or <emu-val>undefined</emu-val>)</ins>, the following steps are taken:
       </p>
 
-      <emu-alg><ol><li><del class="block">Set x to <emu-xref href="#ℝ"><a href="https://tc39.es/ecma262/#ℝ">ℝ</a></emu-xref>(x).</del></li><li>Let <var>f</var> be <var>maxFraction</var>.</li><li><del class="block">Let <var>n</var> be an <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref> for which the exact <emu-xref href="#mathematical-value"><a href="https://tc39.es/ecma262/#mathematical-value">mathematical value</a></emu-xref> of <var>n</var> / 10<sup><var>f</var></sup> - <var>x</var> is as close to zero as possible. If there are two such <var>n</var>, pick the larger <var>n</var>.</del></li><li><del class="block">Let <var>xFinal</var> be <var>n</var> / 10<sup><var>f</var></sup>.</del></li><li><ins class="block">Let <var>n1</var> be an <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref> and <var>r1</var> a <emu-xref href="#mathematical-value"><a href="https://tc39.es/ecma262/#mathematical-value">mathematical value</a></emu-xref>, with <emu-eqn class="inline"><var>r1</var> = <emu-xref aoid="ToRawFixedFn" id="_ref_88"><a href="#eqn-ToRawFixedFn">ToRawFixedFn</a></emu-xref>(<var>n1</var>, <var>f</var>)</emu-eqn>, such that <emu-eqn class="inline"><var>n1</var> <emu-xref aoid="modulo"><a href="https://tc39.es/ecma262/#eqn-modulo">modulo</a></emu-xref> <var>roundingIncrement</var> = 0</emu-eqn>, <emu-eqn class="inline"><var>r1</var> ≤ <var>x</var></emu-eqn>, and <var>r1</var> is maximized.</ins></li><li><ins class="block">Let <var>n2</var> be an <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref> and <var>r2</var> a <emu-xref href="#mathematical-value"><a href="https://tc39.es/ecma262/#mathematical-value">mathematical value</a></emu-xref>, with <emu-eqn class="inline"><var>r2</var> = <emu-xref aoid="ToRawFixedFn" id="_ref_89"><a href="#eqn-ToRawFixedFn">ToRawFixedFn</a></emu-xref>(<var>n2</var>, <var>f</var>)</emu-eqn>, such that <emu-eqn class="inline"><var>n2</var> <emu-xref aoid="modulo"><a href="https://tc39.es/ecma262/#eqn-modulo">modulo</a></emu-xref> <var>roundingIncrement</var> = 0</emu-eqn>, <emu-eqn class="inline"><var>r2</var> ≥ <var>x</var></emu-eqn>, and <var>r2</var> is minimized.</ins></li><li><ins class="block">Let <var>r</var> be <emu-xref aoid="ApplyUnsignedRoundingMode" id="_ref_90"><a href="#sec-applyunsignedroundingmode">ApplyUnsignedRoundingMode</a></emu-xref>(<var>x</var>, <var>r1</var>, <var>r2</var>, <var>unsignedRoundingMode</var>).</ins></li><li><ins class="block">If <var>r</var> is <var>r1</var>, then</ins><ol><li><ins class="block">Let <var>n</var> be <var>n1</var>.</ins></li><li><ins class="block">Let <var>xFinal</var> be <var>r1</var>.</ins></li></ol></li><li><ins class="block">Else,</ins><ol><li><ins class="block">Let <var>n</var> be <var>n2</var>.</ins></li><li><ins class="block">Let <var>xFinal</var> be <var>r2</var>.</ins></li></ol></li><li>If <var>n</var> = 0, let <var>m</var> be <emu-val>"0"</emu-val>. Otherwise, let <var>m</var> be the String consisting of the digits of the decimal representation of <var>n</var> (in order, with no leading zeroes).</li><li>If <var>f</var> ≠ 0, then<ol><li>Let <var>k</var> be the length of <var>m</var>.</li><li>If <var>k</var> ≤ <var>f</var>, then<ol><li>Let <var>z</var> be the String value consisting of <var>f</var> + 1 - <var>k</var> occurrences of the code unit 0x0030 (DIGIT ZERO).</li><li>Set <var>m</var> to the <emu-xref href="#sec-ecmascript-language-types-string-type"><a href="https://tc39.es/ecma262/#sec-ecmascript-language-types-string-type">string-concatenation</a></emu-xref> of <var>z</var> and <var>m</var>.</li><li>Set <var>k</var> to <var>f</var> + 1.</li></ol></li><li>Let <var>a</var> be the first <var>k</var> - <var>f</var> code units of <var>m</var>, and let <var>b</var> be the remaining <var>f</var> code units of <var>m</var>.</li><li>Set <var>m</var> to the <emu-xref href="#sec-ecmascript-language-types-string-type"><a href="https://tc39.es/ecma262/#sec-ecmascript-language-types-string-type">string-concatenation</a></emu-xref> of <var>a</var>, <emu-val>"."</emu-val>, and <var>b</var>.</li><li>Let <var>int</var> be the length of <var>a</var>.</li></ol></li><li>Else, let <var>int</var> be the length of <var>m</var>.</li><li>Let <var>cut</var> be <var>maxFraction</var> - <var>minFraction</var>.</li><li>Repeat, while <var>cut</var> &gt; 0 and the last code unit of <var>m</var> is 0x0030 (DIGIT ZERO),<ol><li>Remove the last code unit from <var>m</var>.</li><li>Decrease <var>cut</var> by 1.</li></ol></li><li>If the last code unit of <var>m</var> is 0x002E (FULL STOP), then<ol><li>Remove the last code unit from <var>m</var>.</li></ol></li><li>Return the <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[FormattedString]]: <var>m</var>, [[RoundedNumber]]: <var>xFinal</var>, [[IntegerDigitsCount]]: <var>int</var><ins>, [[RoundingMagnitude]]: –<var>f</var></ins> }.</li></ol></emu-alg>
+      <emu-alg><ol><li><del class="block">Set x to ℝ(x).</del></li><li>Let <var>f</var> be <var>maxFraction</var>.</li><li><del class="block">Let <var>n</var> be an integer for which the exact mathematical value of <var>n</var> / 10<sup><var>f</var></sup> - <var>x</var> is as close to zero as possible. If there are two such <var>n</var>, pick the larger <var>n</var>.</del></li><li><del class="block">Let <var>xFinal</var> be <var>n</var> / 10<sup><var>f</var></sup>.</del></li><li><ins class="block">Let <var>n1</var> be an integer and <var>r1</var> a mathematical value, with <emu-eqn class="inline"><var>r1</var> = <emu-xref aoid="ToRawFixedFn" id="_ref_64"><a href="#eqn-ToRawFixedFn">ToRawFixedFn</a></emu-xref>(<var>n1</var>, <var>f</var>)</emu-eqn>, such that <emu-eqn class="inline"><var>n1</var> modulo <var>roundingIncrement</var> = 0</emu-eqn>, <emu-eqn class="inline"><var>r1</var> ≤ <var>x</var></emu-eqn>, and <var>r1</var> is maximized.</ins></li><li><ins class="block">Let <var>n2</var> be an integer and <var>r2</var> a mathematical value, with <emu-eqn class="inline"><var>r2</var> = <emu-xref aoid="ToRawFixedFn" id="_ref_65"><a href="#eqn-ToRawFixedFn">ToRawFixedFn</a></emu-xref>(<var>n2</var>, <var>f</var>)</emu-eqn>, such that <emu-eqn class="inline"><var>n2</var> modulo <var>roundingIncrement</var> = 0</emu-eqn>, <emu-eqn class="inline"><var>r2</var> ≥ <var>x</var></emu-eqn>, and <var>r2</var> is minimized.</ins></li><li><ins class="block">Let <var>r</var> be <emu-xref aoid="ApplyUnsignedRoundingMode" id="_ref_66"><a href="#sec-applyunsignedroundingmode">ApplyUnsignedRoundingMode</a></emu-xref>(<var>x</var>, <var>r1</var>, <var>r2</var>, <var>unsignedRoundingMode</var>).</ins></li><li><ins class="block">If <var>r</var> is <var>r1</var>, then</ins><ol><li><ins class="block">Let <var>n</var> be <var>n1</var>.</ins></li><li><ins class="block">Let <var>xFinal</var> be <var>r1</var>.</ins></li></ol></li><li><ins class="block">Else,</ins><ol><li><ins class="block">Let <var>n</var> be <var>n2</var>.</ins></li><li><ins class="block">Let <var>xFinal</var> be <var>r2</var>.</ins></li></ol></li><li>If <var>n</var> = 0, let <var>m</var> be <emu-val>"0"</emu-val>. Otherwise, let <var>m</var> be the String consisting of the digits of the decimal representation of <var>n</var> (in order, with no leading zeroes).</li><li>If <var>f</var> ≠ 0, then<ol><li>Let <var>k</var> be the length of <var>m</var>.</li><li>If <var>k</var> ≤ <var>f</var>, then<ol><li>Let <var>z</var> be the String value consisting of <var>f</var> + 1 - <var>k</var> occurrences of the code unit 0x0030 (DIGIT ZERO).</li><li>Set <var>m</var> to the string-concatenation of <var>z</var> and <var>m</var>.</li><li>Set <var>k</var> to <var>f</var> + 1.</li></ol></li><li>Let <var>a</var> be the first <var>k</var> - <var>f</var> code units of <var>m</var>, and let <var>b</var> be the remaining <var>f</var> code units of <var>m</var>.</li><li>Set <var>m</var> to the string-concatenation of <var>a</var>, <emu-val>"."</emu-val>, and <var>b</var>.</li><li>Let <var>int</var> be the length of <var>a</var>.</li></ol></li><li>Else, let <var>int</var> be the length of <var>m</var>.</li><li>Let <var>cut</var> be <var>maxFraction</var> - <var>minFraction</var>.</li><li>Repeat, while <var>cut</var> &gt; 0 and the last code unit of <var>m</var> is 0x0030 (DIGIT ZERO),<ol><li>Remove the last code unit from <var>m</var>.</li><li>Decrease <var>cut</var> by 1.</li></ol></li><li>If the last code unit of <var>m</var> is 0x002E (FULL STOP), then<ol><li>Remove the last code unit from <var>m</var>.</li></ol></li><li>Return the Record { [[FormattedString]]: <var>m</var>, [[RoundedNumber]]: <var>xFinal</var>, [[IntegerDigitsCount]]: <var>int</var><ins>, [[RoundingMagnitude]]: –<var>f</var></ins> }.</li></ol></emu-alg>
     </emu-clause>
 
     <emu-normative-optional>
@@ -2711,19 +3487,19 @@ li.menu-search-result-term:before {
       <p>
         The UnwrapNumberFormat abstract operation returns the NumberFormat instance
         of its input object, which is either the value itself or a value associated
-        with it by <emu-xref href="#sec-intl-numberformat-constructor" id="_ref_91"><a href="#sec-intl-numberformat-constructor">%NumberFormat%</a></emu-xref> according to the normative optional
-        <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> mode of <emu-xref href="#legacy-constructor"></emu-xref>.
+        with it by <emu-xref href="#sec-intl-numberformat-constructor" id="_ref_67"><a href="#sec-intl-numberformat-constructor">%NumberFormat%</a></emu-xref> according to the normative optional
+        constructor mode of <emu-xref href="#legacy-constructor"></emu-xref>.
       </p>
-      <emu-alg><ol><li>If <emu-xref aoid="Type" id="_ref_92"><a href="https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>nf</var>) is not Object, throw a <emu-val>TypeError</emu-val> exception.</li><li>If <var>nf</var> does not have an [[InitializedNumberFormat]] internal slot and ?&nbsp;<emu-xref aoid="OrdinaryHasInstance" id="_ref_93"><a href="https://tc39.es/ecma262/#sec-ordinaryhasinstance">OrdinaryHasInstance</a></emu-xref>(<emu-xref href="#sec-intl-numberformat-constructor" id="_ref_94"><a href="#sec-intl-numberformat-constructor">%NumberFormat%</a></emu-xref>, <var>nf</var>) is <emu-val>true</emu-val>, then<ol><li>Return ?&nbsp;<emu-xref aoid="Get" id="_ref_95"><a href="https://tc39.es/ecma262/#sec-get-o-p">Get</a></emu-xref>(<var>nf</var>, %Intl%.[[FallbackSymbol]]).</li></ol></li><li>Return <var>nf</var>.</li></ol></emu-alg>
+      <emu-alg><ol><li>If Type(<var>nf</var>) is not Object, throw a <emu-val>TypeError</emu-val> exception.</li><li>If <var>nf</var> does not have an [[InitializedNumberFormat]] internal slot and ?&nbsp;OrdinaryHasInstance(<emu-xref href="#sec-intl-numberformat-constructor" id="_ref_68"><a href="#sec-intl-numberformat-constructor">%NumberFormat%</a></emu-xref>, <var>nf</var>) is <emu-val>true</emu-val>, then<ol><li>Return ?&nbsp;Get(<var>nf</var>, %Intl%.[[FallbackSymbol]]).</li></ol></li><li>Return <var>nf</var>.</li></ol></emu-alg>
     </emu-clause>
     </emu-normative-optional>
 
     <emu-clause id="sec-getnumberformatpattern" aoid="GetNumberFormatPattern">
       <h1><span class="secnum">1.5.11</span> GetNumberFormatPattern ( <var>numberFormat</var>, <var>x</var> )</h1>
       <p>
-        The abstract operation GetNumberFormatPattern considers the resolved unit-related options in the number format object along with the final scaled and rounded number being formatted and returns a pattern, a String value as described in <emu-xref href="#sec-intl.numberformat-internal-slots" id="_ref_9"><a href="#sec-intl.numberformat-internal-slots">1.2.3</a></emu-xref>.
+        The abstract operation GetNumberFormatPattern considers the resolved unit-related options in the number format object along with the final scaled and rounded number being formatted <ins>(an <emu-xref href="#intl-mathematical-value" id="_ref_69"><a href="#intl-mathematical-value">Intl mathematical value</a></emu-xref>)</ins> and returns a pattern, a String value as described in <emu-xref href="#sec-intl.numberformat-internal-slots" id="_ref_9"><a href="#sec-intl.numberformat-internal-slots">1.2.3</a></emu-xref>.
       </p>
-      <emu-alg><ol><li>Let <var>localeData</var> be <emu-xref href="#sec-intl-numberformat-constructor" id="_ref_96"><a href="#sec-intl-numberformat-constructor">%NumberFormat%</a></emu-xref>.[[LocaleData]].</li><li>Let <var>dataLocale</var> be <var>numberFormat</var>.[[DataLocale]].</li><li>Let <var>dataLocaleData</var> be <var>localeData</var>.[[&lt;<var>dataLocale</var>&gt;]].</li><li>Let <var>patterns</var> be <var>dataLocaleData</var>.[[patterns]].</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>patterns</var> is a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> (see <emu-xref href="#sec-intl.numberformat-internal-slots" id="_ref_10"><a href="#sec-intl.numberformat-internal-slots">1.2.3</a></emu-xref>).</li><li>Let <var>style</var> be <var>numberFormat</var>.[[Style]].</li><li>If <var>style</var> is <emu-val>"percent"</emu-val>, then<ol><li>Let <var>patterns</var> be <var>patterns</var>.[[percent]].</li></ol></li><li>Else if <var>style</var> is <emu-val>"unit"</emu-val>, then<ol><li>Let <var>unit</var> be <var>numberFormat</var>.[[Unit]].</li><li>Let <var>unitDisplay</var> be <var>numberFormat</var>.[[UnitDisplay]].</li><li>Let <var>patterns</var> be <var>patterns</var>.[[unit]].</li><li>If <var>patterns</var> doesn't have a field [[&lt;<var>unit</var>&gt;]], then<ol><li>Let <var>unit</var> be <emu-val>"fallback"</emu-val>.</li></ol></li><li>Let <var>patterns</var> be <var>patterns</var>.[[&lt;<var>unit</var>&gt;]].</li><li>Let <var>patterns</var> be <var>patterns</var>.[[&lt;<var>unitDisplay</var>&gt;]].</li></ol></li><li>Else if <var>style</var> is <emu-val>"currency"</emu-val>, then<ol><li>Let <var>currency</var> be <var>numberFormat</var>.[[Currency]].</li><li>Let <var>currencyDisplay</var> be <var>numberFormat</var>.[[CurrencyDisplay]].</li><li>Let <var>currencySign</var> be <var>numberFormat</var>.[[CurrencySign]].</li><li>Let <var>patterns</var> be <var>patterns</var>.[[currency]].</li><li>If <var>patterns</var> doesn't have a field [[&lt;<var>currency</var>&gt;]], then<ol><li>Let <var>currency</var> be <emu-val>"fallback"</emu-val>.</li></ol></li><li>Let <var>patterns</var> be <var>patterns</var>.[[&lt;<var>currency</var>&gt;]].</li><li>Let <var>patterns</var> be <var>patterns</var>.[[&lt;<var>currencyDisplay</var>&gt;]].</li><li>Let <var>patterns</var> be <var>patterns</var>.[[&lt;<var>currencySign</var>&gt;]].</li></ol></li><li>Else,<ol><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>style</var> is <emu-val>"decimal"</emu-val>.</li><li>Let <var>patterns</var> be <var>patterns</var>.[[decimal]].</li></ol></li><li>Let <var>signDisplay</var> be <var>numberFormat</var>.[[SignDisplay]].</li><li>If <var>signDisplay</var> is <emu-val>"never"</emu-val>, then<ol><li>Let <var>pattern</var> be <var>patterns</var>.[[zeroPattern]].</li></ol></li><li>Else if <var>signDisplay</var> is <emu-val>"auto"</emu-val>, then<ol><li>If <var>x</var> is 0 or <var>x</var> &gt; 0 or <var>x</var> is <emu-val>NaN</emu-val>, then<ol><li>Let <var>pattern</var> be <var>patterns</var>.[[zeroPattern]].</li></ol></li><li>Else,<ol><li>Let <var>pattern</var> be <var>patterns</var>.[[negativePattern]].</li></ol></li></ol></li><li>Else if <var>signDisplay</var> is <emu-val>"always"</emu-val>, then<ol><li>If <var>x</var> is 0 or <var>x</var> &gt; 0 or <var>x</var> is <emu-val>NaN</emu-val>, then<ol><li>Let <var>pattern</var> be <var>patterns</var>.[[positivePattern]].</li></ol></li><li>Else,<ol><li>Let <var>pattern</var> be <var>patterns</var>.[[negativePattern]].</li></ol></li></ol></li><li>Else <ins>if <var>signDisplay</var> is <emu-val>"exceptZero"</emu-val></ins>, then<ol><li><del class="block"><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>signDisplay</var> is <emu-val>"exceptZero"</emu-val>.</del></li><li>If <var>x</var> is <emu-val>NaN</emu-val>, or if <var>x</var> is finite and <emu-xref href="#ℝ"><a href="https://tc39.es/ecma262/#ℝ">ℝ</a></emu-xref>(<var>x</var>) is 0, then<ol><li>Let <var>pattern</var> be <var>patterns</var>.[[zeroPattern]].</li></ol></li><li>Else if <emu-xref href="#ℝ"><a href="https://tc39.es/ecma262/#ℝ">ℝ</a></emu-xref>(<var>x</var>) &gt; 0, then<ol><li>Let <var>pattern</var> be <var>patterns</var>.[[positivePattern]].</li></ol></li><li>Else,<ol><li>Let <var>pattern</var> be <var>patterns</var>.[[negativePattern]].</li></ol></li></ol></li><li><ins class="block">Else,</ins><ol><li><ins class="block"><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>signDisplay</var> is <emu-val>"negative"</emu-val>.</ins></li><li><ins class="block">If <var>x</var> is <emu-val>NaN</emu-val>, or if <var>x</var> is finite and <emu-xref href="#ℝ"><a href="https://tc39.es/ecma262/#ℝ">ℝ</a></emu-xref>(<var>x</var>) ≥ 0, then</ins><ol><li><ins class="block">Let <var>pattern</var> be <var>patterns</var>.[[zeroPattern]].</ins></li></ol></li><li><ins class="block">Else,</ins><ol><li><ins class="block">Let <var>pattern</var> be <var>patterns</var>.[[negativePattern]].</ins></li></ol></li></ol></li><li>Return <var>pattern</var>.</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>localeData</var> be <emu-xref href="#sec-intl-numberformat-constructor" id="_ref_70"><a href="#sec-intl-numberformat-constructor">%NumberFormat%</a></emu-xref>.[[LocaleData]].</li><li>Let <var>dataLocale</var> be <var>numberFormat</var>.[[DataLocale]].</li><li>Let <var>dataLocaleData</var> be <var>localeData</var>.[[&lt;<var>dataLocale</var>&gt;]].</li><li>Let <var>patterns</var> be <var>dataLocaleData</var>.[[patterns]].</li><li>Assert: <var>patterns</var> is a Record (see <emu-xref href="#sec-intl.numberformat-internal-slots" id="_ref_10"><a href="#sec-intl.numberformat-internal-slots">1.2.3</a></emu-xref>).</li><li>Let <var>style</var> be <var>numberFormat</var>.[[Style]].</li><li>If <var>style</var> is <emu-val>"percent"</emu-val>, then<ol><li>Let <var>patterns</var> be <var>patterns</var>.[[percent]].</li></ol></li><li>Else if <var>style</var> is <emu-val>"unit"</emu-val>, then<ol><li>Let <var>unit</var> be <var>numberFormat</var>.[[Unit]].</li><li>Let <var>unitDisplay</var> be <var>numberFormat</var>.[[UnitDisplay]].</li><li>Let <var>patterns</var> be <var>patterns</var>.[[unit]].</li><li>If <var>patterns</var> doesn't have a field [[&lt;<var>unit</var>&gt;]], then<ol><li>Let <var>unit</var> be <emu-val>"fallback"</emu-val>.</li></ol></li><li>Let <var>patterns</var> be <var>patterns</var>.[[&lt;<var>unit</var>&gt;]].</li><li>Let <var>patterns</var> be <var>patterns</var>.[[&lt;<var>unitDisplay</var>&gt;]].</li></ol></li><li>Else if <var>style</var> is <emu-val>"currency"</emu-val>, then<ol><li>Let <var>currency</var> be <var>numberFormat</var>.[[Currency]].</li><li>Let <var>currencyDisplay</var> be <var>numberFormat</var>.[[CurrencyDisplay]].</li><li>Let <var>currencySign</var> be <var>numberFormat</var>.[[CurrencySign]].</li><li>Let <var>patterns</var> be <var>patterns</var>.[[currency]].</li><li>If <var>patterns</var> doesn't have a field [[&lt;<var>currency</var>&gt;]], then<ol><li>Let <var>currency</var> be <emu-val>"fallback"</emu-val>.</li></ol></li><li>Let <var>patterns</var> be <var>patterns</var>.[[&lt;<var>currency</var>&gt;]].</li><li>Let <var>patterns</var> be <var>patterns</var>.[[&lt;<var>currencyDisplay</var>&gt;]].</li><li>Let <var>patterns</var> be <var>patterns</var>.[[&lt;<var>currencySign</var>&gt;]].</li></ol></li><li>Else,<ol><li>Assert: <var>style</var> is <emu-val>"decimal"</emu-val>.</li><li>Let <var>patterns</var> be <var>patterns</var>.[[decimal]].</li></ol></li><li><ins class="block">If <var>x</var> is <emu-const>negative-infinity</emu-const>, then</ins><ol><li><ins class="block">Let <var>category</var> be <emu-const>negative-nonzero</emu-const>.</ins></li></ol></li><li><ins class="block">Else if <var>x</var> is <emu-const>negative-zero</emu-const>, then</ins><ol><li><ins class="block">Let <var>category</var> be <emu-const>negative-zero</emu-const>.</ins></li></ol></li><li><ins class="block">Else if <var>x</var> is <emu-const>not-a-number</emu-const>, then</ins><ol><li><ins class="block">Let <var>category</var> be <emu-const>positive-zero</emu-const>.</ins></li></ol></li><li><ins class="block">Else if <var>x</var> is <emu-const>positive-infinity</emu-const>, then</ins><ol><li><ins class="block">Let <var>category</var> be <emu-const>positive-nonzero</emu-const>.</ins></li></ol></li><li><ins class="block">Else,</ins><ol><li><ins class="block">Assert: <var>x</var> is a mathematical value.</ins></li><li><ins class="block">If <var>x</var> &lt; 0, then</ins><ol><li><ins class="block">Let <var>category</var> be <emu-const>negative-nonzero</emu-const>.</ins></li></ol></li><li><ins class="block">Else if <var>x</var> &gt; 0, then</ins><ol><li><ins class="block">Let <var>category</var> be <emu-const>positive-nonzero</emu-const>.</ins></li></ol></li><li><ins class="block">Else,</ins><ol><li><ins class="block">Let <var>category</var> be <emu-const>positive-zero</emu-const>.</ins></li></ol></li></ol></li><li>Let <var>signDisplay</var> be <var>numberFormat</var>.[[SignDisplay]].</li><li>If <var>signDisplay</var> is <emu-val>"never"</emu-val>, then<ol><li>Let <var>pattern</var> be <var>patterns</var>.[[zeroPattern]].</li></ol></li><li>Else if <var>signDisplay</var> is <emu-val>"auto"</emu-val>, then<ol><li>If <del><var>x</var> is 0 or <var>x</var> &gt; 0 or <var>x</var> is <emu-val>NaN</emu-val></del><ins><var>category</var> is <emu-const>positive-nonzero</emu-const> or <emu-const>positive-zero</emu-const></ins>, then<ol><li>Let <var>pattern</var> be <var>patterns</var>.[[zeroPattern]].</li></ol></li><li>Else,<ol><li>Let <var>pattern</var> be <var>patterns</var>.[[negativePattern]].</li></ol></li></ol></li><li>Else if <var>signDisplay</var> is <emu-val>"always"</emu-val>, then<ol><li>If <del><var>x</var> is 0 or <var>x</var> &gt; 0 or <var>x</var> is <emu-val>NaN</emu-val></del><ins><var>category</var> is <emu-const>positive-nonzero</emu-const> or <emu-const>positive-zero</emu-const></ins>, then<ol><li>Let <var>pattern</var> be <var>patterns</var>.[[positivePattern]].</li></ol></li><li>Else,<ol><li>Let <var>pattern</var> be <var>patterns</var>.[[negativePattern]].</li></ol></li></ol></li><li>Else <ins>if <var>signDisplay</var> is <emu-val>"exceptZero"</emu-val></ins>, then<ol><li><del class="block">Assert: <var>signDisplay</var> is <emu-val>"exceptZero"</emu-val>.</del></li><li>If <del><var>x</var> is <emu-val>NaN</emu-val>, or if <var>x</var> is finite and ℝ(<var>x</var>) is 0</del><ins><var>category</var> is <emu-const>positive-zero</emu-const> or <emu-const>negative-zero</emu-const></ins>, then<ol><li>Let <var>pattern</var> be <var>patterns</var>.[[zeroPattern]].</li></ol></li><li>Else if <del>ℝ(<var>x</var>) &gt; 0</del><ins><var>category</var> is <emu-const>positive-nonzero</emu-const></ins>, then<ol><li>Let <var>pattern</var> be <var>patterns</var>.[[positivePattern]].</li></ol></li><li>Else,<ol><li>Let <var>pattern</var> be <var>patterns</var>.[[negativePattern]].</li></ol></li></ol></li><li><ins class="block">Else,</ins><ol><li><ins class="block">Assert: <var>signDisplay</var> is <emu-val>"negative"</emu-val>.</ins></li><li><ins class="block">If <var>category</var> is <emu-const>negative-nonzero</emu-const>, then</ins><ol><li><ins class="block">Let <var>pattern</var> be <var>patterns</var>.[[negativePattern]].</ins></li></ol></li><li><ins class="block">Else,</ins><ol><li><ins class="block">Let <var>pattern</var> be <var>patterns</var>.[[zeroPattern]].</ins></li></ol></li></ol></li><li>Return <var>pattern</var>.</li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-getnotationsubpattern" aoid="GetNotationSubPattern">
@@ -2731,7 +3507,7 @@ li.menu-search-result-term:before {
       <p>
         The abstract operation GetNotationSubPattern considers the resolved notation and <var>exponent</var>, and returns a String value for the notation sub pattern as described in <emu-xref href="#sec-intl.numberformat-internal-slots" id="_ref_11"><a href="#sec-intl.numberformat-internal-slots">1.2.3</a></emu-xref>.
       </p>
-      <emu-alg><ol><li>Let <var>localeData</var> be <emu-xref href="#sec-intl-numberformat-constructor" id="_ref_97"><a href="#sec-intl-numberformat-constructor">%NumberFormat%</a></emu-xref>.[[LocaleData]].</li><li>Let <var>dataLocale</var> be <var>numberFormat</var>.[[DataLocale]].</li><li>Let <var>dataLocaleData</var> be <var>localeData</var>.[[&lt;<var>dataLocale</var>&gt;]].</li><li>Let <var>notationSubPatterns</var> be <var>dataLocaleData</var>.[[notationSubPatterns]].</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>notationSubPatterns</var> is a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> (see <emu-xref href="#sec-intl.numberformat-internal-slots" id="_ref_12"><a href="#sec-intl.numberformat-internal-slots">1.2.3</a></emu-xref>).</li><li>Let <var>notation</var> be <var>numberFormat</var>.[[Notation]].</li><li>If <var>notation</var> is <emu-val>"scientific"</emu-val> or <var>notation</var> is <emu-val>"engineering"</emu-val>, then<ol><li>Return <var>notationSubPatterns</var>.[[scientific]].</li></ol></li><li>Else if <var>exponent</var> is not 0, then<ol><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>notation</var> is <emu-val>"compact"</emu-val>.</li><li>Let <var>compactDisplay</var> be <var>numberFormat</var>.[[CompactDisplay]].</li><li>Let <var>compactPatterns</var> be <var>notationSubPatterns</var>.[[compact]].[[&lt;<var>compactDisplay</var>&gt;]].</li><li>Return <var>compactPatterns</var>.[[&lt;<var>exponent</var>&gt;]].</li></ol></li><li>Else,<ol><li>Return <emu-val>"{number}"</emu-val>.</li></ol></li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>localeData</var> be <emu-xref href="#sec-intl-numberformat-constructor" id="_ref_71"><a href="#sec-intl-numberformat-constructor">%NumberFormat%</a></emu-xref>.[[LocaleData]].</li><li>Let <var>dataLocale</var> be <var>numberFormat</var>.[[DataLocale]].</li><li>Let <var>dataLocaleData</var> be <var>localeData</var>.[[&lt;<var>dataLocale</var>&gt;]].</li><li>Let <var>notationSubPatterns</var> be <var>dataLocaleData</var>.[[notationSubPatterns]].</li><li>Assert: <var>notationSubPatterns</var> is a Record (see <emu-xref href="#sec-intl.numberformat-internal-slots" id="_ref_12"><a href="#sec-intl.numberformat-internal-slots">1.2.3</a></emu-xref>).</li><li>Let <var>notation</var> be <var>numberFormat</var>.[[Notation]].</li><li>If <var>notation</var> is <emu-val>"scientific"</emu-val> or <var>notation</var> is <emu-val>"engineering"</emu-val>, then<ol><li>Return <var>notationSubPatterns</var>.[[scientific]].</li></ol></li><li>Else if <var>exponent</var> is not 0, then<ol><li>Assert: <var>notation</var> is <emu-val>"compact"</emu-val>.</li><li>Let <var>compactDisplay</var> be <var>numberFormat</var>.[[CompactDisplay]].</li><li>Let <var>compactPatterns</var> be <var>notationSubPatterns</var>.[[compact]].[[&lt;<var>compactDisplay</var>&gt;]].</li><li>Return <var>compactPatterns</var>.[[&lt;<var>exponent</var>&gt;]].</li></ol></li><li>Else,<ol><li>Return <emu-val>"{number}"</emu-val>.</li></ol></li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-computeexponent" aoid="ComputeExponent">
@@ -2740,7 +3516,7 @@ li.menu-search-result-term:before {
         The abstract operation ComputeExponent computes an exponent (power of ten) by which to scale <var>x</var> according to the number formatting settings.
         It handles cases such as 999 rounding up to 1000, requiring a different exponent.
       </p>
-      <emu-alg><ol><li>If <var>x</var> = 0, then<ol><li>Return 0.</li></ol></li><li>If <var>x</var> &lt; 0, then<ol><li>Let <var>x</var> = -<var>x</var>.</li></ol></li><li>Let <var>magnitude</var> be the base 10 logarithm of <var>x</var> rounded down to the nearest <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref>.</li><li>Let <var>exponent</var> be <emu-xref aoid="ComputeExponentForMagnitude" id="_ref_98"><a href="#sec-computeexponentformagnitude">ComputeExponentForMagnitude</a></emu-xref>(<var>numberFormat</var>, <var>magnitude</var>).</li><li>Let <var>x</var> be <var>x</var> × 10<sup>-<var>exponent</var></sup>.</li><li>Let <var>formatNumberResult</var> be <emu-xref aoid="FormatNumericToString" id="_ref_99"><a href="#sec-formatnumberstring">FormatNumericToString</a></emu-xref>(<var>numberFormat</var>, <var>x</var>).</li><li>If <var>formatNumberResult</var>.[[RoundedNumber]] = 0, then<ol><li>Return <var>exponent</var>.</li></ol></li><li>Let <var>newMagnitude</var> be the base 10 logarithm of <var>formatNumberResult</var>.[[RoundedNumber]] rounded down to the nearest <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref>.</li><li>If <var>newMagnitude</var> is <var>magnitude</var> - <var>exponent</var>, then<ol><li>Return <var>exponent</var>.</li></ol></li><li>Return <emu-xref aoid="ComputeExponentForMagnitude" id="_ref_100"><a href="#sec-computeexponentformagnitude">ComputeExponentForMagnitude</a></emu-xref>(<var>numberFormat</var>, <var>magnitude</var> + 1).</li></ol></emu-alg>
+      <emu-alg><ol><li>If <var>x</var> = 0, then<ol><li>Return 0.</li></ol></li><li>If <var>x</var> &lt; 0, then<ol><li>Let <var>x</var> = -<var>x</var>.</li></ol></li><li>Let <var>magnitude</var> be the base 10 logarithm of <var>x</var> rounded down to the nearest integer.</li><li>Let <var>exponent</var> be <emu-xref aoid="ComputeExponentForMagnitude" id="_ref_72"><a href="#sec-computeexponentformagnitude">ComputeExponentForMagnitude</a></emu-xref>(<var>numberFormat</var>, <var>magnitude</var>).</li><li>Let <var>x</var> be <var>x</var> × 10<sup>-<var>exponent</var></sup>.</li><li>Let <var>formatNumberResult</var> be <emu-xref aoid="FormatNumericToString" id="_ref_73"><a href="#sec-formatnumberstring">FormatNumericToString</a></emu-xref>(<var>numberFormat</var>, <var>x</var>).</li><li>If <var>formatNumberResult</var>.[[RoundedNumber]] = 0, then<ol><li>Return <var>exponent</var>.</li></ol></li><li>Let <var>newMagnitude</var> be the base 10 logarithm of <var>formatNumberResult</var>.[[RoundedNumber]] rounded down to the nearest integer.</li><li>If <var>newMagnitude</var> is <var>magnitude</var> - <var>exponent</var>, then<ol><li>Return <var>exponent</var>.</li></ol></li><li>Return <emu-xref aoid="ComputeExponentForMagnitude" id="_ref_74"><a href="#sec-computeexponentformagnitude">ComputeExponentForMagnitude</a></emu-xref>(<var>numberFormat</var>, <var>magnitude</var> + 1).</li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-computeexponentformagnitude" aoid="ComputeExponentForMagnitude">
@@ -2748,57 +3524,84 @@ li.menu-search-result-term:before {
       <p>
         The abstract operation <del>ComputeExponentHelper</del><ins>ComputeExponentForMagnitude</ins> computes an exponent by which to scale a number of the given magnitude (power of ten of the most significant digit) according to the locale and the desired notation (scientific, engineering, or compact).
       </p>
-      <emu-alg><ol><li>Let <var>notation</var> be <var>numberFormat</var>.[[Notation]].</li><li>If <var>notation</var> is <emu-val>"standard"</emu-val>, then<ol><li>Return 0.</li></ol></li><li>Else if <var>notation</var> is <emu-val>"scientific"</emu-val>, then<ol><li>Return <var>magnitude</var>.</li></ol></li><li>Else if <var>notation</var> is <emu-val>"engineering"</emu-val>, then<ol><li>Let <var>thousands</var> be the greatest <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref> that is not greater than <var>magnitude</var> / 3.</li><li>Return <var>thousands</var> × 3.</li></ol></li><li>Else,<ol><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>notation</var> is <emu-val>"compact"</emu-val>.</li><li>Let <var>exponent</var> be an implementation- and locale-dependent (ILD) <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref> by which to scale a number of the given magnitude in compact notation for the current locale.</li><li>Return <var>exponent</var>.</li></ol></li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>notation</var> be <var>numberFormat</var>.[[Notation]].</li><li>If <var>notation</var> is <emu-val>"standard"</emu-val>, then<ol><li>Return 0.</li></ol></li><li>Else if <var>notation</var> is <emu-val>"scientific"</emu-val>, then<ol><li>Return <var>magnitude</var>.</li></ol></li><li>Else if <var>notation</var> is <emu-val>"engineering"</emu-val>, then<ol><li>Let <var>thousands</var> be the greatest integer that is not greater than <var>magnitude</var> / 3.</li><li>Return <var>thousands</var> × 3.</li></ol></li><li>Else,<ol><li>Assert: <var>notation</var> is <emu-val>"compact"</emu-val>.</li><li>Let <var>exponent</var> be an implementation- and locale-dependent (ILD) integer by which to scale a number of the given magnitude in compact notation for the current locale.</li><li>Return <var>exponent</var>.</li></ol></li></ol></emu-alg>
     </emu-clause>
 
     <ins class="block">
-    <emu-clause id="sec-runtime-semantics-stringintlmv" type="sdo">
+    <emu-clause id="sec-runtime-semantics-stringintlmv" type="sdo" aoid="StringIntlMV">
       <h1><span class="secnum">1.5.15</span> Runtime Semantics: StringIntlMV</h1>
-      <dl class="header">
-      </dl>
+      <p>The syntax-directed operation StringIntlMV takes no arguments.</p>
       <emu-note><span class="note">Note</span><div class="note-contents">
-        <p>The conversion of a <emu-nt id="_ref_127"><a href="#prod-StringNumericLiteral">StringNumericLiteral</a></emu-nt> to a <emu-xref href="#number-value"><a href="https://tc39.es/ecma262/#number-value">Number value</a></emu-xref> is similar overall to the determination of the NumericValue of a <emu-nt><a href="https://tc39.es/ecma262/#prod-annexB-NumericLiteral">NumericLiteral</a></emu-nt> (see <emu-xref href="#sec-literals-numeric-literals"><a href="https://tc39.es/ecma262/#sec-literals-numeric-literals">11.8.3</a></emu-xref>), but some of the details are different.</p>
+        <p>The conversion of a <emu-nt>StringNumericLiteral</emu-nt> to a Number value is similar overall to the determination of the NumericValue of a <emu-nt>NumericLiteral</emu-nt> (see <emu-xref href="#sec-literals-numeric-literals"></emu-xref>), but some of the details are different.</p>
       </div></emu-note>
-      <emu-grammar><emu-production name="StringNumericLiteral" type="regexp" collapsed="" id="prod-StringNumericLiteral">
-    <emu-nt><a href="#prod-StringNumericLiteral">StringNumericLiteral</a></emu-nt><emu-geq>:::</emu-geq><emu-rhs a="9a4be900"><emu-nt optional=""><a href="https://tc39.es/ecma262/#prod-StrWhiteSpace">StrWhiteSpace</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt></emu-rhs>
-</emu-production></emu-grammar>
+      <p>It is defined piecewise over the following productions:</p>
+      <emu-grammar><emu-production name="StringNumericLiteral" type="regexp" collapsed="">
+    <emu-nt>StringNumericLiteral</emu-nt> <emu-geq>:::</emu-geq> <emu-rhs a="mkvpahdu"><emu-nt optional="">StrWhiteSpace<emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt></emu-rhs>
+</emu-production>
+</emu-grammar>
       <emu-alg><ol><li>Return 0.</li></ol></emu-alg>
       <emu-grammar><emu-production name="StringNumericLiteral" type="regexp" collapsed="">
-    <emu-nt><a href="#prod-StringNumericLiteral">StringNumericLiteral</a></emu-nt><emu-geq>:::</emu-geq><emu-rhs a="fe58c396"><emu-nt optional=""><a href="https://tc39.es/ecma262/#prod-StrWhiteSpace">StrWhiteSpace</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt><emu-nt id="_ref_128"><a href="#prod-StrNumericLiteral">StrNumericLiteral</a></emu-nt><emu-nt optional=""><a href="https://tc39.es/ecma262/#prod-StrWhiteSpace">StrWhiteSpace</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt></emu-rhs>
-</emu-production></emu-grammar>
-      <emu-alg><ol><li>Return StringIntlMV of <emu-nt id="_ref_129"><a href="#prod-StrNumericLiteral">StrNumericLiteral</a></emu-nt>.</li></ol></emu-alg>
-      <emu-grammar><emu-production name="StrNumericLiteral" type="regexp" collapsed="" id="prod-StrNumericLiteral">
-    <emu-nt><a href="#prod-StrNumericLiteral">StrNumericLiteral</a></emu-nt><emu-geq>:::</emu-geq><emu-rhs a="e867b70b"><emu-nt><a href="https://tc39.es/ecma262/#prod-NonDecimalIntegerLiteral">NonDecimalIntegerLiteral</a></emu-nt></emu-rhs>
-</emu-production></emu-grammar>
-      <emu-alg><ol><li>Return MV of <emu-nt><a href="https://tc39.es/ecma262/#prod-NonDecimalIntegerLiteral">NonDecimalIntegerLiteral</a></emu-nt>.</li></ol></emu-alg>
-      <emu-grammar><emu-production name="StrDecimalLiteral" type="regexp" collapsed="" id="prod-StrDecimalLiteral">
-    <emu-nt><a href="#prod-StrDecimalLiteral">StrDecimalLiteral</a></emu-nt><emu-geq>:::</emu-geq><emu-rhs a="d60f01a5"><emu-t>-</emu-t><emu-nt id="_ref_130"><a href="#prod-StrUnsignedDecimalLiteral">StrUnsignedDecimalLiteral</a></emu-nt></emu-rhs>
-</emu-production></emu-grammar>
-      <emu-alg><ol><li>Let <var>a</var> be StringIntlMV of <emu-nt id="_ref_131"><a href="#prod-StrUnsignedDecimalLiteral">StrUnsignedDecimalLiteral</a></emu-nt>.</li><li>If <var>a</var> is 0, return <emu-const>negative-zero</emu-const>.</li><li>If <var>a</var> is <emu-const>positive-infinity</emu-const>, return <emu-const>negative-infinity</emu-const>.</li><li>Return -<var>a</var>.</li></ol></emu-alg>
-      <emu-grammar><emu-production name="StrUnsignedDecimalLiteral" type="regexp" collapsed="" id="prod-StrUnsignedDecimalLiteral">
-    <emu-nt><a href="#prod-StrUnsignedDecimalLiteral">StrUnsignedDecimalLiteral</a></emu-nt><emu-geq>:::</emu-geq><emu-rhs a="4afe8df8"><emu-t>Infinity</emu-t></emu-rhs>
-</emu-production></emu-grammar>
+    <emu-nt>StringNumericLiteral</emu-nt> <emu-geq>:::</emu-geq> <emu-rhs a="_ljdljxm">
+        <emu-nt optional="">StrWhiteSpace<emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt>StrNumericLiteral</emu-nt>
+        <emu-nt optional="">StrWhiteSpace<emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+    </emu-rhs>
+</emu-production>
+</emu-grammar>
+      <emu-alg><ol><li>Return <emu-xref aoid="StringIntlMV" id="_ref_75"><a href="#sec-runtime-semantics-stringintlmv">StringIntlMV</a></emu-xref> of <emu-nt>StrNumericLiteral</emu-nt>.</li></ol></emu-alg>
+      <emu-grammar><emu-production name="StrNumericLiteral" type="regexp" collapsed="">
+    <emu-nt>StrNumericLiteral</emu-nt> <emu-geq>:::</emu-geq> <emu-rhs a="6ge3c7dq"><emu-nt>NonDecimalIntegerLiteral</emu-nt></emu-rhs>
+</emu-production>
+</emu-grammar>
+      <emu-alg><ol><li>Return MV of <emu-nt>NonDecimalIntegerLiteral</emu-nt>.</li></ol></emu-alg>
+      <emu-grammar><emu-production name="StrDecimalLiteral" type="regexp" collapsed="">
+    <emu-nt>StrDecimalLiteral</emu-nt> <emu-geq>:::</emu-geq> <emu-rhs a="1g8bpsll">
+        <emu-t>-</emu-t>
+        <emu-nt>StrUnsignedDecimalLiteral</emu-nt>
+    </emu-rhs>
+</emu-production>
+</emu-grammar>
+      <emu-alg><ol><li>Let <var>a</var> be <emu-xref aoid="StringIntlMV" id="_ref_76"><a href="#sec-runtime-semantics-stringintlmv">StringIntlMV</a></emu-xref> of <emu-nt>StrUnsignedDecimalLiteral</emu-nt>.</li><li>If <var>a</var> is 0, return <emu-const>negative-zero</emu-const>.</li><li>If <var>a</var> is <emu-const>positive-infinity</emu-const>, return <emu-const>negative-infinity</emu-const>.</li><li>Return -<var>a</var>.</li></ol></emu-alg>
+      <emu-grammar><emu-production name="StrUnsignedDecimalLiteral" type="regexp" collapsed="">
+    <emu-nt>StrUnsignedDecimalLiteral</emu-nt> <emu-geq>:::</emu-geq> <emu-rhs a="sv6n-gkb"><emu-t>Infinity</emu-t></emu-rhs>
+</emu-production>
+</emu-grammar>
       <emu-alg><ol><li>Return <emu-const>positive-infinity</emu-const>.</li></ol></emu-alg>
       <emu-grammar><emu-production name="StrUnsignedDecimalLiteral" type="regexp" collapsed="">
-    <emu-nt><a href="#prod-StrUnsignedDecimalLiteral">StrUnsignedDecimalLiteral</a></emu-nt><emu-geq>:::</emu-geq><emu-rhs a="8a89062c"><emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-DecimalDigits">DecimalDigits</a></emu-nt><emu-t>.</emu-t><emu-nt optional=""><a href="https://tc39.es/ecma262/#prod-grammar-notation-DecimalDigits">DecimalDigits</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt><emu-nt optional=""><a href="https://tc39.es/ecma262/#prod-ExponentPart">ExponentPart</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt></emu-rhs>
-</emu-production></emu-grammar>
-      <emu-alg><ol><li>Let <var>a</var> be MV of the first <emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-DecimalDigits">DecimalDigits</a></emu-nt>.</li><li>If the second <emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-DecimalDigits">DecimalDigits</a></emu-nt> is present, then<ol><li>Let <var>b</var> be MV of the second <emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-DecimalDigits">DecimalDigits</a></emu-nt>.</li><li>Let <var>n</var> be the number of code points in the second <emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-DecimalDigits">DecimalDigits</a></emu-nt>.</li></ol></li><li>Else,<ol><li>Let <var>b</var> be 0.</li><li>Let <var>n</var> be 0.</li></ol></li><li>If <emu-nt><a href="https://tc39.es/ecma262/#prod-ExponentPart">ExponentPart</a></emu-nt> is present, let <var>e</var> be MV of <emu-nt><a href="https://tc39.es/ecma262/#prod-ExponentPart">ExponentPart</a></emu-nt>. Otherwise, let <var>e</var> be 0.</li><li>Return (<var>a</var> + (<var>b</var> × 10<sup>-<var>n</var></sup>)) × 10<sup><var>e</var></sup>.</li></ol></emu-alg>
+    <emu-nt>StrUnsignedDecimalLiteral</emu-nt> <emu-geq>:::</emu-geq> <emu-rhs a="iokglhcc">
+        <emu-nt>DecimalDigits</emu-nt>
+        <emu-t>.</emu-t>
+        <emu-nt optional="">DecimalDigits<emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt optional="">ExponentPart<emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+    </emu-rhs>
+</emu-production>
+</emu-grammar>
+      <emu-alg><ol><li>Let <var>a</var> be MV of the first <emu-nt>DecimalDigits</emu-nt>.</li><li>If the second <emu-nt>DecimalDigits</emu-nt> is present, then<ol><li>Let <var>b</var> be MV of the second <emu-nt>DecimalDigits</emu-nt>.</li><li>Let <var>n</var> be the number of code points in the second <emu-nt>DecimalDigits</emu-nt>.</li></ol></li><li>Else,<ol><li>Let <var>b</var> be 0.</li><li>Let <var>n</var> be 0.</li></ol></li><li>If <emu-nt>ExponentPart</emu-nt> is present, let <var>e</var> be MV of <emu-nt>ExponentPart</emu-nt>. Otherwise, let <var>e</var> be 0.</li><li>Return (<var>a</var> + (<var>b</var> × 10<sup>-<var>n</var></sup>)) × 10<sup><var>e</var></sup>.</li></ol></emu-alg>
       <emu-grammar><emu-production name="StrUnsignedDecimalLiteral" type="regexp" collapsed="">
-    <emu-nt><a href="#prod-StrUnsignedDecimalLiteral">StrUnsignedDecimalLiteral</a></emu-nt><emu-geq>:::</emu-geq><emu-rhs a="5cf3aa35"><emu-t>.</emu-t><emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-DecimalDigits">DecimalDigits</a></emu-nt><emu-nt optional=""><a href="https://tc39.es/ecma262/#prod-ExponentPart">ExponentPart</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt></emu-rhs>
-</emu-production></emu-grammar>
-      <emu-alg><ol><li>Let <var>b</var> be MV of <emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-DecimalDigits">DecimalDigits</a></emu-nt>.</li><li>If <emu-nt><a href="https://tc39.es/ecma262/#prod-ExponentPart">ExponentPart</a></emu-nt> is present, let <var>e</var> be MV of <emu-nt><a href="https://tc39.es/ecma262/#prod-ExponentPart">ExponentPart</a></emu-nt>. Otherwise, let <var>e</var> be 0.</li><li>Let <var>n</var> be the number of code points in <emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-DecimalDigits">DecimalDigits</a></emu-nt>.</li><li>Return <var>b</var> × 10<sup><var>e</var> - <var>n</var></sup>.</li></ol></emu-alg>
+    <emu-nt>StrUnsignedDecimalLiteral</emu-nt> <emu-geq>:::</emu-geq> <emu-rhs a="xpoqnclz">
+        <emu-t>.</emu-t>
+        <emu-nt>DecimalDigits</emu-nt>
+        <emu-nt optional="">ExponentPart<emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+    </emu-rhs>
+</emu-production>
+</emu-grammar>
+      <emu-alg><ol><li>Let <var>b</var> be MV of <emu-nt>DecimalDigits</emu-nt>.</li><li>If <emu-nt>ExponentPart</emu-nt> is present, let <var>e</var> be MV of <emu-nt>ExponentPart</emu-nt>. Otherwise, let <var>e</var> be 0.</li><li>Let <var>n</var> be the number of code points in <emu-nt>DecimalDigits</emu-nt>.</li><li>Return <var>b</var> × 10<sup><var>e</var> - <var>n</var></sup>.</li></ol></emu-alg>
       <emu-grammar><emu-production name="StrUnsignedDecimalLiteral" type="regexp" collapsed="">
-    <emu-nt><a href="#prod-StrUnsignedDecimalLiteral">StrUnsignedDecimalLiteral</a></emu-nt><emu-geq>:::</emu-geq><emu-rhs a="24e27af7"><emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-DecimalDigits">DecimalDigits</a></emu-nt><emu-nt optional=""><a href="https://tc39.es/ecma262/#prod-ExponentPart">ExponentPart</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt></emu-rhs>
-</emu-production></emu-grammar>
-      <emu-alg><ol><li>Let <var>a</var> be MV of <emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-DecimalDigits">DecimalDigits</a></emu-nt>.</li><li>If <emu-nt><a href="https://tc39.es/ecma262/#prod-ExponentPart">ExponentPart</a></emu-nt> is present, let <var>e</var> be MV of <emu-nt><a href="https://tc39.es/ecma262/#prod-ExponentPart">ExponentPart</a></emu-nt>. Otherwise, let <var>e</var> be 0.</li><li>Return <var>a</var> × 10<sup><var>e</var></sup>.</li></ol></emu-alg>
+    <emu-nt>StrUnsignedDecimalLiteral</emu-nt> <emu-geq>:::</emu-geq> <emu-rhs a="joj696lw">
+        <emu-nt>DecimalDigits</emu-nt>
+        <emu-nt optional="">ExponentPart<emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+    </emu-rhs>
+</emu-production>
+</emu-grammar>
+      <emu-alg><ol><li>Let <var>a</var> be MV of <emu-nt>DecimalDigits</emu-nt>.</li><li>If <emu-nt>ExponentPart</emu-nt> is present, let <var>e</var> be MV of <emu-nt>ExponentPart</emu-nt>. Otherwise, let <var>e</var> be 0.</li><li>Return <var>a</var> × 10<sup><var>e</var></sup>.</li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-tointlmathematicalvalue" aoid="ToIntlMathematicalValue">
       <h1><span class="secnum">1.5.16</span> ToIntlMathematicalValue ( <var>value</var> )</h1>
       <p>
-        The abstract operation ToIntlMathematicalValue takes argument <var>value</var>. It returns <var>value</var> converted to an <dfn id="intl-mathematical-value">Intl mathematical value</dfn>, which is a <emu-xref href="#mathematical-value"><a href="https://tc39.es/ecma262/#mathematical-value">mathematical value</a></emu-xref> together with <emu-const>positive-infinity</emu-const>, <emu-const>negative-infinity</emu-const>, <emu-const>not-a-number</emu-const>, and <emu-const>negative-zero</emu-const>. This abstract operation is similar to <emu-xref href="#sec-tonumeric"><a href="https://tc39.es/ecma262/#sec-tonumeric">7.1.3</a></emu-xref>, but a <emu-xref href="#mathematical-value"><a href="https://tc39.es/ecma262/#mathematical-value">mathematical value</a></emu-xref> can be returned instead of a Number or BigInt, so that exact decimal values can be represented. The following steps are taken:
+        The abstract operation ToIntlMathematicalValue takes argument <var>value</var>. It returns <var>value</var> converted to an <dfn id="intl-mathematical-value">Intl mathematical value</dfn>, which is a mathematical value together with <emu-const>positive-infinity</emu-const>, <emu-const>negative-infinity</emu-const>, <emu-const>not-a-number</emu-const>, and <emu-const>negative-zero</emu-const>. This abstract operation is similar to <emu-xref href="#sec-tonumeric"></emu-xref>, but a mathematical value can be returned instead of a Number or BigInt, so that exact decimal values can be represented. The following steps are taken:
       </p>
-      <emu-alg><ol><li>Let <var>primValue</var> be ?&nbsp;<emu-xref aoid="ToPrimitive" id="_ref_101"><a href="https://tc39.es/ecma262/#sec-toprimitive">ToPrimitive</a></emu-xref>(<var>value</var>, <emu-const>number</emu-const>).</li><li>If <emu-xref aoid="Type" id="_ref_102"><a href="https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>primValue</var>) is BigInt, return <emu-xref href="#ℝ"><a href="https://tc39.es/ecma262/#ℝ">ℝ</a></emu-xref>(<var>primValue</var>).</li><li>If <emu-xref aoid="Type" id="_ref_103"><a href="https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>primValue</var>) is String,<ol><li>Let <var>str</var> be <var>primValue</var>.</li></ol></li><li>Else,<ol><li>Let <var>x</var> be ?&nbsp;<emu-xref aoid="ToNumber" id="_ref_104"><a href="https://tc39.es/ecma262/#sec-tonumber">ToNumber</a></emu-xref>(<var>primValue</var>).</li><li>If <var>x</var> is <emu-val>-0</emu-val><sub>𝔽</sub>, return <emu-const>negative-zero</emu-const>.</li><li>Let <var>str</var> be ! <emu-xref aoid="Number::toString" id="_ref_105"><a href="https://tc39.es/ecma262/#sec-numeric-types-number-tostring">Number::toString</a></emu-xref>(<var>x</var>).</li></ol></li><li>Let <var>text</var> be !&nbsp;StringToCodePoints(<var>str</var>).</li><li>Let <var>literal</var> be ParseText(<var>text</var>, <emu-nt id="_ref_132"><a href="#prod-StringNumericLiteral">StringNumericLiteral</a></emu-nt>).</li><li>If <var>literal</var> is a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> of errors, return <emu-const>not-a-number</emu-const>.</li><li>Return the StringIntlMV of <var>literal</var>.</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>primValue</var> be ?&nbsp;ToPrimitive(<var>value</var>, <emu-const>number</emu-const>).</li><li>If Type(<var>primValue</var>) is BigInt, return ℝ(<var>primValue</var>).</li><li>If Type(<var>primValue</var>) is String,<ol><li>Let <var>str</var> be <var>primValue</var>.</li></ol></li><li>Else,<ol><li>Let <var>x</var> be ?&nbsp;ToNumber(<var>primValue</var>).</li><li>If <var>x</var> is <emu-val>-0</emu-val><sub>𝔽</sub>, return <emu-const>negative-zero</emu-const>.</li><li>Let <var>str</var> be !&nbsp;Number::toString(<var>x</var>).</li></ol></li><li>Let <var>text</var> be !&nbsp;StringToCodePoints(<var>str</var>).</li><li>Let <var>literal</var> be ParseText(<var>text</var>, <emu-nt>StringNumericLiteral</emu-nt>).</li><li>If <var>literal</var> is a List of errors, return <emu-const>not-a-number</emu-const>.</li><li>Let <var>intlMV</var> be the <emu-xref aoid="StringIntlMV" id="_ref_77"><a href="#sec-runtime-semantics-stringintlmv">StringIntlMV</a></emu-xref> of <var>literal</var>.</li><li>If <var>intlMV</var> is a mathematical value, then<ol><li>Let <var>rounded</var> be RoundMVResult(abs(<var>intlMV</var>)).</li><li>If <var>rounded</var> is <emu-val>+∞</emu-val><sub>𝔽</sub> and <var>intlMV</var> &lt; 0, return <emu-const>negative-infinity</emu-const>.</li><li>If <var>rounded</var> is <emu-val>+∞</emu-val><sub>𝔽</sub>, return <emu-const>positive-infinity</emu-const>.</li><li>If <var>rounded</var> is <emu-val>+0</emu-val><sub>𝔽</sub> and <var>intlMV</var> &lt; 0, return <emu-const>negative-zero</emu-const>.</li><li>If <var>rounded</var> is <emu-val>+0</emu-val><sub>𝔽</sub>, return 0.</li></ol></li><li>Return <var>intlMV</var>.</li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-getunsignedroundingmode" aoid="GetUnsignedRoundingMode">
@@ -2905,34 +3708,37 @@ li.menu-search-result-term:before {
     <emu-clause id="sec-applyunsignedroundingmode" aoid="ApplyUnsignedRoundingMode">
       <h1><span class="secnum">1.5.18</span> ApplyUnsignedRoundingMode ( <var>x</var>, <var>r1</var>, <var>r2</var>, <var>unsignedRoundingMode</var> )</h1>
       <p>
-        The abstract operation ApplyUnsignedRoundingMode considers <var>x</var> (a <emu-xref href="#mathematical-value"><a href="https://tc39.es/ecma262/#mathematical-value">mathematical value</a></emu-xref>), bracketed below by <var>r1</var> (a <emu-xref href="#mathematical-value"><a href="https://tc39.es/ecma262/#mathematical-value">mathematical value</a></emu-xref>) and above by <var>r2</var> (a <emu-xref href="#mathematical-value"><a href="https://tc39.es/ecma262/#mathematical-value">mathematical value</a></emu-xref>), and returns either <var>r1</var> or <var>r2</var> according to <var>unsignedRoundingMode</var> (a specification type from the <emu-val>Unsigned Rounding Mode</emu-val> column of <emu-xref href="#table-intl-unsigned-rounding-modes" id="_ref_16"><a href="#table-intl-unsigned-rounding-modes">Table 4</a></emu-xref> or <emu-val>undefined</emu-val>). The following steps are taken:
+        The abstract operation ApplyUnsignedRoundingMode considers <var>x</var> (a mathematical value), bracketed below by <var>r1</var> (a mathematical value) and above by <var>r2</var> (a mathematical value), and returns either <var>r1</var> or <var>r2</var> according to <var>unsignedRoundingMode</var> (a specification type from the <emu-val>Unsigned Rounding Mode</emu-val> column of <emu-xref href="#table-intl-unsigned-rounding-modes" id="_ref_16"><a href="#table-intl-unsigned-rounding-modes">Table 4</a></emu-xref> or <emu-val>undefined</emu-val>). The following steps are taken:
       </p>
-      <emu-alg><ol><li>If <var>x</var> is equal to <var>r1</var>, return <var>r1</var>.</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>r1</var> &lt; <var>x</var> &lt; <var>r2</var>.</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>unsignedRoundingMode</var> is not <emu-val>undefined</emu-val>.</li><li>If <var>unsignedRoundingMode</var> is <emu-const>zero</emu-const>, return <var>r1</var>.</li><li>If <var>unsignedRoundingMode</var> is <emu-const>infinity</emu-const>, return <var>r2</var>.</li><li>Let <var>d1</var> be <emu-eqn class="inline"><var>x</var> – <var>r1</var></emu-eqn>.</li><li>Let <var>d2</var> be <emu-eqn class="inline"><var>r2</var> – <var>x</var></emu-eqn>.</li><li>If <var>d1</var> &lt; <var>d2</var>, return <var>r1</var>.</li><li>If <var>d2</var> &lt; <var>d1</var>, return <var>r2</var>.</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>d1</var> is equal to <var>d2</var>.</li><li>If <var>unsignedRoundingMode</var> is <emu-const>half-zero</emu-const>, return <var>r1</var>.</li><li>If <var>unsignedRoundingMode</var> is <emu-const>half-infinity</emu-const>, return <var>r2</var>.</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>unsignedRoundingMode</var> is <emu-const>half-even</emu-const>.</li><li>Let <var>cardinality</var> be <emu-eqn class="inline">(<var>r1</var> / (<var>r2</var> – <var>r1</var>)) <emu-xref aoid="modulo"><a href="https://tc39.es/ecma262/#eqn-modulo">modulo</a></emu-xref> 2</emu-eqn>.</li><li>If <var>cardinality</var> is 0, return <var>r1</var>.</li><li>Return <var>r2</var>.</li></ol></emu-alg>
+      <emu-alg><ol><li>If <var>x</var> is equal to <var>r1</var>, return <var>r1</var>.</li><li>Assert: <var>r1</var> &lt; <var>x</var> &lt; <var>r2</var>.</li><li>Assert: <var>unsignedRoundingMode</var> is not <emu-val>undefined</emu-val>.</li><li>If <var>unsignedRoundingMode</var> is <emu-const>zero</emu-const>, return <var>r1</var>.</li><li>If <var>unsignedRoundingMode</var> is <emu-const>infinity</emu-const>, return <var>r2</var>.</li><li>Let <var>d1</var> be <emu-eqn class="inline"><var>x</var> – <var>r1</var></emu-eqn>.</li><li>Let <var>d2</var> be <emu-eqn class="inline"><var>r2</var> – <var>x</var></emu-eqn>.</li><li>If <var>d1</var> &lt; <var>d2</var>, return <var>r1</var>.</li><li>If <var>d2</var> &lt; <var>d1</var>, return <var>r2</var>.</li><li>Assert: <var>d1</var> is equal to <var>d2</var>.</li><li>If <var>unsignedRoundingMode</var> is <emu-const>half-zero</emu-const>, return <var>r1</var>.</li><li>If <var>unsignedRoundingMode</var> is <emu-const>half-infinity</emu-const>, return <var>r2</var>.</li><li>Assert: <var>unsignedRoundingMode</var> is <emu-const>half-even</emu-const>.</li><li>Let <var>cardinality</var> be <emu-eqn class="inline">(<var>r1</var> / (<var>r2</var> – <var>r1</var>)) modulo 2</emu-eqn>.</li><li>If <var>cardinality</var> is 0, return <var>r1</var>.</li><li>Return <var>r2</var>.</li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-partitionnumberrangepattern" aoid="PartitionNumberRangePattern">
       <h1><span class="secnum">1.5.19</span> PartitionNumberRangePattern ( <var>numberFormat</var>, <var>x</var>, <var>y</var> )</h1>
       <p>
-        The abstract operation PartitionNumberRangePattern creates the parts for a localized number range according to <var>x</var> (which must be an <emu-xref href="#intl-mathematical-value" id="_ref_106"><a href="#intl-mathematical-value">Intl mathematical value</a></emu-xref>), <var>y</var> (which must be an <emu-xref href="#intl-mathematical-value" id="_ref_107"><a href="#intl-mathematical-value">Intl mathematical value</a></emu-xref>), and the formatting options of <var>numberFormat</var> (which must be an object initialized as NumberFormat). The following steps are taken:
+        The abstract operation PartitionNumberRangePattern creates the parts for a localized number range according to <var>x</var> (which must be an <emu-xref href="#intl-mathematical-value" id="_ref_78"><a href="#intl-mathematical-value">Intl mathematical value</a></emu-xref>), <var>y</var> (which must be an <emu-xref href="#intl-mathematical-value" id="_ref_79"><a href="#intl-mathematical-value">Intl mathematical value</a></emu-xref>), and the formatting options of <var>numberFormat</var> (which must be an object initialized as NumberFormat). The following steps are taken:
       </p>
-      <emu-alg><ol><li>If <var>x</var> is <emu-const>not-a-number</emu-const> or <var>y</var> is <emu-const>not-a-number</emu-const>, throw a <emu-val>RangeError</emu-val> exception.</li><li>Let <var>result</var> be a new empty <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref>.</li><li>Let <var>xResult</var> be ?&nbsp;<emu-xref aoid="PartitionNumberPattern" id="_ref_108"><a href="#sec-partitionnumberpattern">PartitionNumberPattern</a></emu-xref>(<var>numberFormat</var>, <var>x</var>).</li><li>Let <var>yResult</var> be ?&nbsp;<emu-xref aoid="PartitionNumberPattern" id="_ref_109"><a href="#sec-partitionnumberpattern">PartitionNumberPattern</a></emu-xref>(<var>numberFormat</var>, <var>y</var>).</li><li>If <var>xResult</var> is equal to <var>yResult</var>, then<ol><li>Let <var>appxResult</var> be ?&nbsp;<emu-xref aoid="FormatApproximately" id="_ref_110"><a href="#sec-formatapproximately">FormatApproximately</a></emu-xref>(<var>numberFormat</var>, <var>xResult</var>).</li><li>For each <var>r</var> in <var>appxResult</var>, do<ol><li>Set <var>r</var>.[[Source]] to <emu-val>"shared"</emu-val>.</li></ol></li><li>Return <var>appxResult</var>.</li></ol></li><li>For each <var>r</var> in <var>xResult</var>, do<ol><li>Set <var>r</var>.[[Source]] to <emu-val>"startRange"</emu-val>.</li></ol></li><li>Add all elements in <var>xResult</var> to <var>result</var> in order.</li><li>Let <var>rangeSeparator</var> be an ILND String value used to separate two numbers.</li><li>Append a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]]: <emu-val>"literal"</emu-val>, [[Value]]: <var>rangeSeparator</var>, [[Source]]: <emu-val>"shared"</emu-val> } element to <var>result</var>.</li><li>For each <var>r</var> in <var>yResult</var>, do<ol><li>Set <var>r</var>.[[Source]] to <emu-val>"endRange"</emu-val>.</li></ol></li><li>Add all elements in <var>yResult</var> to <var>result</var> in order.</li><li>Return !&nbsp;<emu-xref aoid="CollapseNumberRange" id="_ref_111"><a href="#sec-collapsenumberrange">CollapseNumberRange</a></emu-xref>(<var>result</var>).</li></ol></emu-alg>
+      <emu-alg><ol><li>If <var>x</var> is <emu-const>not-a-number</emu-const> or <var>y</var> is <emu-const>not-a-number</emu-const>, throw a <emu-val>RangeError</emu-val> exception.</li><li>Let <var>result</var> be a new empty List.</li><li>Let <var>xResult</var> be ?&nbsp;<emu-xref aoid="PartitionNumberPattern" id="_ref_80"><a href="#sec-partitionnumberpattern">PartitionNumberPattern</a></emu-xref>(<var>numberFormat</var>, <var>x</var>).</li><li>Let <var>yResult</var> be ?&nbsp;<emu-xref aoid="PartitionNumberPattern" id="_ref_81"><a href="#sec-partitionnumberpattern">PartitionNumberPattern</a></emu-xref>(<var>numberFormat</var>, <var>y</var>).</li><li>If <var>xResult</var> is equal to <var>yResult</var>, then<ol><li>Let <var>appxResult</var> be ?&nbsp;<emu-xref aoid="FormatApproximately" id="_ref_82"><a href="#sec-formatapproximately">FormatApproximately</a></emu-xref>(<var>numberFormat</var>, <var>xResult</var>).</li><li>For each <var>r</var> in <var>appxResult</var>, do<ol><li>Set <var>r</var>.[[Source]] to <emu-val>"shared"</emu-val>.</li></ol></li><li>Return <var>appxResult</var>.</li></ol></li><li>For each <var>r</var> in <var>xResult</var>, do<ol><li>Set <var>r</var>.[[Source]] to <emu-val>"startRange"</emu-val>.</li></ol></li><li>Add all elements in <var>xResult</var> to <var>result</var> in order.</li><li>Let <var>rangeSeparator</var> be an ILND String value used to separate two numbers.</li><li>Append a new Record { [[Type]]: <emu-val>"literal"</emu-val>, [[Value]]: <var>rangeSeparator</var>, [[Source]]: <emu-val>"shared"</emu-val> } element to <var>result</var>.</li><li>For each <var>r</var> in <var>yResult</var>, do<ol><li>Set <var>r</var>.[[Source]] to <emu-val>"endRange"</emu-val>.</li></ol></li><li>Add all elements in <var>yResult</var> to <var>result</var> in order.</li><li>Return !&nbsp;<emu-xref aoid="CollapseNumberRange" id="_ref_83"><a href="#sec-collapsenumberrange">CollapseNumberRange</a></emu-xref>(<var>result</var>).</li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-formatapproximately" aoid="FormatApproximately">
       <h1><span class="secnum">1.5.20</span> FormatApproximately ( <var>numberFormat</var>, <var>result</var> )</h1>
       <p>
-        The FormatApproximately abstract operation modifies <var>result</var>, which must be a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> of <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> values as described in <emu-xref aoid="PartitionNumberPattern" id="_ref_112"><a href="#sec-partitionnumberpattern">PartitionNumberPattern</a></emu-xref>, by adding a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> for the approximately sign, which may depend on <var>numberFormat</var> (which must be an object initialized as NumberFormat). The following steps are taken:
+        The FormatApproximately abstract operation modifies <var>result</var>, which must be a List of Record values as described in <emu-xref aoid="PartitionNumberPattern" id="_ref_84"><a href="#sec-partitionnumberpattern">PartitionNumberPattern</a></emu-xref>, by adding a new Record for the approximately sign, which may depend on <var>numberFormat</var> (which must be an object initialized as NumberFormat). The following steps are taken:
       </p>
-      <emu-alg><ol><li>Let <var>i</var> be an index into <var>result</var>, determined by an implementation-defined algorithm based on <var>numberFormat</var> and <var>result</var>.</li><li>Let <var>approximatelySign</var> be an ILND String value used to signify that a number is approximate.</li><li>Insert a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]]: <emu-val>"approximatelySign"</emu-val>, [[Value]]: <var>approximatelySign</var> } at index <var>i</var> in <var>result</var>.</li><li>Return <var>result</var>.</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>i</var> be an index into <var>result</var>, determined by an implementation-defined algorithm based on <var>numberFormat</var> and <var>result</var>.</li><li>Let <var>approximatelySign</var> be an ILND String value used to signify that a number is approximate.</li><li>If <var>approximatelySign</var> is not empty, insert a new Record { [[Type]]: <emu-val>"approximatelySign"</emu-val>, [[Value]]: <var>approximatelySign</var> } at index <var>i</var> in <var>result</var>.</li><li>Return <var>result</var>.</li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-collapsenumberrange" aoid="CollapseNumberRange">
       <h1><span class="secnum">1.5.21</span> CollapseNumberRange ( <var>result</var> )</h1>
       <p>
-        The CollapseNumberRange abstract operation modifies <var>result</var>, which must be a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> of <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> values as described in <emu-xref aoid="PartitionNumberRangePattern" id="_ref_113"><a href="#sec-partitionnumberrangepattern">PartitionNumberRangePattern</a></emu-xref>, by removing redundant information, and returns the resulting <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref>. The algorithm is implementation dependent, but it must not introduce ambiguity: the resulting list after modification should be unique for all pairs <var>x</var> and <var>y</var>.
+        The CollapseNumberRange abstract operation modifies <var>result</var>, which must be a List of Record values as described in <emu-xref aoid="PartitionNumberRangePattern" id="_ref_85"><a href="#sec-partitionnumberrangepattern">PartitionNumberRangePattern</a></emu-xref>, by removing redundant information, and returns the resulting List. The algorithm is implementation dependent, but it must not introduce ambiguity: the resulting list after modification should be unique for all pairs <var>x</var> and <var>y</var>.
       </p>
       <p>
         For example, an implementation may choose to remove the currency symbol following the range separator, to produce "$3–5" instead of "$3–$5".
+      </p>
+      <p>
+        The implementation may choose to modify symbols for grammatical correctness; for example, "0.5 miles–1 mile" may become "0.5–1 miles".
       </p>
       <p>
         Returning <var>result</var> unmodified is guaranteed to be a correct implementation of CollapseNumberRange.
@@ -2943,20 +3749,20 @@ li.menu-search-result-term:before {
       <h1><span class="secnum">1.5.22</span> FormatNumericRange( <var>numberFormat</var>, <var>x</var>, <var>y</var> )</h1>
 
       <p>
-        The FormatNumericRange abstract operation is called with arguments <var>numberFormat</var> (which must be an object initialized as a NumberFormat), <var>x</var> (which must be an <emu-xref href="#intl-mathematical-value" id="_ref_114"><a href="#intl-mathematical-value">Intl mathematical value</a></emu-xref>), and <var>y</var> (which must be an <emu-xref href="#intl-mathematical-value" id="_ref_115"><a href="#intl-mathematical-value">Intl mathematical value</a></emu-xref> greater than or equal to <var>x</var>), and performs the following steps:
+        The FormatNumericRange abstract operation is called with arguments <var>numberFormat</var> (which must be an object initialized as a NumberFormat), <var>x</var> (which must be an <emu-xref href="#intl-mathematical-value" id="_ref_86"><a href="#intl-mathematical-value">Intl mathematical value</a></emu-xref>), and <var>y</var> (which must be an <emu-xref href="#intl-mathematical-value" id="_ref_87"><a href="#intl-mathematical-value">Intl mathematical value</a></emu-xref> greater than or equal to <var>x</var>), and performs the following steps:
       </p>
 
-      <emu-alg><ol><li>Let <var>parts</var> be ?&nbsp;<emu-xref aoid="PartitionNumberRangePattern" id="_ref_116"><a href="#sec-partitionnumberrangepattern">PartitionNumberRangePattern</a></emu-xref>(<var>numberFormat</var>, <var>x</var>, <var>y</var>).</li><li>Let <var>result</var> be the empty String.</li><li>For each <var>part</var> in <var>parts</var>, do<ol><li>Set <var>result</var> to the <emu-xref href="#sec-ecmascript-language-types-string-type"><a href="https://tc39.es/ecma262/#sec-ecmascript-language-types-string-type">string-concatenation</a></emu-xref> of <var>result</var> and <var>part</var>.[[Value]].</li></ol></li><li>Return <var>result</var>.</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>parts</var> be ?&nbsp;<emu-xref aoid="PartitionNumberRangePattern" id="_ref_88"><a href="#sec-partitionnumberrangepattern">PartitionNumberRangePattern</a></emu-xref>(<var>numberFormat</var>, <var>x</var>, <var>y</var>).</li><li>Let <var>result</var> be the empty String.</li><li>For each <var>part</var> in <var>parts</var>, do<ol><li>Set <var>result</var> to the string-concatenation of <var>result</var> and <var>part</var>.[[Value]].</li></ol></li><li>Return <var>result</var>.</li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-formatnumericrangetoparts" aoid="FormatNumericRangeToParts">
       <h1><span class="secnum">1.5.23</span> FormatNumericRangeToParts( <var>numberFormat</var>, <var>x</var>, <var>y</var> )</h1>
 
       <p>
-        The FormatNumericRangeToParts abstract operation is called with arguments <var>numberFormat</var> (which must be an object initialized as a NumberFormat), <var>x</var> (which must be an <emu-xref href="#intl-mathematical-value" id="_ref_117"><a href="#intl-mathematical-value">Intl mathematical value</a></emu-xref>), and <var>y</var> (which must be an <emu-xref href="#intl-mathematical-value" id="_ref_118"><a href="#intl-mathematical-value">Intl mathematical value</a></emu-xref> greater than or equal to <var>x</var>), and performs the following steps:
+        The FormatNumericRangeToParts abstract operation is called with arguments <var>numberFormat</var> (which must be an object initialized as a NumberFormat), <var>x</var> (which must be an <emu-xref href="#intl-mathematical-value" id="_ref_89"><a href="#intl-mathematical-value">Intl mathematical value</a></emu-xref>), and <var>y</var> (which must be an <emu-xref href="#intl-mathematical-value" id="_ref_90"><a href="#intl-mathematical-value">Intl mathematical value</a></emu-xref> greater than or equal to <var>x</var>), and performs the following steps:
       </p>
 
-      <emu-alg><ol><li>Let <var>parts</var> be ?&nbsp;<emu-xref aoid="PartitionNumberRangePattern" id="_ref_119"><a href="#sec-partitionnumberrangepattern">PartitionNumberRangePattern</a></emu-xref>(<var>numberFormat</var>, <var>x</var>, <var>y</var>).</li><li>Let <var>result</var> be <emu-xref aoid="ArrayCreate" id="_ref_120"><a href="https://tc39.es/ecma262/#sec-arraycreate">ArrayCreate</a></emu-xref>(0).</li><li>Let <var>n</var> be 0.</li><li>For each <var>part</var> in <var>parts</var>, do<ol><li>Let <var>O</var> be <emu-xref aoid="ObjectCreate" id="_ref_121"><a href="https://tc39.es/ecma262/#sec-objectcreate">ObjectCreate</a></emu-xref>(<emu-xref href="#sec-properties-of-the-object-prototype-object"><a href="https://tc39.es/ecma262/#sec-properties-of-the-object-prototype-object">%ObjectPrototype%</a></emu-xref>).</li><li>Perform !&nbsp;<emu-xref aoid="CreateDataPropertyOrThrow" id="_ref_122"><a href="https://tc39.es/ecma262/#sec-createdatapropertyorthrow">CreateDataPropertyOrThrow</a></emu-xref>(<var>O</var>, <emu-val>"type"</emu-val>, <var>part</var>.[[Type]]).</li><li>Perform !&nbsp;<emu-xref aoid="CreateDataPropertyOrThrow" id="_ref_123"><a href="https://tc39.es/ecma262/#sec-createdatapropertyorthrow">CreateDataPropertyOrThrow</a></emu-xref>(<var>O</var>, <emu-val>"value"</emu-val>, <var>part</var>.[[Value]]).</li><li>Perform !&nbsp;<emu-xref aoid="CreateDataPropertyOrThrow" id="_ref_124"><a href="https://tc39.es/ecma262/#sec-createdatapropertyorthrow">CreateDataPropertyOrThrow</a></emu-xref>(<var>O</var>, <emu-val>"source"</emu-val>, <var>part</var>.[[Source]]).</li><li>Perform !&nbsp;<emu-xref aoid="CreateDataPropertyOrThrow" id="_ref_125"><a href="https://tc39.es/ecma262/#sec-createdatapropertyorthrow">CreateDataPropertyOrThrow</a></emu-xref>(<var>result</var>, !&nbsp;<emu-xref aoid="ToString" id="_ref_126"><a href="https://tc39.es/ecma262/#sec-tostring">ToString</a></emu-xref>(<var>n</var>), <var>O</var>).</li><li>Increment <var>n</var> by 1.</li></ol></li><li>Return <var>result</var>.</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>parts</var> be ?&nbsp;<emu-xref aoid="PartitionNumberRangePattern" id="_ref_91"><a href="#sec-partitionnumberrangepattern">PartitionNumberRangePattern</a></emu-xref>(<var>numberFormat</var>, <var>x</var>, <var>y</var>).</li><li>Let <var>result</var> be ArrayCreate(0).</li><li>Let <var>n</var> be 0.</li><li>For each <var>part</var> in <var>parts</var>, do<ol><li>Let <var>O</var> be ObjectCreate(%ObjectPrototype%).</li><li>Perform !&nbsp;CreateDataPropertyOrThrow(<var>O</var>, <emu-val>"type"</emu-val>, <var>part</var>.[[Type]]).</li><li>Perform !&nbsp;CreateDataPropertyOrThrow(<var>O</var>, <emu-val>"value"</emu-val>, <var>part</var>.[[Value]]).</li><li>Perform !&nbsp;CreateDataPropertyOrThrow(<var>O</var>, <emu-val>"source"</emu-val>, <var>part</var>.[[Source]]).</li><li>Perform !&nbsp;CreateDataPropertyOrThrow(<var>result</var>, !&nbsp;ToString(<var>n</var>), <var>O</var>).</li><li>Increment <var>n</var> by 1.</li></ol></li><li>Return <var>result</var>.</li></ol></emu-alg>
     </emu-clause>
     </ins>
   </emu-clause>

--- a/out/numberformat/proposed.html
+++ b/out/numberformat/proposed.html
@@ -1,6 +1,88 @@
 <!doctype html>
-<head><meta charset="utf-8"><script type="application/json" id="menu-search-biblio">[{"type":"term","term":"%NumberFormat%","refId":"sec-intl-numberformat-constructor","referencingIds":[],"namespace":"<no location>","location":"","key":"%NumberFormat%"},{"type":"op","aoid":"ChainNumberFormat","refId":"sec-chainnumberformat","location":"","referencingIds":[],"key":"ChainNumberFormat"},{"type":"clause","id":"sec-chainnumberformat","aoid":"ChainNumberFormat","title":"ChainNumberFormat ( numberFormat, newTarget, this )","titleHTML":"ChainNumberFormat ( <var>numberFormat</var>, <var>newTarget</var>, <var>this</var> )","number":"1.1.1.1","namespace":"<no location>","location":"","referencingIds":["_ref_19"],"key":"ChainNumberFormat ( numberFormat, newTarget, this )"},{"type":"clause","id":"sec-intl.numberformat","aoid":null,"title":"Intl.NumberFormat ( [ locales [ , options ] ] )","titleHTML":"Intl.NumberFormat ( [ <var>locales</var> [ , <var>options</var> ] ] )","number":"1.1.1","namespace":"<no location>","location":"","referencingIds":[],"key":"Intl.NumberFormat ( [ locales [ , options ] ] )"},{"type":"op","aoid":"InitializeNumberFormat","refId":"sec-initializenumberformat","location":"","referencingIds":[],"key":"InitializeNumberFormat"},{"type":"clause","id":"sec-initializenumberformat","aoid":"InitializeNumberFormat","title":"InitializeNumberFormat ( numberFormat, locales, options )","titleHTML":"InitializeNumberFormat ( <var>numberFormat</var>, <var>locales</var>, <var>options</var> )","number":"1.1.2","namespace":"<no location>","location":"","referencingIds":["_ref_18"],"key":"InitializeNumberFormat ( numberFormat, locales, options )"},{"type":"op","aoid":"SetNumberFormatDigitOptions","refId":"sec-setnfdigitoptions","location":"","referencingIds":[],"key":"SetNumberFormatDigitOptions"},{"type":"clause","id":"sec-setnfdigitoptions","aoid":"SetNumberFormatDigitOptions","title":"SetNumberFormatDigitOptions ( intlObj, options, mnfdDefault, mxfdDefault, notation )","titleHTML":"SetNumberFormatDigitOptions ( <var>intlObj</var>, <var>options</var>, <var>mnfdDefault</var>, <var>mxfdDefault</var>, <var>notation</var> )","number":"1.1.3","namespace":"<no location>","location":"","referencingIds":["_ref_28"],"key":"SetNumberFormatDigitOptions ( intlObj, options, mnfdDefault, mxfdDefault, notation )"},{"type":"op","aoid":"SetNumberFormatUnitOptions","refId":"sec-setnumberformatunitoptions","location":"","referencingIds":[],"key":"SetNumberFormatUnitOptions"},{"type":"clause","id":"sec-setnumberformatunitoptions","aoid":"SetNumberFormatUnitOptions","title":"SetNumberFormatUnitOptions ( intlObj, options )","titleHTML":"SetNumberFormatUnitOptions ( <var>intlObj</var>, <var>options</var> )","number":"1.1.4","namespace":"<no location>","location":"","referencingIds":["_ref_26"],"key":"SetNumberFormatUnitOptions ( intlObj, options )"},{"type":"clause","id":"sec-intl-numberformat-constructor","aoid":null,"title":"The Intl.NumberFormat Constructor","titleHTML":"The Intl.NumberFormat Constructor","number":"1.1","namespace":"<no location>","location":"","referencingIds":["_ref_21","_ref_23","_ref_24","_ref_25","_ref_36","_ref_37","_ref_87","_ref_90","_ref_92","_ref_93"],"key":"The Intl.NumberFormat Constructor"},{"type":"clause","id":"sec-intl.numberformat.prototype","aoid":null,"title":"Intl.NumberFormat.prototype","titleHTML":"Intl.NumberFormat.prototype","number":"1.2.1","namespace":"<no location>","location":"","referencingIds":[],"key":"Intl.NumberFormat.prototype"},{"type":"clause","id":"sec-intl.numberformat.supportedlocalesof","aoid":null,"title":"Intl.NumberFormat.supportedLocalesOf ( locales [ , options ] )","titleHTML":"Intl.NumberFormat.supportedLocalesOf ( <var>locales</var> [ , <var>options</var> ] )","number":"1.2.2","namespace":"<no location>","location":"","referencingIds":[],"key":"Intl.NumberFormat.supportedLocalesOf ( locales [ , options ] )"},{"type":"clause","id":"sec-intl.numberformat-internal-slots","aoid":null,"title":"Internal slots","titleHTML":"Internal slots","number":"1.2.3","namespace":"<no location>","location":"","referencingIds":["_ref_9","_ref_10","_ref_11","_ref_12"],"key":"Internal slots"},{"type":"clause","id":"sec-properties-of-intl-numberformat-constructor","aoid":null,"title":"Properties of the Intl.NumberFormat Constructor","titleHTML":"Properties of the Intl.NumberFormat Constructor","number":"1.2","namespace":"<no location>","location":"","referencingIds":[],"key":"Properties of the Intl.NumberFormat Constructor"},{"type":"term","term":"%NumberFormat.prototype%","refId":"sec-properties-of-intl-numberformat-prototype-object","referencingIds":[],"namespace":"<no location>","location":"","key":"%NumberFormat.prototype%"},{"type":"clause","id":"sec-intl.numberformat.prototype.constructor","aoid":null,"title":"Intl.NumberFormat.prototype.constructor","titleHTML":"Intl.NumberFormat.prototype.constructor","number":"1.3.1","namespace":"<no location>","location":"","referencingIds":[],"key":"Intl.NumberFormat.prototype.constructor"},{"type":"clause","id":"sec-intl.numberformat.prototype-@@tostringtag","aoid":null,"title":"Intl.NumberFormat.prototype [ @@toStringTag ]","titleHTML":"Intl.NumberFormat.prototype [ @@toStringTag ]","number":"1.3.2","namespace":"<no location>","location":"","referencingIds":[],"key":"Intl.NumberFormat.prototype [ @@toStringTag ]"},{"type":"clause","id":"sec-intl.numberformat.prototype.format","aoid":null,"title":"get Intl.NumberFormat.prototype.format","titleHTML":"get Intl.NumberFormat.prototype.format","number":"1.3.3","namespace":"<no location>","location":"","referencingIds":["_ref_4"],"key":"get Intl.NumberFormat.prototype.format"},{"type":"clause","id":"sec-intl.numberformat.prototype.formattoparts","aoid":null,"title":"Intl.NumberFormat.prototype.formatToParts ( value )","titleHTML":"Intl.NumberFormat.prototype.formatToParts ( <var>value</var> )","number":"1.3.4","namespace":"<no location>","location":"","referencingIds":[],"key":"Intl.NumberFormat.prototype.formatToParts ( value )"},{"type":"clause","id":"sec-intl.numberformat.prototype.formatrange","aoid":null,"title":"Intl.NumberFormat.prototype.formatRange ( start, end )","titleHTML":"Intl.NumberFormat.prototype.formatRange ( <var>start</var>, <var>end</var> )","number":"1.3.5","namespace":"<no location>","location":"","referencingIds":[],"key":"Intl.NumberFormat.prototype.formatRange ( start, end )"},{"type":"clause","id":"sec-intl.numberformat.prototype.formatrangetoparts","aoid":null,"title":"Intl.NumberFormat.prototype.formatRangeToParts ( start, end )","titleHTML":"Intl.NumberFormat.prototype.formatRangeToParts ( <var>start</var>, <var>end</var> )","number":"1.3.6","namespace":"<no location>","location":"","referencingIds":[],"key":"Intl.NumberFormat.prototype.formatRangeToParts ( start, end )"},{"type":"table","id":"table-numberformat-resolvedoptions-properties","number":1,"caption":"Table 1: Resolved Options of NumberFormat Instances","referencingIds":["_ref_1"],"namespace":"<no location>","location":"","key":"Table 1: Resolved Options of NumberFormat Instances"},{"type":"clause","id":"sec-intl.numberformat.prototype.resolvedoptions","aoid":null,"title":"Intl.NumberFormat.prototype.resolvedOptions ( )","titleHTML":"Intl.NumberFormat.prototype.resolvedOptions ( )","number":"1.3.7","namespace":"<no location>","location":"","referencingIds":["_ref_2"],"key":"Intl.NumberFormat.prototype.resolvedOptions ( )"},{"type":"clause","id":"sec-properties-of-intl-numberformat-prototype-object","aoid":null,"title":"Properties of the Intl.NumberFormat Prototype Object","titleHTML":"Properties of the Intl.NumberFormat Prototype Object","number":"1.3","namespace":"<no location>","location":"","referencingIds":["_ref_35","_ref_57"],"key":"Properties of the Intl.NumberFormat Prototype Object"},{"type":"table","id":"table-intl-rounding-modes","number":2,"caption":"Table 2: Rounding modes in Intl.NumberFormat","referencingIds":["_ref_3","_ref_13"],"namespace":"<no location>","location":"","key":"Table 2: Rounding modes in Intl.NumberFormat"},{"type":"clause","id":"sec-properties-of-intl-numberformat-instances","aoid":null,"title":"Properties of Intl.NumberFormat Instances","titleHTML":"Properties of Intl.NumberFormat Instances","number":"1.4","namespace":"<no location>","location":"","referencingIds":[],"key":"Properties of Intl.NumberFormat Instances"},{"type":"op","aoid":"CurrencyDigits","refId":"sec-currencydigits","location":"","referencingIds":[],"key":"CurrencyDigits"},{"type":"clause","id":"sec-currencydigits","aoid":"CurrencyDigits","title":"CurrencyDigits ( currency )","titleHTML":"CurrencyDigits ( <var>currency</var> )","number":"1.5.1","namespace":"<no location>","location":"","referencingIds":["_ref_27"],"key":"CurrencyDigits ( currency )"},{"type":"clause","id":"sec-number-format-functions","aoid":null,"title":"Number Format Functions","titleHTML":"Number Format Functions","number":"1.5.2","namespace":"<no location>","location":"","referencingIds":["_ref_0"],"key":"Number Format Functions"},{"type":"op","aoid":"FormatNumericToString","refId":"sec-formatnumberstring","location":"","referencingIds":[],"key":"FormatNumericToString"},{"type":"clause","id":"sec-formatnumberstring","aoid":"FormatNumericToString","title":"FormatNumericToString ( intlObject, x )","titleHTML":"FormatNumericToString ( <var>intlObject</var>, <var>x</var> )","number":"1.5.3","namespace":"<no location>","location":"","referencingIds":["_ref_67","_ref_95"],"key":"FormatNumericToString ( intlObject, x )"},{"type":"op","aoid":"PartitionNumberPattern","refId":"sec-partitionnumberpattern","location":"","referencingIds":[],"key":"PartitionNumberPattern"},{"type":"clause","id":"sec-partitionnumberpattern","aoid":"PartitionNumberPattern","title":"\n        PartitionNumberPattern (\n          numberFormat: an object initialized as a NumberFormat,\n          x: an Intl mathematical value,\n        )\n      ","titleHTML":"\n        PartitionNumberPattern (\n          <var>numberFormat</var>: an object initialized as a NumberFormat,\n          <var>x</var>: an Intl mathematical value,\n        )\n      ","number":"1.5.4","namespace":"<no location>","location":"","referencingIds":["_ref_73","_ref_75","_ref_104","_ref_105","_ref_108"],"key":"\n        PartitionNumberPattern (\n          numberFormat: an object initialized as a NumberFormat,\n          x: an Intl mathematical value,\n        )\n      "},{"type":"table","id":"table-numbering-system-digits","number":3,"caption":"Table 3: Numbering systems with simple digit mappings","referencingIds":["_ref_5","_ref_6"],"namespace":"<no location>","location":"","key":"Table 3: Numbering systems with simple digit mappings"},{"type":"op","aoid":"PartitionNotationSubPattern","refId":"sec-partitionnotationsubpattern","location":"","referencingIds":[],"key":"PartitionNotationSubPattern"},{"type":"clause","id":"sec-partitionnotationsubpattern","aoid":"PartitionNotationSubPattern","title":"PartitionNotationSubPattern ( numberFormat, x, n, exponent )","titleHTML":"PartitionNotationSubPattern ( <var>numberFormat</var>, <var>x</var>, <var>n</var>, <var>exponent</var> )","number":"1.5.5","namespace":"<no location>","location":"","referencingIds":["_ref_69"],"key":"PartitionNotationSubPattern ( numberFormat, x, n, exponent )"},{"type":"op","aoid":"FormatNumeric","refId":"sec-formatnumber","location":"","referencingIds":[],"key":"FormatNumeric"},{"type":"clause","id":"sec-formatnumber","aoid":"FormatNumeric","title":"FormatNumeric ( numberFormat, x )","titleHTML":"FormatNumeric ( <var>numberFormat</var>, <var>x</var> )","number":"1.5.6","namespace":"<no location>","location":"","referencingIds":["_ref_60"],"key":"FormatNumeric ( numberFormat, x )"},{"type":"op","aoid":"FormatNumericToParts","refId":"sec-formatnumbertoparts","location":"","referencingIds":[],"key":"FormatNumericToParts"},{"type":"clause","id":"sec-formatnumbertoparts","aoid":"FormatNumericToParts","title":"FormatNumericToParts ( numberFormat, x )","titleHTML":"FormatNumericToParts ( <var>numberFormat</var>, <var>x</var> )","number":"1.5.7","namespace":"<no location>","location":"","referencingIds":["_ref_42"],"key":"FormatNumericToParts ( numberFormat, x )"},{"type":"op","aoid":"ToRawPrecisionFn","id":"eqn-ToRawPrecisionFn","referencingIds":["_ref_81","_ref_82"],"namespace":"<no location>","location":"","key":"ToRawPrecisionFn"},{"type":"op","aoid":"ToRawPrecision","refId":"sec-torawprecision","location":"","referencingIds":[],"key":"ToRawPrecision"},{"type":"clause","id":"sec-torawprecision","aoid":"ToRawPrecision","title":"ToRawPrecision ( x, minPrecision, maxPrecision, unsignedRoundingMode )","titleHTML":"ToRawPrecision ( <var>x</var>, <var>minPrecision</var>, <var>maxPrecision</var>, <var>unsignedRoundingMode</var> )","number":"1.5.8","namespace":"<no location>","location":"","referencingIds":["_ref_62","_ref_64"],"key":"ToRawPrecision ( x, minPrecision, maxPrecision, unsignedRoundingMode )"},{"type":"op","aoid":"ToRawFixedFn","id":"eqn-ToRawFixedFn","referencingIds":["_ref_84","_ref_85"],"namespace":"<no location>","location":"","key":"ToRawFixedFn"},{"type":"op","aoid":"ToRawFixed","refId":"sec-torawfixed","location":"","referencingIds":[],"key":"ToRawFixed"},{"type":"clause","id":"sec-torawfixed","aoid":"ToRawFixed","title":"ToRawFixed ( x, minFraction, maxFraction, roundingIncrement, unsignedRoundingMode )","titleHTML":"ToRawFixed ( <var>x</var>, <var>minFraction</var>, <var>maxFraction</var>, <var>roundingIncrement</var>, <var>unsignedRoundingMode</var> )","number":"1.5.9","namespace":"<no location>","location":"","referencingIds":["_ref_63","_ref_65","_ref_71"],"key":"ToRawFixed ( x, minFraction, maxFraction, roundingIncrement, unsignedRoundingMode )"},{"type":"op","aoid":"UnwrapNumberFormat","refId":"sec-unwrapnumberformat","location":"","referencingIds":[],"key":"UnwrapNumberFormat"},{"type":"clause","id":"sec-unwrapnumberformat","aoid":"UnwrapNumberFormat","title":"UnwrapNumberFormat ( nf )","titleHTML":"UnwrapNumberFormat ( <var>nf</var> )","number":"1.5.10","namespace":"<no location>","location":"","referencingIds":["_ref_38","_ref_51"],"key":"UnwrapNumberFormat ( nf )"},{"type":"op","aoid":"GetNumberFormatPattern","refId":"sec-getnumberformatpattern","location":"","referencingIds":[],"key":"GetNumberFormatPattern"},{"type":"clause","id":"sec-getnumberformatpattern","aoid":"GetNumberFormatPattern","title":"GetNumberFormatPattern ( numberFormat, x )","titleHTML":"GetNumberFormatPattern ( <var>numberFormat</var>, <var>x</var> )","number":"1.5.11","namespace":"<no location>","location":"","referencingIds":["_ref_68"],"key":"GetNumberFormatPattern ( numberFormat, x )"},{"type":"op","aoid":"GetNotationSubPattern","refId":"sec-getnotationsubpattern","location":"","referencingIds":[],"key":"GetNotationSubPattern"},{"type":"clause","id":"sec-getnotationsubpattern","aoid":"GetNotationSubPattern","title":"GetNotationSubPattern ( numberFormat, exponent )","titleHTML":"GetNotationSubPattern ( <var>numberFormat</var>, <var>exponent</var> )","number":"1.5.12","namespace":"<no location>","location":"","referencingIds":["_ref_70"],"key":"GetNotationSubPattern ( numberFormat, exponent )"},{"type":"op","aoid":"ComputeExponent","refId":"sec-computeexponent","location":"","referencingIds":[],"key":"ComputeExponent"},{"type":"clause","id":"sec-computeexponent","aoid":"ComputeExponent","title":"ComputeExponent ( numberFormat, x )","titleHTML":"ComputeExponent ( <var>numberFormat</var>, <var>x</var> )","number":"1.5.13","namespace":"<no location>","location":"","referencingIds":["_ref_66"],"key":"ComputeExponent ( numberFormat, x )"},{"type":"op","aoid":"ComputeExponentForMagnitude","refId":"sec-computeexponentformagnitude","location":"","referencingIds":[],"key":"ComputeExponentForMagnitude"},{"type":"clause","id":"sec-computeexponentformagnitude","aoid":"ComputeExponentForMagnitude","title":"ComputeExponentForMagnitude ( numberFormat, magnitude )","titleHTML":"ComputeExponentForMagnitude ( <var>numberFormat</var>, <var>magnitude</var> )","number":"1.5.14","namespace":"<no location>","location":"","referencingIds":["_ref_94","_ref_96"],"key":"ComputeExponentForMagnitude ( numberFormat, magnitude )"},{"type":"production","id":"prod-StringNumericLiteral","name":"StringNumericLiteral","referencingIds":["_ref_123","_ref_128"],"namespace":"<no location>","location":"","key":"StringNumericLiteral"},{"type":"production","id":"prod-StrNumericLiteral","name":"StrNumericLiteral","referencingIds":["_ref_124","_ref_125"],"namespace":"<no location>","location":"","key":"StrNumericLiteral"},{"type":"production","id":"prod-StrDecimalLiteral","name":"StrDecimalLiteral","referencingIds":[],"namespace":"<no location>","location":"","key":"StrDecimalLiteral"},{"type":"production","id":"prod-StrUnsignedDecimalLiteral","name":"StrUnsignedDecimalLiteral","referencingIds":["_ref_126","_ref_127"],"namespace":"<no location>","location":"","key":"StrUnsignedDecimalLiteral"},{"type":"clause","id":"sec-runtime-semantics-stringintlmv","aoid":null,"title":"Runtime Semantics: StringIntlMV","titleHTML":"Runtime Semantics: StringIntlMV","number":"1.5.15","namespace":"<no location>","location":"","referencingIds":[],"key":"Runtime Semantics: StringIntlMV"},{"type":"term","term":"Intl mathematical value","refId":"sec-tointlmathematicalvalue","referencingIds":["_ref_72","_ref_74","_ref_102","_ref_103","_ref_110","_ref_111","_ref_113","_ref_114"],"id":"intl-mathematical-value","namespace":"<no location>","location":"","key":"Intl mathematical value"},{"type":"op","aoid":"ToIntlMathematicalValue","refId":"sec-tointlmathematicalvalue","location":"","referencingIds":[],"key":"ToIntlMathematicalValue"},{"type":"clause","id":"sec-tointlmathematicalvalue","aoid":"ToIntlMathematicalValue","title":"ToIntlMathematicalValue ( value )","titleHTML":"ToIntlMathematicalValue ( <var>value</var> )","number":"1.5.16","namespace":"<no location>","location":"","referencingIds":["_ref_41","_ref_44","_ref_45","_ref_48","_ref_49","_ref_59"],"key":"ToIntlMathematicalValue ( value )"},{"type":"table","id":"table-intl-unsigned-rounding-modes","number":4,"caption":"Table 4: Conversion from rounding mode to unsigned rounding mode","referencingIds":["_ref_7","_ref_8","_ref_14","_ref_15","_ref_16"],"namespace":"<no location>","location":"","key":"Table 4: Conversion from rounding mode to unsigned rounding mode"},{"type":"op","aoid":"GetUnsignedRoundingMode","refId":"sec-getunsignedroundingmode","location":"","referencingIds":[],"key":"GetUnsignedRoundingMode"},{"type":"clause","id":"sec-getunsignedroundingmode","aoid":"GetUnsignedRoundingMode","title":"GetUnsignedRoundingMode ( roundingMode, isNegative )","titleHTML":"GetUnsignedRoundingMode ( <var>roundingMode</var>, <var>isNegative</var> )","number":"1.5.17","namespace":"<no location>","location":"","referencingIds":["_ref_61"],"key":"GetUnsignedRoundingMode ( roundingMode, isNegative )"},{"type":"op","aoid":"ApplyUnsignedRoundingMode","refId":"sec-applyunsignedroundingmode","location":"","referencingIds":[],"key":"ApplyUnsignedRoundingMode"},{"type":"clause","id":"sec-applyunsignedroundingmode","aoid":"ApplyUnsignedRoundingMode","title":"ApplyUnsignedRoundingMode ( x, r1, r2, unsignedRoundingMode )","titleHTML":"ApplyUnsignedRoundingMode ( <var>x</var>, <var>r1</var>, <var>r2</var>, <var>unsignedRoundingMode</var> )","number":"1.5.18","namespace":"<no location>","location":"","referencingIds":["_ref_83","_ref_86"],"key":"ApplyUnsignedRoundingMode ( x, r1, r2, unsignedRoundingMode )"},{"type":"op","aoid":"PartitionNumberRangePattern","refId":"sec-partitionnumberrangepattern","location":"","referencingIds":[],"key":"PartitionNumberRangePattern"},{"type":"clause","id":"sec-partitionnumberrangepattern","aoid":"PartitionNumberRangePattern","title":"PartitionNumberRangePattern ( numberFormat, x, y )","titleHTML":"PartitionNumberRangePattern ( <var>numberFormat</var>, <var>x</var>, <var>y</var> )","number":"1.5.19","namespace":"<no location>","location":"","referencingIds":["_ref_109","_ref_112","_ref_115"],"key":"PartitionNumberRangePattern ( numberFormat, x, y )"},{"type":"op","aoid":"FormatApproximately","refId":"sec-formatapproximately","location":"","referencingIds":[],"key":"FormatApproximately"},{"type":"clause","id":"sec-formatapproximately","aoid":"FormatApproximately","title":"FormatApproximately ( numberFormat, result )","titleHTML":"FormatApproximately ( <var>numberFormat</var>, <var>result</var> )","number":"1.5.20","namespace":"<no location>","location":"","referencingIds":["_ref_106"],"key":"FormatApproximately ( numberFormat, result )"},{"type":"op","aoid":"CollapseNumberRange","refId":"sec-collapsenumberrange","location":"","referencingIds":[],"key":"CollapseNumberRange"},{"type":"clause","id":"sec-collapsenumberrange","aoid":"CollapseNumberRange","title":"CollapseNumberRange ( result )","titleHTML":"CollapseNumberRange ( <var>result</var> )","number":"1.5.21","namespace":"<no location>","location":"","referencingIds":["_ref_107"],"key":"CollapseNumberRange ( result )"},{"type":"op","aoid":"FormatNumericRange","refId":"sec-formatnumericrange","location":"","referencingIds":[],"key":"FormatNumericRange"},{"type":"clause","id":"sec-formatnumericrange","aoid":"FormatNumericRange","title":"FormatNumericRange( numberFormat, x, y )","titleHTML":"FormatNumericRange( <var>numberFormat</var>, <var>x</var>, <var>y</var> )","number":"1.5.22","namespace":"<no location>","location":"","referencingIds":["_ref_46"],"key":"FormatNumericRange( numberFormat, x, y )"},{"type":"op","aoid":"FormatNumericRangeToParts","refId":"sec-formatnumericrangetoparts","location":"","referencingIds":[],"key":"FormatNumericRangeToParts"},{"type":"clause","id":"sec-formatnumericrangetoparts","aoid":"FormatNumericRangeToParts","title":"FormatNumericRangeToParts( numberFormat, x, y )","titleHTML":"FormatNumericRangeToParts( <var>numberFormat</var>, <var>x</var>, <var>y</var> )","number":"1.5.23","namespace":"<no location>","location":"","referencingIds":["_ref_50"],"key":"FormatNumericRangeToParts( numberFormat, x, y )"},{"type":"clause","id":"sec-numberformat-abstracts","aoid":null,"title":"Abstract Operations for NumberFormat Objects","titleHTML":"Abstract Operations for NumberFormat Objects","number":"1.5","namespace":"<no location>","location":"","referencingIds":[],"key":"Abstract Operations for NumberFormat Objects"},{"type":"clause","id":"numberformat-objects","aoid":null,"title":"NumberFormat Objects","titleHTML":"NumberFormat Objects","number":"1","namespace":"<no location>","location":"","referencingIds":[],"key":"NumberFormat Objects"}]</script><script>"use strict";
+<head><meta charset="utf-8"><script>'use strict';
+let sdoBox = {
+  init() {
+    this.$alternativeId = null;
+    this.$outer = document.createElement('div');
+    this.$outer.classList.add('toolbox-container');
+    this.$container = document.createElement('div');
+    this.$container.classList.add('toolbox');
+    this.$displayLink = document.createElement('a');
+    this.$displayLink.setAttribute('href', '#');
+    this.$displayLink.textContent = 'Syntax-Directed Operations';
+    this.$displayLink.addEventListener('click', e => {
+      e.preventDefault();
+      e.stopPropagation();
+      referencePane.showSDOs(sdoMap[this.$alternativeId] || {}, this.$alternativeId);
+    });
+    this.$container.appendChild(this.$displayLink);
+    this.$outer.appendChild(this.$container);
+    document.body.appendChild(this.$outer);
+  },
 
+  activate(el) {
+    clearTimeout(this.deactiveTimeout);
+    Toolbox.deactivate();
+    this.$alternativeId = el.id;
+    let numSdos = Object.keys(sdoMap[this.$alternativeId] || {}).length;
+    this.$displayLink.textContent = 'Syntax-Directed Operations (' + numSdos + ')';
+    this.$outer.classList.add('active');
+    let top = el.offsetTop - this.$outer.offsetHeight;
+    let left = el.offsetLeft + 50 - 10; // 50px = padding-left(=75px) + text-indent(=-25px)
+    this.$outer.setAttribute('style', 'left: ' + left + 'px; top: ' + top + 'px');
+    if (top < document.body.scrollTop) {
+      this.$container.scrollIntoView();
+    }
+  },
+
+  deactivate() {
+    clearTimeout(this.deactiveTimeout);
+    this.$outer.classList.remove('active');
+  },
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+  if (typeof sdoMap == 'undefined') {
+    console.error('could not find sdo map');
+    return;
+  }
+  sdoBox.init();
+
+  let insideTooltip = false;
+  sdoBox.$outer.addEventListener('pointerenter', () => {
+    insideTooltip = true;
+  });
+  sdoBox.$outer.addEventListener('pointerleave', () => {
+    insideTooltip = false;
+    sdoBox.deactivate();
+  });
+
+  sdoBox.deactiveTimeout = null;
+  [].forEach.call(document.querySelectorAll('emu-grammar[type=definition] emu-rhs'), node => {
+    node.addEventListener('pointerenter', function () {
+      sdoBox.activate(this);
+    });
+
+    node.addEventListener('pointerleave', () => {
+      sdoBox.deactiveTimeout = setTimeout(() => {
+        if (!insideTooltip) {
+          sdoBox.deactivate();
+        }
+      }, 500);
+    });
+  });
+
+  document.addEventListener(
+    'keydown',
+    debounce(e => {
+      if (e.code === 'Escape') {
+        sdoBox.deactivate();
+      }
+    })
+  );
+});
+
+'use strict';
 function Search(menu) {
   this.menu = menu;
   this.$search = document.getElementById('menu-search');
@@ -11,8 +93,14 @@ function Search(menu) {
 
   document.addEventListener('keydown', this.documentKeydown.bind(this));
 
-  this.$searchBox.addEventListener('keydown', debounce(this.searchBoxKeydown.bind(this), { stopPropagation: true }));
-  this.$searchBox.addEventListener('keyup', debounce(this.searchBoxKeyup.bind(this), { stopPropagation: true }));
+  this.$searchBox.addEventListener(
+    'keydown',
+    debounce(this.searchBoxKeydown.bind(this), { stopPropagation: true })
+  );
+  this.$searchBox.addEventListener(
+    'keyup',
+    debounce(this.searchBoxKeyup.bind(this), { stopPropagation: true })
+  );
 
   // Perform an initial search if the box is not empty.
   if (this.$searchBox.value) {
@@ -21,26 +109,34 @@ function Search(menu) {
 }
 
 Search.prototype.loadBiblio = function () {
-  var $biblio = document.getElementById('menu-search-biblio');
-  if (!$biblio) {
-    this.biblio = [];
+  if (typeof biblio === 'undefined') {
+    console.error('could not find biblio');
+    this.biblio = { refToClause: {}, entries: [] };
   } else {
-    this.biblio = JSON.parse($biblio.textContent);
-    this.biblio.clauses = this.biblio.filter(function (e) { return e.type === 'clause' });
-    this.biblio.byId = this.biblio.reduce(function (map, entry) {
+    this.biblio = biblio;
+    this.biblio.clauses = this.biblio.entries.filter(e => e.type === 'clause');
+    this.biblio.byId = this.biblio.entries.reduce((map, entry) => {
       map[entry.id] = entry;
       return map;
     }, {});
+    let refParentClause = Object.create(null);
+    this.biblio.refParentClause = refParentClause;
+    let refsByClause = this.biblio.refsByClause;
+    Object.keys(refsByClause).forEach(clause => {
+      refsByClause[clause].forEach(ref => {
+        refParentClause[ref] = clause;
+      });
+    });
   }
-}
+};
 
 Search.prototype.documentKeydown = function (e) {
-  if (e.keyCode === 191) {
+  if (e.key === '/') {
     e.preventDefault();
     e.stopPropagation();
     this.triggerSearch();
   }
-}
+};
 
 Search.prototype.searchBoxKeydown = function (e) {
   e.stopPropagation();
@@ -51,7 +147,7 @@ Search.prototype.searchBoxKeydown = function (e) {
     e.preventDefault();
     this.selectResult();
   }
-}
+};
 
 Search.prototype.searchBoxKeyup = function (e) {
   if (e.keyCode === 13 || e.keyCode === 9) {
@@ -59,10 +155,9 @@ Search.prototype.searchBoxKeyup = function (e) {
   }
 
   this.search(e.target.value);
-}
+};
 
-
-Search.prototype.triggerSearch = function (e) {
+Search.prototype.triggerSearch = function () {
   if (this.menu.isVisible()) {
     this._closeAfterSearch = false;
   } else {
@@ -72,14 +167,14 @@ Search.prototype.triggerSearch = function (e) {
 
   this.$searchBox.focus();
   this.$searchBox.select();
-}
+};
 // bit 12 - Set if the result starts with searchString
 // bits 8-11: 8 - number of chunks multiplied by 2 if cases match, otherwise 1.
 // bits 1-7: 127 - length of the entry
 // General scheme: prefer case sensitive matches with fewer chunks, and otherwise
 // prefer shorter matches.
-function relevance(result, searchString) {
-  var relevance = 0;
+function relevance(result) {
+  let relevance = 0;
 
   relevance = Math.max(0, 8 - result.match.chunks) << 7;
 
@@ -88,10 +183,10 @@ function relevance(result, searchString) {
   }
 
   if (result.match.prefix) {
-    relevance += 2048
+    relevance += 2048;
   }
 
-  relevance += Math.max(0, 255 - result.entry.key.length);
+  relevance += Math.max(0, 255 - result.key.length);
 
   return relevance;
 }
@@ -110,36 +205,34 @@ Search.prototype.search = function (searchString) {
     return;
   }
 
-  var results;
+  let results;
 
-  if (/^[\d\.]*$/.test(searchString)) {
-    results = this.biblio.clauses.filter(function (clause) {
-      return clause.number.substring(0, searchString.length) === searchString;
-    }).map(function (clause) {
-      return { entry: clause };
-    });
+  if (/^[\d.]*$/.test(searchString)) {
+    results = this.biblio.clauses
+      .filter(clause => clause.number.substring(0, searchString.length) === searchString)
+      .map(clause => ({ key: getKey(clause), entry: clause }));
   } else {
     results = [];
 
-    for (var i = 0; i < this.biblio.length; i++) {
-      var entry = this.biblio[i];
-      if (!entry.key) {
+    for (let i = 0; i < this.biblio.entries.length; i++) {
+      let entry = this.biblio.entries[i];
+      let key = getKey(entry);
+      if (!key) {
         // biblio entries without a key aren't searchable
         continue;
       }
 
-      var match = fuzzysearch(searchString, entry.key);
+      let match = fuzzysearch(searchString, key);
       if (match) {
-        results.push({ entry: entry, match: match });
+        results.push({ key, entry, match });
       }
     }
 
-    results.forEach(function (result) {
+    results.forEach(result => {
       result.relevance = relevance(result, searchString);
     });
 
-    results = results.sort(function (a, b) { return b.relevance - a.relevance });
-
+    results = results.sort((a, b) => b.relevance - a.relevance);
   }
 
   if (results.length > 50) {
@@ -147,17 +240,17 @@ Search.prototype.search = function (searchString) {
   }
 
   this.displayResults(results);
-}
+};
 Search.prototype.hideSearch = function () {
   this.$search.classList.remove('active');
-}
+};
 
 Search.prototype.showSearch = function () {
   this.$search.classList.add('active');
-}
+};
 
 Search.prototype.selectResult = function () {
-  var $first = this.$searchResults.querySelector('li:first-child a');
+  let $first = this.$searchResults.querySelector('li:first-child a');
 
   if ($first) {
     document.location = $first.getAttribute('href');
@@ -171,53 +264,79 @@ Search.prototype.selectResult = function () {
   if (this._closeAfterSearch) {
     this.menu.hide();
   }
-}
+};
 
 Search.prototype.displayResults = function (results) {
   if (results.length > 0) {
     this.$searchResults.classList.remove('no-results');
 
-    var html = '<ul>';
+    let html = '<ul>';
 
-    results.forEach(function (result) {
-      var entry = result.entry;
-      var id = entry.id;
-      var cssClass = '';
-      var text = '';
+    results.forEach(result => {
+      let key = result.key;
+      let entry = result.entry;
+      let id = entry.id;
+      let cssClass = '';
+      let text = '';
 
       if (entry.type === 'clause') {
-        var number = entry.number ? entry.number + ' ' : '';
-        text = number + entry.key;
+        let number = entry.number ? entry.number + ' ' : '';
+        text = number + key;
         cssClass = 'clause';
         id = entry.id;
       } else if (entry.type === 'production') {
-        text = entry.key;
+        text = key;
         cssClass = 'prod';
         id = entry.id;
       } else if (entry.type === 'op') {
-        text = entry.key;
+        text = key;
         cssClass = 'op';
         id = entry.id || entry.refId;
       } else if (entry.type === 'term') {
-        text = entry.key;
+        text = key;
         cssClass = 'term';
         id = entry.id || entry.refId;
       }
 
       if (text) {
-        html += '<li class=menu-search-result-' + cssClass + '><a href="#' + id + '">' + text + '</a></li>';
+        // prettier-ignore
+        html += `<li class=menu-search-result-${cssClass}><a href="${makeLinkToId(id)}">${text}</a></li>`;
       }
     });
 
-    html += '</ul>'
+    html += '</ul>';
 
     this.$searchResults.innerHTML = html;
   } else {
     this.$searchResults.innerHTML = '';
     this.$searchResults.classList.add('no-results');
   }
-}
+};
 
+function getKey(item) {
+  if (item.key) {
+    return item.key;
+  }
+  switch (item.type) {
+    case 'clause':
+      return item.title || item.titleHTML;
+    case 'production':
+      return item.name;
+    case 'op':
+      return item.aoid;
+    case 'term':
+      return item.term;
+    case 'table':
+    case 'figure':
+    case 'example':
+    case 'note':
+      return item.caption;
+    case 'step':
+      return item.id;
+    default:
+      throw new Error("Can't get key for " + item.type);
+  }
+}
 
 function Menu() {
   this.$toggle = document.getElementById('menu-toggle');
@@ -229,7 +348,7 @@ function Menu() {
   this.$specContainer = document.getElementById('spec-container');
   this.search = new Search(this);
 
-  this._pinnedIds = {}; 
+  this._pinnedIds = {};
   this.loadPinEntries();
 
   // toggle menu
@@ -239,23 +358,23 @@ function Menu() {
   document.addEventListener('keydown', this.documentKeydown.bind(this));
 
   // toc expansion
-  var tocItems = this.$menu.querySelectorAll('#menu-toc li');
-  for (var i = 0; i < tocItems.length; i++) {
-    var $item = tocItems[i];
-    $item.addEventListener('click', function($item, event) {
+  let tocItems = this.$menu.querySelectorAll('#menu-toc li');
+  for (let i = 0; i < tocItems.length; i++) {
+    let $item = tocItems[i];
+    $item.addEventListener('click', event => {
       $item.classList.toggle('active');
       event.stopPropagation();
-    }.bind(null, $item));
+    });
   }
 
   // close toc on toc item selection
-  var tocLinks = this.$menu.querySelectorAll('#menu-toc li > a');
-  for (var i = 0; i < tocLinks.length; i++) {
-    var $link = tocLinks[i];
-    $link.addEventListener('click', function(event) {
+  let tocLinks = this.$menu.querySelectorAll('#menu-toc li > a');
+  for (let i = 0; i < tocLinks.length; i++) {
+    let $link = tocLinks[i];
+    $link.addEventListener('click', event => {
       this.toggle();
       event.stopPropagation();
-    }.bind(this));
+    });
   }
 
   // update active clause on scroll
@@ -263,14 +382,13 @@ function Menu() {
   this.updateActiveClause();
 
   // prevent menu scrolling from scrolling the body
-  this.$toc.addEventListener('wheel', function (e) {
-    var target = e.currentTarget;
-    var offTop = e.deltaY < 0 && target.scrollTop === 0;
+  this.$toc.addEventListener('wheel', e => {
+    let target = e.currentTarget;
+    let offTop = e.deltaY < 0 && target.scrollTop === 0;
     if (offTop) {
       e.preventDefault();
     }
-    var offBottom = e.deltaY > 0
-                    && target.offsetHeight + target.scrollTop >= target.scrollHeight;
+    let offBottom = e.deltaY > 0 && target.offsetHeight + target.scrollTop >= target.scrollHeight;
 
     if (offBottom) {
       e.preventDefault();
@@ -285,62 +403,66 @@ Menu.prototype.documentKeydown = function (e) {
   } else if (e.keyCode > 48 && e.keyCode < 58) {
     this.selectPin(e.keyCode - 49);
   }
-}
+};
 
 Menu.prototype.updateActiveClause = function () {
-  this.setActiveClause(findActiveClause(this.$specContainer))
-}
+  this.setActiveClause(findActiveClause(this.$specContainer));
+};
 
 Menu.prototype.setActiveClause = function (clause) {
   this.$activeClause = clause;
   this.revealInToc(this.$activeClause);
-}
+};
 
 Menu.prototype.revealInToc = function (path) {
-  var current = this.$toc.querySelectorAll('li.revealed');
-  for (var i = 0; i < current.length; i++) {
+  let current = this.$toc.querySelectorAll('li.revealed');
+  for (let i = 0; i < current.length; i++) {
     current[i].classList.remove('revealed');
     current[i].classList.remove('revealed-leaf');
   }
 
-  var current = this.$toc;
-  var index = 0;
-  while (index < path.length) {
-    var children = current.children;
-    for (var i = 0; i < children.length; i++) {
-      if ('#' + path[index].id === children[i].children[1].getAttribute('href') ) {
+  current = this.$toc;
+  let index = 0;
+  outer: while (index < path.length) {
+    let children = current.children;
+    for (let i = 0; i < children.length; i++) {
+      if ('#' + path[index].id === children[i].children[1].hash) {
         children[i].classList.add('revealed');
         if (index === path.length - 1) {
           children[i].classList.add('revealed-leaf');
-          var rect = children[i].getBoundingClientRect();
+          let rect = children[i].getBoundingClientRect();
           // this.$toc.getBoundingClientRect().top;
-          var tocRect = this.$toc.getBoundingClientRect();
+          let tocRect = this.$toc.getBoundingClientRect();
           if (rect.top + 10 > tocRect.bottom) {
-            this.$toc.scrollTop = this.$toc.scrollTop + (rect.top - tocRect.bottom) + (rect.bottom - rect.top);
+            this.$toc.scrollTop =
+              this.$toc.scrollTop + (rect.top - tocRect.bottom) + (rect.bottom - rect.top);
           } else if (rect.top < tocRect.top) {
             this.$toc.scrollTop = this.$toc.scrollTop - (tocRect.top - rect.top);
           }
         }
         current = children[i].querySelector('ol');
         index++;
-        break;
+        continue outer;
       }
     }
-
+    console.log('could not find location in table of contents', path);
+    break;
   }
-}
+};
 
 function findActiveClause(root, path) {
-  var clauses = new ClauseWalker(root);
-  var $clause;
-  var path = path || [];
+  let clauses = getChildClauses(root);
+  path = path || [];
 
-  while ($clause = clauses.nextNode()) {
-    var rect = $clause.getBoundingClientRect();
-    var $header = $clause.querySelector("h1");
-    var marginTop = parseInt(getComputedStyle($header)["margin-top"]);
+  for (let $clause of clauses) {
+    let rect = $clause.getBoundingClientRect();
+    let $header = $clause.querySelector('h1');
+    let marginTop = Math.max(
+      parseInt(getComputedStyle($clause)['margin-top']),
+      parseInt(getComputedStyle($header)['margin-top'])
+    );
 
-    if ((rect.top - marginTop) <= 0 && rect.bottom > 0) {
+    if (rect.top - marginTop <= 1 && rect.bottom > 0) {
       return findActiveClause($clause, path.concat($clause)) || path;
     }
   }
@@ -348,57 +470,49 @@ function findActiveClause(root, path) {
   return path;
 }
 
-function ClauseWalker(root) {
-  var previous;
-  var treeWalker = document.createTreeWalker(
-    root,
-    NodeFilter.SHOW_ELEMENT,
-    {
-      acceptNode: function (node) {
-        if (previous === node.parentNode) {
-          return NodeFilter.FILTER_REJECT;
-        } else {
-          previous = node;
-        }
-        if (node.nodeName === 'EMU-CLAUSE' || node.nodeName === 'EMU-INTRO' || node.nodeName === 'EMU-ANNEX') {
-          return NodeFilter.FILTER_ACCEPT;
-        } else {
-          return NodeFilter.FILTER_SKIP;
-        }
-      }
-    },
-    false
-    );
+function* getChildClauses(root) {
+  for (let el of root.children) {
+    switch (el.nodeName) {
+      // descend into <emu-import>
+      case 'EMU-IMPORT':
+        yield* getChildClauses(el);
+        break;
 
-  return treeWalker;
+      // accept <emu-clause>, <emu-intro>, and <emu-annex>
+      case 'EMU-CLAUSE':
+      case 'EMU-INTRO':
+      case 'EMU-ANNEX':
+        yield el;
+    }
+  }
 }
 
 Menu.prototype.toggle = function () {
   this.$menu.classList.toggle('active');
-}
+};
 
 Menu.prototype.show = function () {
   this.$menu.classList.add('active');
-}
+};
 
 Menu.prototype.hide = function () {
   this.$menu.classList.remove('active');
-}
+};
 
-Menu.prototype.isVisible = function() {
+Menu.prototype.isVisible = function () {
   return this.$menu.classList.contains('active');
-}
+};
 
 Menu.prototype.showPins = function () {
   this.$pins.classList.add('active');
-}
+};
 
 Menu.prototype.hidePins = function () {
   this.$pins.classList.remove('active');
-}
+};
 
 Menu.prototype.addPinEntry = function (id) {
-  var entry = this.search.biblio.byId[id];
+  let entry = this.search.biblio.byId[id];
   if (!entry) {
     // id was deleted after pin (or something) so remove it
     delete this._pinnedIds[id];
@@ -407,15 +521,16 @@ Menu.prototype.addPinEntry = function (id) {
   }
 
   if (entry.type === 'clause') {
-    var prefix;
+    let prefix;
     if (entry.number) {
       prefix = entry.number + ' ';
     } else {
       prefix = '';
     }
-    this.$pinList.innerHTML += '<li><a href="#' + entry.id + '">' + prefix + entry.titleHTML + '</a></li>';
+    // prettier-ignore
+    this.$pinList.innerHTML += `<li><a href="${makeLinkToId(entry.id)}">${prefix}${entry.titleHTML}</a></li>`;
   } else {
-    this.$pinList.innerHTML += '<li><a href="#' + entry.id + '">' + entry.key + '</a></li>';
+    this.$pinList.innerHTML += `<li><a href="${makeLinkToId(entry.id)}">${getKey(entry)}</a></li>`;
   }
 
   if (Object.keys(this._pinnedIds).length === 0) {
@@ -423,10 +538,10 @@ Menu.prototype.addPinEntry = function (id) {
   }
   this._pinnedIds[id] = true;
   this.persistPinEntries();
-}
+};
 
 Menu.prototype.removePinEntry = function (id) {
-  var item = this.$pinList.querySelector('a[href="#' + id + '"]').parentNode;
+  let item = this.$pinList.querySelector(`a[href="${makeLinkToId(id)}"]`).parentNode;
   this.$pinList.removeChild(item);
   delete this._pinnedIds[id];
   if (Object.keys(this._pinnedIds).length === 0) {
@@ -434,7 +549,7 @@ Menu.prototype.removePinEntry = function (id) {
   }
 
   this.persistPinEntries();
-}
+};
 
 Menu.prototype.persistPinEntries = function () {
   try {
@@ -444,7 +559,7 @@ Menu.prototype.persistPinEntries = function () {
   }
 
   localStorage.pinEntries = JSON.stringify(Object.keys(this._pinnedIds));
-}
+};
 
 Menu.prototype.loadPinEntries = function () {
   try {
@@ -453,13 +568,13 @@ Menu.prototype.loadPinEntries = function () {
     return;
   }
 
-  var pinsString = window.localStorage.pinEntries;
+  let pinsString = window.localStorage.pinEntries;
   if (!pinsString) return;
-  var pins = JSON.parse(pinsString);
-  for(var i = 0; i < pins.length; i++) {
+  let pins = JSON.parse(pinsString);
+  for (let i = 0; i < pins.length; i++) {
     this.addPinEntry(pins[i]);
   }
-}
+};
 
 Menu.prototype.togglePinEntry = function (id) {
   if (!id) {
@@ -471,62 +586,49 @@ Menu.prototype.togglePinEntry = function (id) {
   } else {
     this.addPinEntry(id);
   }
-}
+};
 
 Menu.prototype.selectPin = function (num) {
   document.location = this.$pinList.children[num].children[0].href;
-}
+};
 
-var menu;
-function init() {
-  menu = new Menu();
-  var $container = document.getElementById('spec-container');
-  $container.addEventListener('mouseover', debounce(function (e) {
-    Toolbox.activateIfMouseOver(e);
-  }));
-  document.addEventListener('keydown', debounce(function (e) {
-    if (e.code === "Escape" && Toolbox.active) {
-      Toolbox.deactivate();
-    }
-  }));
-}
+let menu;
 
 document.addEventListener('DOMContentLoaded', init);
 
 function debounce(fn, opts) {
   opts = opts || {};
-  var timeout;
-  return function(e) {
+  let timeout;
+  return function (e) {
     if (opts.stopPropagation) {
       e.stopPropagation();
     }
-    var args = arguments;
+    let args = arguments;
     if (timeout) {
       clearTimeout(timeout);
     }
-    timeout = setTimeout(function() {
+    timeout = setTimeout(() => {
       timeout = null;
       fn.apply(this, args);
-    }.bind(this), 150);
-  }
+    }, 150);
+  };
 }
 
-var CLAUSE_NODES = ['EMU-CLAUSE', 'EMU-INTRO', 'EMU-ANNEX'];
-function findLocalReferences ($elem) {
-  var name = $elem.innerHTML;
-  var references = [];
-
-  var parentClause = $elem.parentNode;
+let CLAUSE_NODES = ['EMU-CLAUSE', 'EMU-INTRO', 'EMU-ANNEX'];
+function findContainer($elem) {
+  let parentClause = $elem.parentNode;
   while (parentClause && CLAUSE_NODES.indexOf(parentClause.nodeName) === -1) {
     parentClause = parentClause.parentNode;
   }
+  return parentClause;
+}
 
-  if(!parentClause) return;
+function findLocalReferences(parentClause, name) {
+  let vars = parentClause.querySelectorAll('var');
+  let references = [];
 
-  var vars = parentClause.querySelectorAll('var');
-
-  for (var i = 0; i < vars.length; i++) {
-    var $var = vars[i];
+  for (let i = 0; i < vars.length; i++) {
+    let $var = vars[i];
 
     if ($var.innerHTML === name) {
       references.push($var);
@@ -536,21 +638,38 @@ function findLocalReferences ($elem) {
   return references;
 }
 
+let REFERENCED_CLASSES = Array.from({ length: 7 }, (x, i) => `referenced${i}`);
+function chooseHighlightIndex(parentClause) {
+  let counts = REFERENCED_CLASSES.map($class => parentClause.getElementsByClassName($class).length);
+  // Find the earliest index with the lowest count.
+  let minCount = Infinity;
+  let index = null;
+  for (let i = 0; i < counts.length; i++) {
+    if (counts[i] < minCount) {
+      minCount = counts[i];
+      index = i;
+    }
+  }
+  return index;
+}
+
 function toggleFindLocalReferences($elem) {
-  var references = findLocalReferences($elem);
+  let parentClause = findContainer($elem);
+  let references = findLocalReferences(parentClause, $elem.innerHTML);
   if ($elem.classList.contains('referenced')) {
-    references.forEach(function ($reference) {
-      $reference.classList.remove('referenced');
+    references.forEach($reference => {
+      $reference.classList.remove('referenced', ...REFERENCED_CLASSES);
     });
   } else {
-    references.forEach(function ($reference) {
-      $reference.classList.add('referenced');
+    let index = chooseHighlightIndex(parentClause);
+    references.forEach($reference => {
+      $reference.classList.add('referenced', `referenced${index}`);
     });
   }
 }
 
-function installFindLocalReferences () {
-  document.addEventListener('click', function (e) {
+function installFindLocalReferences() {
+  document.addEventListener('click', e => {
     if (e.target.nodeName === 'VAR') {
       toggleFindLocalReferences(e.target);
     }
@@ -558,9 +677,6 @@ function installFindLocalReferences () {
 }
 
 document.addEventListener('DOMContentLoaded', installFindLocalReferences);
-
-
-
 
 // The following license applies to the fuzzysearch function
 // The MIT License (MIT)
@@ -582,11 +698,11 @@ document.addEventListener('DOMContentLoaded', installFindLocalReferences);
 // COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-function fuzzysearch (searchString, haystack, caseInsensitive) {
-  var tlen = haystack.length;
-  var qlen = searchString.length;
-  var chunks = 1;
-  var finding = false;
+function fuzzysearch(searchString, haystack, caseInsensitive) {
+  let tlen = haystack.length;
+  let qlen = searchString.length;
+  let chunks = 1;
+  let finding = false;
 
   if (qlen > tlen) {
     return false;
@@ -602,10 +718,11 @@ function fuzzysearch (searchString, haystack, caseInsensitive) {
     }
   }
 
-  outer: for (var i = 0, j = 0; i < qlen; i++) {
-    var nch = searchString[i];
+  let j = 0;
+  outer: for (let i = 0; i < qlen; i++) {
+    let nch = searchString[i];
     while (j < tlen) {
-      var targetChar = haystack[j++];
+      let targetChar = haystack[j++];
       if (targetChar === nch) {
         finding = true;
         continue outer;
@@ -616,113 +733,24 @@ function fuzzysearch (searchString, haystack, caseInsensitive) {
       }
     }
 
-    if (caseInsensitive) { return false; }
+    if (caseInsensitive) {
+      return false;
+    }
 
     return fuzzysearch(searchString.toLowerCase(), haystack.toLowerCase(), true);
   }
 
-  return { caseMatch: !caseInsensitive, chunks: chunks, prefix: j <= qlen };
+  return { caseMatch: !caseInsensitive, chunks, prefix: j <= qlen };
 }
 
-var Toolbox = {
-  init: function () {
-    this.$container = document.createElement('div');
-    this.$container.classList.add('toolbox');
-    this.$permalink = document.createElement('a');
-    this.$permalink.textContent = 'Permalink';
-    this.$pinLink = document.createElement('a');
-    this.$pinLink.textContent = 'Pin';
-    this.$pinLink.setAttribute('href', '#');
-    this.$pinLink.addEventListener('click', function (e) {
-      e.preventDefault();
-      e.stopPropagation();
-      menu.togglePinEntry(this.entry.id);
-    }.bind(this));
-
-    this.$refsLink = document.createElement('a');
-    this.$refsLink.setAttribute('href', '#');
-    this.$refsLink.addEventListener('click', function (e) {
-      e.preventDefault();
-      e.stopPropagation();
-      referencePane.showReferencesFor(this.entry);
-    }.bind(this));
-    this.$container.appendChild(this.$permalink);
-    this.$container.appendChild(this.$pinLink);
-    this.$container.appendChild(this.$refsLink);
-    document.body.appendChild(this.$container);
-  },
-
-  activate: function (el, entry, target) {
-    if (el === this._activeEl) return;
-    this.active = true;
-    this.entry = entry;
-    this.$container.classList.add('active');
-    this.top = el.offsetTop - this.$container.offsetHeight - 10;
-    this.left = el.offsetLeft;
-    this.$container.setAttribute('style', 'left: ' + this.left + 'px; top: ' + this.top + 'px');
-    this.updatePermalink();
-    this.updateReferences();
-    this._activeEl = el;
-    if (this.top < document.body.scrollTop && el === target) {
-      // don't scroll unless it's a small thing (< 200px)
-      this.$container.scrollIntoView();
-    }
-  },
-
-  updatePermalink: function () {
-    this.$permalink.setAttribute('href', '#' + this.entry.id);
-  },
-
-  updateReferences: function () {
-    this.$refsLink.textContent = 'References (' + this.entry.referencingIds.length + ')';
-  },
-
-  activateIfMouseOver: function (e) {
-    var ref = this.findReferenceUnder(e.target);
-    if (ref && (!this.active || e.pageY > this._activeEl.offsetTop)) {
-      var entry = menu.search.biblio.byId[ref.id];
-      this.activate(ref.element, entry, e.target);
-    } else if (this.active && ((e.pageY < this.top) || e.pageY > (this._activeEl.offsetTop + this._activeEl.offsetHeight))) {
-      this.deactivate();
-    }
-  },
-
-  findReferenceUnder: function (el) {
-    while (el) {
-      var parent = el.parentNode;
-      if (el.nodeName === 'H1' && parent.nodeName.match(/EMU-CLAUSE|EMU-ANNEX|EMU-INTRO/) && parent.id) {
-        return { element: el, id: parent.id };
-      } else if (el.nodeName.match(/EMU-(?!CLAUSE|XREF|ANNEX|INTRO)|DFN/) &&
-                el.id && el.id[0] !== '_') {
-        if (el.nodeName === 'EMU-FIGURE' || el.nodeName === 'EMU-TABLE' || el.nodeName === 'EMU-EXAMPLE') {
-          // return the figcaption element
-          return { element: el.children[0].children[0], id: el.id };
-        } else if (el.nodeName === 'EMU-PRODUCTION') {
-          // return the LHS non-terminal element
-          return { element: el.children[0], id: el.id };
-        } else {
-          return { element: el, id: el.id };
-        }
-      }
-      el = parent;
-    }
-  },
-
-  deactivate: function () {
-    this.$container.classList.remove('active');
-    this._activeEl = null;
-    this.activeElBounds = null;
-    this.active = false;
-  }
-}
-
-var referencePane = {
-  init: function() {
+let referencePane = {
+  init() {
     this.$container = document.createElement('div');
     this.$container.setAttribute('id', 'references-pane-container');
 
-    var $spacer = document.createElement('div');
+    let $spacer = document.createElement('div');
     $spacer.setAttribute('id', 'references-pane-spacer');
+    $spacer.classList.add('menu-spacer');
 
     this.$pane = document.createElement('div');
     this.$pane.setAttribute('id', 'references-pane');
@@ -732,18 +760,19 @@ var referencePane = {
 
     this.$header = document.createElement('div');
     this.$header.classList.add('menu-pane-header');
-    this.$header.textContent = 'References to ';
+    this.$headerText = document.createElement('span');
+    this.$header.appendChild(this.$headerText);
     this.$headerRefId = document.createElement('a');
     this.$header.appendChild(this.$headerRefId);
     this.$closeButton = document.createElement('span');
     this.$closeButton.setAttribute('id', 'references-pane-close');
-    this.$closeButton.addEventListener('click', function (e) {
+    this.$closeButton.addEventListener('click', () => {
       this.deactivate();
-    }.bind(this));
+    });
     this.$header.appendChild(this.$closeButton);
 
     this.$pane.appendChild(this.$header);
-    var tableContainer = document.createElement('div');
+    let tableContainer = document.createElement('div');
     tableContainer.setAttribute('id', 'references-pane-table-container');
 
     this.$table = document.createElement('table');
@@ -757,70 +786,238 @@ var referencePane = {
     menu.$specContainer.appendChild(this.$container);
   },
 
-  activate: function () {
+  activate() {
     this.$container.classList.add('active');
   },
 
-  deactivate: function () {
+  deactivate() {
     this.$container.classList.remove('active');
+    this.state = null;
   },
 
   showReferencesFor(entry) {
     this.activate();
-    var newBody = document.createElement('tbody');
-    var previousId;
-    var previousCell;
-    var dupCount = 0;
+    this.state = { type: 'ref', id: entry.id };
+    this.$headerText.textContent = 'References to ';
+    let newBody = document.createElement('tbody');
+    let previousId;
+    let previousCell;
+    let dupCount = 0;
     this.$headerRefId.textContent = '#' + entry.id;
-    this.$headerRefId.setAttribute('href', '#' + entry.id);
-    entry.referencingIds.map(function (id) {
-      var target = document.getElementById(id);
-      var cid = findParentClauseId(target);
-      var clause = menu.search.biblio.byId[cid];
-      return { id: id, clause: clause }
-    }).sort(function (a, b) {
-      return sortByClauseNumber(a.clause, b.clause);
-    }).forEach(function (record, i) {
-      if (previousId === record.clause.id) {
-        previousCell.innerHTML += ' (<a href="#' + record.id + '">' + (dupCount + 2) + '</a>)';
-        dupCount++;
-      } else {
-        var row = newBody.insertRow();
-        var cell = row.insertCell();
-        cell.innerHTML = record.clause.number;
-        cell = row.insertCell();
-        cell.innerHTML = '<a href="#' + record.id + '">' + record.clause.titleHTML + '</a>';
-        previousCell = cell;
-        previousId = record.clause.id;
-        dupCount = 0;
-      }
-    }, this);
+    this.$headerRefId.setAttribute('href', makeLinkToId(entry.id));
+    this.$headerRefId.style.display = 'inline';
+    (entry.referencingIds || [])
+      .map(id => {
+        let cid = menu.search.biblio.refParentClause[id];
+        let clause = menu.search.biblio.byId[cid];
+        if (clause == null) {
+          throw new Error('could not find clause for id ' + cid);
+        }
+        return { id, clause };
+      })
+      .sort((a, b) => sortByClauseNumber(a.clause, b.clause))
+      .forEach(record => {
+        if (previousId === record.clause.id) {
+          previousCell.innerHTML += ` (<a href="${makeLinkToId(record.id)}">${dupCount + 2}</a>)`;
+          dupCount++;
+        } else {
+          let row = newBody.insertRow();
+          let cell = row.insertCell();
+          cell.innerHTML = record.clause.number;
+          cell = row.insertCell();
+          cell.innerHTML = `<a href="${makeLinkToId(record.id)}">${record.clause.titleHTML}</a>`;
+          previousCell = cell;
+          previousId = record.clause.id;
+          dupCount = 0;
+        }
+      }, this);
     this.$table.removeChild(this.$tableBody);
     this.$tableBody = newBody;
     this.$table.appendChild(this.$tableBody);
-  }
-}
-function findParentClauseId(node) {
-  while (node && node.nodeName !== 'EMU-CLAUSE' && node.nodeName !== 'EMU-INTRO' && node.nodeName !== 'EMU-ANNEX') {
-    node = node.parentNode;
-  }
-  if (!node) return null;
-  return node.getAttribute('id');
-}
+  },
 
-function sortByClauseNumber(c1, c2) {
-  var c1c = c1.number.split('.');
-  var c2c = c2.number.split('.');
+  showSDOs(sdos, alternativeId) {
+    let rhs = document.getElementById(alternativeId);
+    let parentName = rhs.parentNode.getAttribute('name');
+    let colons = rhs.parentNode.querySelector('emu-geq');
+    rhs = rhs.cloneNode(true);
+    rhs.querySelectorAll('emu-params,emu-constraints').forEach(e => {
+      e.remove();
+    });
+    rhs.querySelectorAll('[id]').forEach(e => {
+      e.removeAttribute('id');
+    });
+    rhs.querySelectorAll('a').forEach(e => {
+      e.parentNode.replaceChild(document.createTextNode(e.textContent), e);
+    });
 
-  for (var i = 0; i < c1c.length; i++) {
+    // prettier-ignore
+    this.$headerText.innerHTML = `Syntax-Directed Operations for<br><a href="${makeLinkToId(alternativeId)}" class="menu-pane-header-production"><emu-nt>${parentName}</emu-nt> ${colons.outerHTML} </a>`;
+    this.$headerText.querySelector('a').append(rhs);
+    this.showSDOsBody(sdos, alternativeId);
+  },
+
+  showSDOsBody(sdos, alternativeId) {
+    this.activate();
+    this.state = { type: 'sdo', id: alternativeId, html: this.$headerText.innerHTML };
+    this.$headerRefId.style.display = 'none';
+    let newBody = document.createElement('tbody');
+    Object.keys(sdos).forEach(sdoName => {
+      let pair = sdos[sdoName];
+      let clause = pair.clause;
+      let ids = pair.ids;
+      let first = ids[0];
+      let row = newBody.insertRow();
+      let cell = row.insertCell();
+      cell.innerHTML = clause;
+      cell = row.insertCell();
+      let html = '<a href="' + makeLinkToId(first) + '">' + sdoName + '</a>';
+      for (let i = 1; i < ids.length; ++i) {
+        html += ' (<a href="' + makeLinkToId(ids[i]) + '">' + (i + 1) + '</a>)';
+      }
+      cell.innerHTML = html;
+    });
+    this.$table.removeChild(this.$tableBody);
+    this.$tableBody = newBody;
+    this.$table.appendChild(this.$tableBody);
+  },
+};
+
+let Toolbox = {
+  init() {
+    this.$outer = document.createElement('div');
+    this.$outer.classList.add('toolbox-container');
+    this.$container = document.createElement('div');
+    this.$container.classList.add('toolbox');
+    this.$outer.appendChild(this.$container);
+    this.$permalink = document.createElement('a');
+    this.$permalink.textContent = 'Permalink';
+    this.$pinLink = document.createElement('a');
+    this.$pinLink.textContent = 'Pin';
+    this.$pinLink.setAttribute('href', '#');
+    this.$pinLink.addEventListener('click', e => {
+      e.preventDefault();
+      e.stopPropagation();
+      menu.togglePinEntry(this.entry.id);
+      this.$pinLink.textContent = menu._pinnedIds[this.entry.id] ? 'Unpin' : 'Pin';
+    });
+
+    this.$refsLink = document.createElement('a');
+    this.$refsLink.setAttribute('href', '#');
+    this.$refsLink.addEventListener('click', e => {
+      e.preventDefault();
+      e.stopPropagation();
+      referencePane.showReferencesFor(this.entry);
+    });
+    this.$container.appendChild(this.$permalink);
+    this.$container.appendChild(this.$pinLink);
+    this.$container.appendChild(this.$refsLink);
+    document.body.appendChild(this.$outer);
+  },
+
+  activate(el, entry, target) {
+    if (el === this._activeEl) return;
+    sdoBox.deactivate();
+    this.active = true;
+    this.entry = entry;
+    this.$pinLink.textContent = menu._pinnedIds[entry.id] ? 'Unpin' : 'Pin';
+    this.$outer.classList.add('active');
+    this.top = el.offsetTop - this.$outer.offsetHeight;
+    this.left = el.offsetLeft - 10;
+    this.$outer.setAttribute('style', 'left: ' + this.left + 'px; top: ' + this.top + 'px');
+    this.updatePermalink();
+    this.updateReferences();
+    this._activeEl = el;
+    if (this.top < document.body.scrollTop && el === target) {
+      // don't scroll unless it's a small thing (< 200px)
+      this.$outer.scrollIntoView();
+    }
+  },
+
+  updatePermalink() {
+    this.$permalink.setAttribute('href', makeLinkToId(this.entry.id));
+  },
+
+  updateReferences() {
+    this.$refsLink.textContent = `References (${(this.entry.referencingIds || []).length})`;
+  },
+
+  activateIfMouseOver(e) {
+    let ref = this.findReferenceUnder(e.target);
+    if (ref && (!this.active || e.pageY > this._activeEl.offsetTop)) {
+      let entry = menu.search.biblio.byId[ref.id];
+      this.activate(ref.element, entry, e.target);
+    } else if (
+      this.active &&
+      (e.pageY < this.top || e.pageY > this._activeEl.offsetTop + this._activeEl.offsetHeight)
+    ) {
+      this.deactivate();
+    }
+  },
+
+  findReferenceUnder(el) {
+    while (el) {
+      let parent = el.parentNode;
+      if (el.nodeName === 'EMU-RHS' || el.nodeName === 'EMU-PRODUCTION') {
+        return null;
+      }
+      if (
+        el.nodeName === 'H1' &&
+        parent.nodeName.match(/EMU-CLAUSE|EMU-ANNEX|EMU-INTRO/) &&
+        parent.id
+      ) {
+        return { element: el, id: parent.id };
+      } else if (el.nodeName === 'EMU-NT') {
+        if (
+          parent.nodeName === 'EMU-PRODUCTION' &&
+          parent.id &&
+          parent.id[0] !== '_' &&
+          parent.firstElementChild === el
+        ) {
+          // return the LHS non-terminal element
+          return { element: el, id: parent.id };
+        }
+        return null;
+      } else if (
+        el.nodeName.match(/EMU-(?!CLAUSE|XREF|ANNEX|INTRO)|DFN/) &&
+        el.id &&
+        el.id[0] !== '_'
+      ) {
+        if (
+          el.nodeName === 'EMU-FIGURE' ||
+          el.nodeName === 'EMU-TABLE' ||
+          el.nodeName === 'EMU-EXAMPLE'
+        ) {
+          // return the figcaption element
+          return { element: el.children[0].children[0], id: el.id };
+        } else {
+          return { element: el, id: el.id };
+        }
+      }
+      el = parent;
+    }
+  },
+
+  deactivate() {
+    this.$outer.classList.remove('active');
+    this._activeEl = null;
+    this.active = false;
+  },
+};
+
+function sortByClauseNumber(clause1, clause2) {
+  let c1c = clause1.number.split('.');
+  let c2c = clause2.number.split('.');
+
+  for (let i = 0; i < c1c.length; i++) {
     if (i >= c2c.length) {
       return 1;
     }
 
-    var c1 = c1c[i];
-    var c2 = c2c[i];
-    var c1cn = Number(c1);
-    var c2cn = Number(c2);
+    let c1 = c1c[i];
+    let c2 = c2c[i];
+    let c1cn = Number(c1);
+    let c2cn = Number(c2);
 
     if (Number.isNaN(c1cn) && Number.isNaN(c2cn)) {
       if (c1 > c2) {
@@ -832,7 +1029,7 @@ function sortByClauseNumber(c1, c2) {
       return -1;
     } else if (Number.isNaN(c1cn) && !Number.isNaN(c2cn)) {
       return 1;
-    } else if(c1cn > c2cn) {
+    } else if (c1cn > c2cn) {
       return 1;
     } else if (c1cn < c2cn) {
       return -1;
@@ -845,59 +1042,314 @@ function sortByClauseNumber(c1, c2) {
   return -1;
 }
 
-document.addEventListener('DOMContentLoaded', function () {
+function makeLinkToId(id) {
+  let hash = '#' + id;
+  if (typeof idToSection === 'undefined' || !idToSection[id]) {
+    return hash;
+  }
+  let targetSec = idToSection[id];
+  return (targetSec === 'index' ? './' : targetSec + '.html') + hash;
+}
+
+function doShortcut(e) {
+  if (!(e.target instanceof HTMLElement)) {
+    return;
+  }
+  let target = e.target;
+  let name = target.nodeName.toLowerCase();
+  if (name === 'textarea' || name === 'input' || name === 'select' || target.isContentEditable) {
+    return;
+  }
+  if (e.altKey || e.ctrlKey || e.metaKey) {
+    return;
+  }
+  if (e.key === 'm' && usesMultipage) {
+    let pathParts = location.pathname.split('/');
+    let hash = location.hash;
+    if (pathParts[pathParts.length - 2] === 'multipage') {
+      if (hash === '') {
+        let sectionName = pathParts[pathParts.length - 1];
+        if (sectionName.endsWith('.html')) {
+          sectionName = sectionName.slice(0, -5);
+        }
+        if (idToSection['sec-' + sectionName] !== undefined) {
+          hash = '#sec-' + sectionName;
+        }
+      }
+      location = pathParts.slice(0, -2).join('/') + '/' + hash;
+    } else {
+      location = 'multipage/' + hash;
+    }
+  } else if (e.key === 'u') {
+    document.documentElement.classList.toggle('show-ao-annotations');
+  } else if (e.key === '?') {
+    document.getElementById('shortcuts-help').classList.toggle('active');
+  }
+}
+
+function init() {
+  menu = new Menu();
+  let $container = document.getElementById('spec-container');
+  $container.addEventListener(
+    'mouseover',
+    debounce(e => {
+      Toolbox.activateIfMouseOver(e);
+    })
+  );
+  document.addEventListener(
+    'keydown',
+    debounce(e => {
+      if (e.code === 'Escape') {
+        if (Toolbox.active) {
+          Toolbox.deactivate();
+        }
+        document.getElementById('shortcuts-help').classList.remove('active');
+      }
+    })
+  );
+}
+
+document.addEventListener('keypress', doShortcut);
+
+document.addEventListener('DOMContentLoaded', () => {
   Toolbox.init();
   referencePane.init();
-})
-var CLAUSE_NODES = ['EMU-CLAUSE', 'EMU-INTRO', 'EMU-ANNEX'];
-function findLocalReferences ($elem) {
-  var name = $elem.innerHTML;
-  var references = [];
+});
 
-  var parentClause = $elem.parentNode;
-  while (parentClause && CLAUSE_NODES.indexOf(parentClause.nodeName) === -1) {
-    parentClause = parentClause.parentNode;
+// preserve state during navigation
+
+function getTocPath(li) {
+  let path = [];
+  let pointer = li;
+  while (true) {
+    let parent = pointer.parentElement;
+    if (parent == null) {
+      return null;
+    }
+    let index = [].indexOf.call(parent.children, pointer);
+    if (index == -1) {
+      return null;
+    }
+    path.unshift(index);
+    pointer = parent.parentElement;
+    if (pointer == null) {
+      return null;
+    }
+    if (pointer.id === 'menu-toc') {
+      break;
+    }
+    if (pointer.tagName !== 'LI') {
+      return null;
+    }
   }
+  return path;
+}
 
-  if(!parentClause) return;
+function activateTocPath(path) {
+  try {
+    let pointer = document.getElementById('menu-toc');
+    for (let index of path) {
+      pointer = pointer.querySelector('ol').children[index];
+    }
+    pointer.classList.add('active');
+  } catch (e) {
+    // pass
+  }
+}
 
-  var vars = parentClause.querySelectorAll('var');
+function getActiveTocPaths() {
+  return [...menu.$menu.querySelectorAll('.active')].map(getTocPath).filter(p => p != null);
+}
 
-  for (var i = 0; i < vars.length; i++) {
-    var $var = vars[i];
-
-    if ($var.innerHTML === name) {
-      references.push($var);
+function loadStateFromSessionStorage() {
+  if (!window.sessionStorage || typeof menu === 'undefined' || window.navigating) {
+    return;
+  }
+  if (sessionStorage.referencePaneState != null) {
+    let state = JSON.parse(sessionStorage.referencePaneState);
+    if (state != null) {
+      if (state.type === 'ref') {
+        let entry = menu.search.biblio.byId[state.id];
+        if (entry != null) {
+          referencePane.showReferencesFor(entry);
+        }
+      } else if (state.type === 'sdo') {
+        let sdos = sdoMap[state.id];
+        if (sdos != null) {
+          referencePane.$headerText.innerHTML = state.html;
+          referencePane.showSDOsBody(sdos, state.id);
+        }
+      }
+      delete sessionStorage.referencePaneState;
     }
   }
 
-  return references;
-}
+  if (sessionStorage.activeTocPaths != null) {
+    document
+      .getElementById('menu-toc')
+      .querySelectorAll('.active')
+      .forEach(e => {
+        e.classList.remove('active');
+      });
+    let active = JSON.parse(sessionStorage.activeTocPaths);
+    active.forEach(activateTocPath);
+    delete sessionStorage.activeTocPaths;
+  }
 
-function toggleFindLocalReferences($elem) {
-  var references = findLocalReferences($elem);
-  if ($elem.classList.contains('referenced')) {
-    references.forEach(function ($reference) {
-      $reference.classList.remove('referenced');
-    });
-  } else {
-    references.forEach(function ($reference) {
-      $reference.classList.add('referenced');
-    });
+  if (sessionStorage.searchValue != null) {
+    let value = JSON.parse(sessionStorage.searchValue);
+    menu.search.$searchBox.value = value;
+    menu.search.search(value);
+    delete sessionStorage.searchValue;
+  }
+
+  if (sessionStorage.tocScroll != null) {
+    let tocScroll = JSON.parse(sessionStorage.tocScroll);
+    menu.$toc.scrollTop = tocScroll;
+    delete sessionStorage.tocScroll;
   }
 }
 
-function installFindLocalReferences () {
-  document.addEventListener('click', function (e) {
-    if (e.target.nodeName === 'VAR') {
-      toggleFindLocalReferences(e.target);
+document.addEventListener('DOMContentLoaded', loadStateFromSessionStorage);
+
+window.addEventListener('pageshow', loadStateFromSessionStorage);
+
+window.addEventListener('beforeunload', () => {
+  if (!window.sessionStorage || typeof menu === 'undefined') {
+    return;
+  }
+  sessionStorage.referencePaneState = JSON.stringify(referencePane.state || null);
+  sessionStorage.activeTocPaths = JSON.stringify(getActiveTocPaths());
+  sessionStorage.searchValue = JSON.stringify(menu.search.$searchBox.value);
+  sessionStorage.tocScroll = JSON.stringify(menu.$toc.scrollTop);
+});
+
+'use strict';
+
+// Manually prefix algorithm step list items with hidden counter representations
+// corresponding with their markers so they get selected and copied with content.
+// We read list-style-type to avoid divergence with the style sheet, but
+// for efficiency assume that all lists at the same nesting depth use the same
+// style (except for those associated with replacement steps).
+// We also precompute some initial items for each supported style type.
+// https://w3c.github.io/csswg-drafts/css-counter-styles/
+
+const lowerLetters = Array.from({ length: 26 }, (_, i) =>
+  String.fromCharCode('a'.charCodeAt(0) + i)
+);
+// Implement the lower-alpha 'alphabetic' algorithm,
+// adjusting for indexing from 0 rather than 1.
+// https://w3c.github.io/csswg-drafts/css-counter-styles/#simple-alphabetic
+// https://w3c.github.io/csswg-drafts/css-counter-styles/#alphabetic-system
+const lowerAlphaTextForIndex = i => {
+  let S = '';
+  for (const N = lowerLetters.length; i >= 0; i--) {
+    S = lowerLetters[i % N] + S;
+    i = Math.floor(i / N);
+  }
+  return S;
+};
+
+const weightedLowerRomanSymbols = Object.entries({
+  m: 1000,
+  cm: 900,
+  d: 500,
+  cd: 400,
+  c: 100,
+  xc: 90,
+  l: 50,
+  xl: 40,
+  x: 10,
+  ix: 9,
+  v: 5,
+  iv: 4,
+  i: 1,
+});
+// Implement the lower-roman 'additive' algorithm,
+// adjusting for indexing from 0 rather than 1.
+// https://w3c.github.io/csswg-drafts/css-counter-styles/#simple-numeric
+// https://w3c.github.io/csswg-drafts/css-counter-styles/#additive-system
+const lowerRomanTextForIndex = i => {
+  let value = i + 1;
+  let S = '';
+  for (const [symbol, weight] of weightedLowerRomanSymbols) {
+    if (!value) break;
+    if (weight > value) continue;
+    const reps = Math.floor(value / weight);
+    S += symbol.repeat(reps);
+    value -= weight * reps;
+  }
+  return S;
+};
+
+// Memoize pure index-to-text functions with an exposed cache for fast retrieval.
+const makeCounter = (pureGetTextForIndex, precomputeCount = 30) => {
+  const cache = Array.from({ length: precomputeCount }, (_, i) => pureGetTextForIndex(i));
+  const getTextForIndex = i => {
+    if (i >= cache.length) cache[i] = pureGetTextForIndex(i);
+    return cache[i];
+  };
+  return { getTextForIndex, cache };
+};
+
+const counterByStyle = {
+  __proto__: null,
+  decimal: makeCounter(i => String(i + 1)),
+  'lower-alpha': makeCounter(lowerAlphaTextForIndex),
+  'upper-alpha': makeCounter(i => lowerAlphaTextForIndex(i).toUpperCase()),
+  'lower-roman': makeCounter(lowerRomanTextForIndex),
+  'upper-roman': makeCounter(i => lowerRomanTextForIndex(i).toUpperCase()),
+};
+const fallbackCounter = makeCounter(() => '?');
+const counterByDepth = [];
+
+function addStepNumberText(
+  ol,
+  depth = 0,
+  special = [...ol.classList].some(c => c.startsWith('nested-'))
+) {
+  let counter = !special && counterByDepth[depth];
+  if (!counter) {
+    const counterStyle = getComputedStyle(ol)['list-style-type'];
+    counter = counterByStyle[counterStyle];
+    if (!counter) {
+      console.warn('unsupported list-style-type', {
+        ol,
+        counterStyle,
+        id: ol.closest('[id]')?.getAttribute('id'),
+      });
+      counterByStyle[counterStyle] = fallbackCounter;
+      counter = fallbackCounter;
     }
+    if (!special) {
+      counterByDepth[depth] = counter;
+    }
+  }
+  const { cache, getTextForIndex } = counter;
+  let i = (Number(ol.getAttribute('start')) || 1) - 1;
+  for (const li of ol.children) {
+    const marker = document.createElement('span');
+    marker.textContent = `${i < cache.length ? cache[i] : getTextForIndex(i)}. `;
+    marker.setAttribute('aria-hidden', 'true');
+    li.prepend(marker);
+    for (const sublist of li.querySelectorAll(':scope > ol')) {
+      addStepNumberText(sublist, depth + 1, special);
+    }
+    i++;
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('emu-alg > ol').forEach(ol => {
+    addStepNumberText(ol);
   });
-}
+});
 
-document.addEventListener('DOMContentLoaded', installFindLocalReferences);
-</script><style>body {
+let sdoMap = JSON.parse(`{}`);
+let biblio = JSON.parse(`{"refsByClause":{"sec-intl.numberformat.prototype.format":["_ref_0","_ref_30"],"sec-intl.numberformat.prototype.resolvedoptions":["_ref_1","_ref_39"],"sec-properties-of-intl-numberformat-instances":["_ref_2","_ref_3","_ref_4","_ref_40"],"sec-partitionnotationsubpattern":["_ref_5","_ref_6","_ref_54","_ref_55","_ref_56"],"sec-torawprecision":["_ref_7","_ref_61","_ref_62","_ref_63"],"sec-torawfixed":["_ref_8","_ref_64","_ref_65","_ref_66"],"sec-getnumberformatpattern":["_ref_9","_ref_10","_ref_69","_ref_70"],"sec-getnotationsubpattern":["_ref_11","_ref_12","_ref_71"],"sec-getunsignedroundingmode":["_ref_13","_ref_14","_ref_15"],"sec-applyunsignedroundingmode":["_ref_16"],"sec-intl.numberformat":["_ref_17","_ref_18"],"sec-chainnumberformat":["_ref_19"],"sec-initializenumberformat":["_ref_20","_ref_21","_ref_22","_ref_23","_ref_24","_ref_25"],"sec-setnfdigitoptions":["_ref_26"],"sec-intl.numberformat.prototype":["_ref_27"],"sec-intl.numberformat.supportedlocalesof":["_ref_28"],"sec-intl.numberformat.prototype.constructor":["_ref_29"],"sec-intl.numberformat.prototype.formattoparts":["_ref_31","_ref_32"],"sec-intl.numberformat.prototype.formatrange":["_ref_33","_ref_34","_ref_35"],"sec-intl.numberformat.prototype.formatrangetoparts":["_ref_36","_ref_37","_ref_38"],"sec-number-format-functions":["_ref_41","_ref_42"],"sec-formatnumberstring":["_ref_43","_ref_44","_ref_45","_ref_46","_ref_47","_ref_48"],"sec-partitionnumberpattern":["_ref_49","_ref_50","_ref_51","_ref_52","_ref_53"],"sec-formatnumber":["_ref_57","_ref_58"],"sec-formatnumbertoparts":["_ref_59","_ref_60"],"sec-unwrapnumberformat":["_ref_67","_ref_68"],"sec-computeexponent":["_ref_72","_ref_73","_ref_74"],"sec-runtime-semantics-stringintlmv":["_ref_75","_ref_76"],"sec-tointlmathematicalvalue":["_ref_77"],"sec-partitionnumberrangepattern":["_ref_78","_ref_79","_ref_80","_ref_81","_ref_82","_ref_83"],"sec-formatapproximately":["_ref_84"],"sec-collapsenumberrange":["_ref_85"],"sec-formatnumericrange":["_ref_86","_ref_87","_ref_88"],"sec-formatnumericrangetoparts":["_ref_89","_ref_90","_ref_91"]},"entries":[{"type":"term","term":"%NumberFormat%","refId":"sec-intl-numberformat-constructor"},{"type":"op","aoid":"ChainNumberFormat","refId":"sec-chainnumberformat"},{"type":"clause","id":"sec-chainnumberformat","title":"ChainNumberFormat ( numberFormat, newTarget, this )","titleHTML":"ChainNumberFormat ( <var>numberFormat</var>, <var>newTarget</var>, <var>this</var> )","number":"1.1.1.1","referencingIds":["_ref_18"]},{"type":"clause","id":"sec-intl.numberformat","title":"Intl.NumberFormat ( [ locales [ , options ] ] )","titleHTML":"Intl.NumberFormat ( [ <var>locales</var> [ , <var>options</var> ] ] )","number":"1.1.1"},{"type":"op","aoid":"InitializeNumberFormat","refId":"sec-initializenumberformat"},{"type":"clause","id":"sec-initializenumberformat","title":"InitializeNumberFormat ( numberFormat, locales, options )","titleHTML":"InitializeNumberFormat ( <var>numberFormat</var>, <var>locales</var>, <var>options</var> )","number":"1.1.2","referencingIds":["_ref_17"]},{"type":"op","aoid":"SetNumberFormatDigitOptions","refId":"sec-setnfdigitoptions"},{"type":"clause","id":"sec-setnfdigitoptions","title":"SetNumberFormatDigitOptions ( intlObj, options, mnfdDefault, mxfdDefault, notation )","titleHTML":"SetNumberFormatDigitOptions ( <var>intlObj</var>, <var>options</var>, <var>mnfdDefault</var>, <var>mxfdDefault</var>, <var>notation</var> )","number":"1.1.3","referencingIds":["_ref_25","_ref_26"]},{"type":"op","aoid":"SetNumberFormatUnitOptions","refId":"sec-setnumberformatunitoptions"},{"type":"clause","id":"sec-setnumberformatunitoptions","title":"SetNumberFormatUnitOptions ( intlObj, options )","titleHTML":"SetNumberFormatUnitOptions ( <var>intlObj</var>, <var>options</var> )","number":"1.1.4","referencingIds":["_ref_23"]},{"type":"clause","id":"sec-intl-numberformat-constructor","titleHTML":"The Intl.NumberFormat Constructor","number":"1.1","referencingIds":["_ref_19","_ref_20","_ref_21","_ref_22","_ref_28","_ref_29","_ref_67","_ref_68","_ref_70","_ref_71"]},{"type":"clause","id":"sec-intl.numberformat.prototype","titleHTML":"Intl.NumberFormat.prototype","number":"1.2.1"},{"type":"clause","id":"sec-intl.numberformat.supportedlocalesof","title":"Intl.NumberFormat.supportedLocalesOf ( locales [ , options ] )","titleHTML":"Intl.NumberFormat.supportedLocalesOf ( <var>locales</var> [ , <var>options</var> ] )","number":"1.2.2"},{"type":"clause","id":"sec-intl.numberformat-internal-slots","titleHTML":"Internal slots","number":"1.2.3","referencingIds":["_ref_9","_ref_10","_ref_11","_ref_12"]},{"type":"clause","id":"sec-properties-of-intl-numberformat-constructor","titleHTML":"Properties of the Intl.NumberFormat Constructor","number":"1.2"},{"type":"term","term":"%NumberFormat.prototype%","refId":"sec-properties-of-intl-numberformat-prototype-object"},{"type":"clause","id":"sec-intl.numberformat.prototype.constructor","titleHTML":"Intl.NumberFormat.prototype.constructor","number":"1.3.1"},{"type":"clause","id":"sec-intl.numberformat.prototype-@@tostringtag","titleHTML":"Intl.NumberFormat.prototype [ @@toStringTag ]","number":"1.3.2"},{"type":"clause","id":"sec-intl.numberformat.prototype.format","titleHTML":"get Intl.NumberFormat.prototype.format","number":"1.3.3","referencingIds":["_ref_4"]},{"type":"clause","id":"sec-intl.numberformat.prototype.formattoparts","title":"Intl.NumberFormat.prototype.formatToParts ( value )","titleHTML":"Intl.NumberFormat.prototype.formatToParts ( <var>value</var> )","number":"1.3.4"},{"type":"clause","id":"sec-intl.numberformat.prototype.formatrange","title":"Intl.NumberFormat.prototype.formatRange ( start, end )","titleHTML":"Intl.NumberFormat.prototype.formatRange ( <var>start</var>, <var>end</var> )","number":"1.3.5"},{"type":"clause","id":"sec-intl.numberformat.prototype.formatrangetoparts","title":"Intl.NumberFormat.prototype.formatRangeToParts ( start, end )","titleHTML":"Intl.NumberFormat.prototype.formatRangeToParts ( <var>start</var>, <var>end</var> )","number":"1.3.6"},{"type":"table","id":"table-numberformat-resolvedoptions-properties","number":1,"caption":"Table 1: Resolved Options of NumberFormat Instances","referencingIds":["_ref_1"]},{"type":"clause","id":"sec-intl.numberformat.prototype.resolvedoptions","titleHTML":"Intl.NumberFormat.prototype.resolvedOptions ( )","number":"1.3.7","referencingIds":["_ref_2"]},{"type":"clause","id":"sec-properties-of-intl-numberformat-prototype-object","titleHTML":"Properties of the Intl.NumberFormat Prototype Object","number":"1.3","referencingIds":["_ref_27","_ref_40"]},{"type":"table","id":"table-intl-rounding-modes","number":2,"caption":"Table 2: Rounding modes in Intl.NumberFormat","referencingIds":["_ref_3","_ref_13"]},{"type":"clause","id":"sec-properties-of-intl-numberformat-instances","titleHTML":"Properties of Intl.NumberFormat Instances","number":"1.4"},{"type":"op","aoid":"CurrencyDigits","refId":"sec-currencydigits"},{"type":"clause","id":"sec-currencydigits","title":"CurrencyDigits ( currency )","titleHTML":"CurrencyDigits ( <var>currency</var> )","number":"1.5.1","referencingIds":["_ref_24"]},{"type":"clause","id":"sec-number-format-functions","titleHTML":"Number Format Functions","number":"1.5.2","referencingIds":["_ref_0"]},{"type":"op","aoid":"FormatNumericToString","refId":"sec-formatnumberstring"},{"type":"clause","id":"sec-formatnumberstring","title":"FormatNumericToString ( intlObject, x )","titleHTML":"FormatNumericToString ( <var>intlObject</var>, <var>x</var> )","number":"1.5.3","referencingIds":["_ref_51","_ref_73"]},{"type":"op","aoid":"PartitionNumberPattern","refId":"sec-partitionnumberpattern"},{"type":"clause","id":"sec-partitionnumberpattern","title":"PartitionNumberPattern ( numberFormat, x )","titleHTML":"PartitionNumberPattern ( <var>numberFormat</var>, <var>x</var> )","number":"1.5.4","referencingIds":["_ref_58","_ref_60","_ref_80","_ref_81","_ref_84"]},{"type":"table","id":"table-numbering-system-digits","number":3,"caption":"Table 3: Numbering systems with simple digit mappings","referencingIds":["_ref_5","_ref_6"]},{"type":"op","aoid":"PartitionNotationSubPattern","refId":"sec-partitionnotationsubpattern"},{"type":"clause","id":"sec-partitionnotationsubpattern","title":"PartitionNotationSubPattern ( numberFormat, x, n, exponent )","titleHTML":"PartitionNotationSubPattern ( <var>numberFormat</var>, <var>x</var>, <var>n</var>, <var>exponent</var> )","number":"1.5.5","referencingIds":["_ref_53"]},{"type":"op","aoid":"FormatNumeric","refId":"sec-formatnumber"},{"type":"clause","id":"sec-formatnumber","title":"FormatNumeric ( numberFormat, x )","titleHTML":"FormatNumeric ( <var>numberFormat</var>, <var>x</var> )","number":"1.5.6","referencingIds":["_ref_42"]},{"type":"op","aoid":"FormatNumericToParts","refId":"sec-formatnumbertoparts"},{"type":"clause","id":"sec-formatnumbertoparts","title":"FormatNumericToParts ( numberFormat, x )","titleHTML":"FormatNumericToParts ( <var>numberFormat</var>, <var>x</var> )","number":"1.5.7","referencingIds":["_ref_32"]},{"type":"op","aoid":"ToRawPrecisionFn","id":"eqn-ToRawPrecisionFn","referencingIds":["_ref_61","_ref_62"]},{"type":"op","aoid":"ToRawPrecision","refId":"sec-torawprecision"},{"type":"clause","id":"sec-torawprecision","title":"ToRawPrecision ( x, minPrecision, maxPrecision, unsignedRoundingMode )","titleHTML":"ToRawPrecision ( <var>x</var>, <var>minPrecision</var>, <var>maxPrecision</var>, <var>unsignedRoundingMode</var> )","number":"1.5.8","referencingIds":["_ref_45","_ref_47"]},{"type":"op","aoid":"ToRawFixedFn","id":"eqn-ToRawFixedFn","referencingIds":["_ref_64","_ref_65"]},{"type":"op","aoid":"ToRawFixed","refId":"sec-torawfixed"},{"type":"clause","id":"sec-torawfixed","title":"ToRawFixed ( x, minFraction, maxFraction, roundingIncrement, unsignedRoundingMode )","titleHTML":"ToRawFixed ( <var>x</var>, <var>minFraction</var>, <var>maxFraction</var>, <var>roundingIncrement</var>, <var>unsignedRoundingMode</var> )","number":"1.5.9","referencingIds":["_ref_46","_ref_48","_ref_56"]},{"type":"op","aoid":"UnwrapNumberFormat","refId":"sec-unwrapnumberformat"},{"type":"clause","id":"sec-unwrapnumberformat","title":"UnwrapNumberFormat ( nf )","titleHTML":"UnwrapNumberFormat ( <var>nf</var> )","number":"1.5.10","referencingIds":["_ref_30","_ref_39"]},{"type":"op","aoid":"GetNumberFormatPattern","refId":"sec-getnumberformatpattern"},{"type":"clause","id":"sec-getnumberformatpattern","title":"GetNumberFormatPattern ( numberFormat, x )","titleHTML":"GetNumberFormatPattern ( <var>numberFormat</var>, <var>x</var> )","number":"1.5.11","referencingIds":["_ref_52"]},{"type":"op","aoid":"GetNotationSubPattern","refId":"sec-getnotationsubpattern"},{"type":"clause","id":"sec-getnotationsubpattern","title":"GetNotationSubPattern ( numberFormat, exponent )","titleHTML":"GetNotationSubPattern ( <var>numberFormat</var>, <var>exponent</var> )","number":"1.5.12","referencingIds":["_ref_55"]},{"type":"op","aoid":"ComputeExponent","refId":"sec-computeexponent"},{"type":"clause","id":"sec-computeexponent","title":"ComputeExponent ( numberFormat, x )","titleHTML":"ComputeExponent ( <var>numberFormat</var>, <var>x</var> )","number":"1.5.13","referencingIds":["_ref_50"]},{"type":"op","aoid":"ComputeExponentForMagnitude","refId":"sec-computeexponentformagnitude"},{"type":"clause","id":"sec-computeexponentformagnitude","title":"ComputeExponentForMagnitude ( numberFormat, magnitude )","titleHTML":"ComputeExponentForMagnitude ( <var>numberFormat</var>, <var>magnitude</var> )","number":"1.5.14","referencingIds":["_ref_72","_ref_74"]},{"type":"op","aoid":"StringIntlMV","refId":"sec-runtime-semantics-stringintlmv"},{"type":"clause","id":"sec-runtime-semantics-stringintlmv","titleHTML":"Runtime Semantics: StringIntlMV","number":"1.5.15","referencingIds":["_ref_75","_ref_76","_ref_77"]},{"type":"term","term":"Intl mathematical value","id":"intl-mathematical-value","referencingIds":["_ref_43","_ref_49","_ref_54","_ref_57","_ref_59","_ref_69","_ref_78","_ref_79","_ref_86","_ref_87","_ref_89","_ref_90"]},{"type":"op","aoid":"ToIntlMathematicalValue","refId":"sec-tointlmathematicalvalue"},{"type":"clause","id":"sec-tointlmathematicalvalue","title":"ToIntlMathematicalValue ( value )","titleHTML":"ToIntlMathematicalValue ( <var>value</var> )","number":"1.5.16","referencingIds":["_ref_31","_ref_33","_ref_34","_ref_36","_ref_37","_ref_41"]},{"type":"table","id":"table-intl-unsigned-rounding-modes","number":4,"caption":"Table 4: Conversion from rounding mode to unsigned rounding mode","referencingIds":["_ref_7","_ref_8","_ref_14","_ref_15","_ref_16"]},{"type":"op","aoid":"GetUnsignedRoundingMode","refId":"sec-getunsignedroundingmode"},{"type":"clause","id":"sec-getunsignedroundingmode","title":"GetUnsignedRoundingMode ( roundingMode, isNegative )","titleHTML":"GetUnsignedRoundingMode ( <var>roundingMode</var>, <var>isNegative</var> )","number":"1.5.17","referencingIds":["_ref_44"]},{"type":"op","aoid":"ApplyUnsignedRoundingMode","refId":"sec-applyunsignedroundingmode"},{"type":"clause","id":"sec-applyunsignedroundingmode","title":"ApplyUnsignedRoundingMode ( x, r1, r2, unsignedRoundingMode )","titleHTML":"ApplyUnsignedRoundingMode ( <var>x</var>, <var>r1</var>, <var>r2</var>, <var>unsignedRoundingMode</var> )","number":"1.5.18","referencingIds":["_ref_63","_ref_66"]},{"type":"op","aoid":"PartitionNumberRangePattern","refId":"sec-partitionnumberrangepattern"},{"type":"clause","id":"sec-partitionnumberrangepattern","title":"PartitionNumberRangePattern ( numberFormat, x, y )","titleHTML":"PartitionNumberRangePattern ( <var>numberFormat</var>, <var>x</var>, <var>y</var> )","number":"1.5.19","referencingIds":["_ref_85","_ref_88","_ref_91"]},{"type":"op","aoid":"FormatApproximately","refId":"sec-formatapproximately"},{"type":"clause","id":"sec-formatapproximately","title":"FormatApproximately ( numberFormat, result )","titleHTML":"FormatApproximately ( <var>numberFormat</var>, <var>result</var> )","number":"1.5.20","referencingIds":["_ref_82"]},{"type":"op","aoid":"CollapseNumberRange","refId":"sec-collapsenumberrange"},{"type":"clause","id":"sec-collapsenumberrange","title":"CollapseNumberRange ( result )","titleHTML":"CollapseNumberRange ( <var>result</var> )","number":"1.5.21","referencingIds":["_ref_83"]},{"type":"op","aoid":"FormatNumericRange","refId":"sec-formatnumericrange"},{"type":"clause","id":"sec-formatnumericrange","title":"FormatNumericRange( numberFormat, x, y )","titleHTML":"FormatNumericRange( <var>numberFormat</var>, <var>x</var>, <var>y</var> )","number":"1.5.22","referencingIds":["_ref_35"]},{"type":"op","aoid":"FormatNumericRangeToParts","refId":"sec-formatnumericrangetoparts"},{"type":"clause","id":"sec-formatnumericrangetoparts","title":"FormatNumericRangeToParts( numberFormat, x, y )","titleHTML":"FormatNumericRangeToParts( <var>numberFormat</var>, <var>x</var>, <var>y</var> )","number":"1.5.23","referencingIds":["_ref_38"]},{"type":"clause","id":"sec-numberformat-abstracts","titleHTML":"Abstract Operations for NumberFormat Objects","number":"1.5"},{"type":"clause","id":"numberformat-objects","titleHTML":"NumberFormat Objects","number":"1"}]}`);
+;let usesMultipage = false</script><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.0.1/styles/base16/solarized-light.min.css"><style>body {
   display: flex;
+  word-wrap: break-word;
   font-size: 18px;
   line-height: 1.5;
   font-family: Cambria, Palatino Linotype, Palatino, Liberation Serif, serif;
@@ -912,6 +1364,7 @@ document.addEventListener('DOMContentLoaded', installFindLocalReferences);
   flex-basis: 66%;
   box-sizing: border-box;
   overflow: hidden;
+  padding-bottom: 1em;
 }
 
 body.oldtoc {
@@ -919,8 +1372,8 @@ body.oldtoc {
 }
 
 a {
-    text-decoration: none;
-    color: #206ca7;
+  text-decoration: none;
+  color: #206ca7;
 }
 
 a:visited {
@@ -928,15 +1381,51 @@ a:visited {
 }
 
 a:hover {
-    text-decoration: underline;
-    color: #239dee;
+  text-decoration: underline;
+  color: #239dee;
 }
 
+a.e-user-code,
+span.e-user-code {
+  white-space: nowrap;
+}
+
+a.e-user-code::before,
+span.e-user-code::before {
+  display: none;
+  color: brown;
+  background-color: white;
+  border: 2pt solid brown;
+  padding: 0.3ex;
+  margin: 0 0.25em 0 0;
+  line-height: 1;
+  vertical-align: text-top;
+  text-transform: uppercase;
+  font-family: 'Comic Code', sans-serif;
+  font-weight: 900;
+  font-size: x-small;
+}
+
+a.e-user-code:hover::before,
+span.e-user-code:hover::before {
+  background-color: brown;
+  color: white;
+}
+
+html.show-ao-annotations a.e-user-code::before,
+html.show-ao-annotations span.e-user-code::before {
+  display: inline-block;
+}
+
+a.e-user-code::before,
+span.e-user-code::before {
+  content: 'UC';
+}
 
 code {
-    font-weight: bold;
-    font-family: Consolas, Monaco, monospace;
-    white-space: pre;
+  font-weight: bold;
+  font-family: Consolas, Monaco, monospace;
+  white-space: pre;
 }
 
 pre code {
@@ -950,13 +1439,13 @@ pre code.hljs {
 }
 
 ol.toc {
-    list-style: none;
-    padding-left: 0;
+  list-style: none;
+  padding-left: 0;
 }
 
 ol.toc ol.toc {
-    padding-left: 2ex;
-    list-style: none;
+  padding-left: 2ex;
+  list-style: none;
 }
 
 var {
@@ -965,8 +1454,40 @@ var {
   cursor: pointer;
 }
 
-var.referenced {
+var.referenced0 {
+  color: inherit;
   background-color: #ffff33;
+  box-shadow: 0 0 0 2px #ffff33;
+}
+var.referenced1 {
+  color: inherit;
+  background-color: #ff87a2;
+  box-shadow: 0 0 0 2px #ff87a2;
+}
+var.referenced2 {
+  color: inherit;
+  background-color: #96e885;
+  box-shadow: 0 0 0 2px #96e885;
+}
+var.referenced3 {
+  color: inherit;
+  background-color: #3eeed2;
+  box-shadow: 0 0 0 2px #3eeed2;
+}
+var.referenced4 {
+  color: inherit;
+  background-color: #eacfb6;
+  box-shadow: 0 0 0 2px #eacfb6;
+}
+var.referenced5 {
+  color: inherit;
+  background-color: #82ddff;
+  box-shadow: 0 0 0 2px #82ddff;
+}
+var.referenced6 {
+  color: inherit;
+  background-color: #ffbcf2;
+  box-shadow: 0 0 0 2px #ffbcf2;
 }
 
 emu-const {
@@ -1015,6 +1536,10 @@ emu-alg ol.nested-lots ol {
   list-style-type: lower-roman;
 }
 
+emu-alg [aria-hidden=true] {
+  font-size: 0;
+}
+
 emu-eqn {
   display: block;
   margin-left: 4em;
@@ -1030,29 +1555,32 @@ emu-eqn div:first-child {
 }
 
 emu-note {
-    margin: 1em 0;
-    color: #666;
-    border-left: 5px solid #ccc;
-    display: flex;
-    flex-direction: row;
+  margin: 1em 0;
+  display: flex;
+  flex-direction: row;
+  color: inherit;
+  border-left: 5px solid #52e052;
+  background: #e9fbe9;
+  padding: 10px 10px 10px 0;
 }
 
 emu-note > span.note {
-    flex-basis: 100px;
-    min-width: 100px;
-    flex-grow: 0;
-    flex-shrink: 1;
-    text-transform: uppercase;
-    padding-left: 5px;
+  flex-basis: 100px;
+  min-width: 100px;
+  flex-grow: 0;
+  flex-shrink: 1;
+  text-transform: uppercase;
+  padding-left: 5px;
 }
 
-emu-note[type=editor] {
+emu-note[type='editor'] {
   border-left-color: #faa;
 }
 
 emu-note > div.note-contents {
   flex-grow: 1;
   flex-shrink: 1;
+  overflow: auto;
 }
 
 emu-note > div.note-contents > p:first-of-type {
@@ -1063,9 +1591,9 @@ emu-note > div.note-contents > p:last-of-type {
   margin-bottom: 0;
 }
 
-emu-table td code {
+emu-table:not(.code) td code {
   white-space: normal;
-} 
+}
 
 emu-figure {
   display: block;
@@ -1090,99 +1618,120 @@ emu-table figure {
 }
 
 emu-production {
-    display: block;
+  display: block;
 }
 
-emu-grammar[type="example"] emu-production,
-emu-grammar[type="definition"] emu-production {
-    margin-top: 1em;
-    margin-bottom: 1em;
-    margin-left: 5ex;
+emu-grammar[type='example'] emu-production,
+emu-grammar[type='definition'] emu-production {
+  margin-top: 1em;
+  margin-bottom: 1em;
+  margin-left: 5ex;
 }
 
-emu-grammar.inline, emu-production.inline,
-emu-grammar.inline emu-production emu-rhs, emu-production.inline emu-rhs,
-emu-grammar[collapsed] emu-production emu-rhs, emu-production[collapsed] emu-rhs {
-    display: inline;
-    padding-left: 1ex;
-    margin-left: 0;
+emu-grammar.inline,
+emu-production.inline,
+emu-grammar.inline emu-production emu-rhs,
+emu-production.inline emu-rhs,
+emu-grammar[collapsed] emu-production emu-rhs {
+  display: inline;
+  padding-left: 1ex;
+  margin-left: 0;
 }
 
-emu-grammar[collapsed] emu-production, emu-production[collapsed] {
-    margin: 0;
+emu-production[collapsed] emu-rhs {
+  display: inline;
+  padding-left: 0.5ex;
+  margin-left: 0;
+}
+
+emu-grammar[collapsed] emu-production,
+emu-production[collapsed] {
+  margin: 0;
 }
 
 emu-constraints {
-    font-size: .75em;
-    margin-right: 1ex;
+  font-size: 0.75em;
+  margin-right: 0.5ex;
 }
 
 emu-gann {
-    margin-right: 1ex;
+  margin-right: 0.5ex;
 }
 
 emu-gann emu-t:last-child,
 emu-gann emu-gprose:last-child,
 emu-gann emu-nt:last-child {
-    margin-right: 0;
+  margin-right: 0;
 }
 
 emu-geq {
-    margin-left: 1ex;
-    font-weight: bold;
+  margin-left: 0.5ex;
+  font-weight: bold;
 }
 
 emu-oneof {
-    font-weight: bold;
-    margin-left: 1ex;
+  font-weight: bold;
+  margin-left: 0.5ex;
 }
 
 emu-nt {
-    display: inline-block;
-    font-style: italic;
-    white-space: nowrap;
-    text-indent: 0;
+  display: inline-block;
+  font-style: italic;
+  white-space: nowrap;
+  text-indent: 0;
 }
 
-emu-nt a, emu-nt a:visited {
+emu-nt a,
+emu-nt a:visited {
   color: #333;
 }
 
 emu-rhs emu-nt {
-    margin-right: 1ex;
+  margin-right: 0.5ex;
 }
 
 emu-t {
-    display: inline-block;
-    font-family: monospace;
-    font-weight: bold;
-    white-space: nowrap;
-    text-indent: 0;
+  display: inline-block;
+  font-family: monospace;
+  font-weight: bold;
+  white-space: nowrap;
+  text-indent: 0;
 }
 
 emu-production emu-t {
-    margin-right: 1ex;
+  margin-right: 0.5ex;
 }
 
 emu-rhs {
-    display: block;
-    padding-left: 75px;
-    text-indent: -25px;
+  display: block;
+  padding-left: 75px;
+  text-indent: -25px;
+}
+
+emu-production:not([collapsed]) emu-rhs {
+  border: 0.2ex dashed transparent;
+}
+
+emu-production:not([collapsed]) emu-rhs:hover {
+  border-color: #888;
+  background-color: #f0f0f0;
 }
 
 emu-mods {
-    font-size: .85em;
-    vertical-align: sub;
-    font-style: normal;
-    font-weight: normal;
+  font-size: 0.85em;
+  vertical-align: sub;
+  font-style: normal;
+  font-weight: normal;
 }
 
-emu-params, emu-opt {
+emu-params,
+emu-opt {
   margin-right: 1ex;
   font-family: monospace;
 }
 
-emu-params, emu-constraints {
+emu-params,
+emu-constraints {
   color: #2aa198;
 }
 
@@ -1191,12 +1740,12 @@ emu-opt {
 }
 
 emu-gprose {
-    font-size: 0.9em;
-    font-family: Helvetica, Arial, sans-serif;
+  font-size: 0.9em;
+  font-family: Helvetica, Arial, sans-serif;
 }
 
 emu-production emu-gprose {
-    margin-right: 1ex;
+  margin-right: 1ex;
 }
 
 h1.shortname {
@@ -1208,20 +1757,19 @@ h1.shortname {
 h1.version {
   color: #f60;
   font-size: 1.5em;
-  margin: 0;
 }
 
 h1.title {
-  margin-top: 0;
   color: #f60;
 }
 
-h1.first {
-  margin-top: 0;
-}
-
-h1, h2, h3, h4, h5, h6 {
-    position: relative;
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  position: relative;
 }
 
 h1 .secnum {
@@ -1233,142 +1781,267 @@ h1 span.title {
   order: 2;
 }
 
+h1 {
+  font-size: 2.67em;
+  margin-bottom: 0;
+  line-height: 1em;
+}
+h2 {
+  font-size: 2em;
+}
+h3 {
+  font-size: 1.56em;
+}
+h4 {
+  font-size: 1.25em;
+}
+h5 {
+  font-size: 1.11em;
+}
+h6 {
+  font-size: 1em;
+}
 
-h1 { font-size: 2.67em; margin-top: 2em; margin-bottom: 0; line-height: 1em;}
-h2 { font-size: 2em; }
-h3 { font-size: 1.56em; }
-h4 { font-size: 1.25em; }
-h5 { font-size: 1.11em; }
-h6 { font-size: 1em; }
+pre code.hljs {
+  background: transparent;
+}
 
-h1:hover span.utils {
+emu-clause[id],
+emu-annex[id],
+emu-intro[id] {
+  scroll-margin-top: 2ex;
+}
+
+emu-intro h1,
+emu-clause h1,
+emu-annex h1 {
+  font-size: 2em;
+}
+emu-intro h2,
+emu-clause h2,
+emu-annex h2 {
+  font-size: 1.56em;
+}
+emu-intro h3,
+emu-clause h3,
+emu-annex h3 {
+  font-size: 1.25em;
+}
+emu-intro h4,
+emu-clause h4,
+emu-annex h4 {
+  font-size: 1.11em;
+}
+emu-intro h5,
+emu-clause h5,
+emu-annex h5 {
+  font-size: 1em;
+}
+emu-intro h6,
+emu-clause h6,
+emu-annex h6 {
+  font-size: 0.9em;
+}
+emu-intro emu-intro h1,
+emu-clause emu-clause h1,
+emu-annex emu-annex h1 {
+  font-size: 1.56em;
+}
+emu-intro emu-intro h2,
+emu-clause emu-clause h2,
+emu-annex emu-annex h2 {
+  font-size: 1.25em;
+}
+emu-intro emu-intro h3,
+emu-clause emu-clause h3,
+emu-annex emu-annex h3 {
+  font-size: 1.11em;
+}
+emu-intro emu-intro h4,
+emu-clause emu-clause h4,
+emu-annex emu-annex h4 {
+  font-size: 1em;
+}
+emu-intro emu-intro h5,
+emu-clause emu-clause h5,
+emu-annex emu-annex h5 {
+  font-size: 0.9em;
+}
+emu-intro emu-intro emu-intro h1,
+emu-clause emu-clause emu-clause h1,
+emu-annex emu-annex emu-annex h1 {
+  font-size: 1.25em;
+}
+emu-intro emu-intro emu-intro h2,
+emu-clause emu-clause emu-clause h2,
+emu-annex emu-annex emu-annex h2 {
+  font-size: 1.11em;
+}
+emu-intro emu-intro emu-intro h3,
+emu-clause emu-clause emu-clause h3,
+emu-annex emu-annex emu-annex h3 {
+  font-size: 1em;
+}
+emu-intro emu-intro emu-intro h4,
+emu-clause emu-clause emu-clause h4,
+emu-annex emu-annex emu-annex h4 {
+  font-size: 0.9em;
+}
+emu-intro emu-intro emu-intro emu-intro h1,
+emu-clause emu-clause emu-clause emu-clause h1,
+emu-annex emu-annex emu-annex emu-annex h1 {
+  font-size: 1.11em;
+}
+emu-intro emu-intro emu-intro emu-intro h2,
+emu-clause emu-clause emu-clause emu-clause h2,
+emu-annex emu-annex emu-annex emu-annex h2 {
+  font-size: 1em;
+}
+emu-intro emu-intro emu-intro emu-intro h3,
+emu-clause emu-clause emu-clause emu-clause h3,
+emu-annex emu-annex emu-annex emu-annex h3 {
+  font-size: 0.9em;
+}
+emu-intro emu-intro emu-intro emu-intro emu-intro h1,
+emu-clause emu-clause emu-clause emu-clause emu-clause h1,
+emu-annex emu-annex emu-annex emu-annex emu-annex h1 {
+  font-size: 1em;
+}
+emu-intro emu-intro emu-intro emu-intro emu-intro h2,
+emu-clause emu-clause emu-clause emu-clause emu-clause h2,
+emu-annex emu-annex emu-annex emu-annex emu-annex h2 {
+  font-size: 0.9em;
+}
+emu-intro emu-intro emu-intro emu-intro emu-intro emu-intro h1,
+emu-clause emu-clause emu-clause emu-clause emu-clause emu-clause h1,
+emu-annex emu-annex emu-annex emu-annex emu-annex emu-annex h1 {
+  font-size: 0.9em;
+}
+
+emu-clause,
+emu-intro,
+emu-annex {
   display: block;
 }
 
-span.utils {
-  font-size: 18px;
-  line-height: 18px;
-  display: none;
-  position: absolute;
-  top: 100%;
-  left: 0;
-  right: 0;
-  font-weight: normal;
+/* these values are twice the font-size for the <h1> titles for clauses */
+emu-intro,
+emu-clause,
+emu-annex {
+  margin-top: 4em;
+}
+emu-intro emu-intro,
+emu-clause emu-clause,
+emu-annex emu-annex {
+  margin-top: 3.12em;
+}
+emu-intro emu-intro emu-intro,
+emu-clause emu-clause emu-clause,
+emu-annex emu-annex emu-annex {
+  margin-top: 2.5em;
+}
+emu-intro emu-intro emu-intro emu-intro,
+emu-clause emu-clause emu-clause emu-clause,
+emu-annex emu-annex emu-annex emu-annex {
+  margin-top: 2.22em;
+}
+emu-intro emu-intro emu-intro emu-intro emu-intro,
+emu-clause emu-clause emu-clause emu-clause emu-clause,
+emu-annex emu-annex emu-annex emu-annex emu-annex {
+  margin-top: 2em;
+}
+emu-intro emu-intro emu-intro emu-intro emu-intro emu-intro,
+emu-clause emu-clause emu-clause emu-clause emu-clause emu-clause,
+emu-annex emu-annex emu-annex emu-annex emu-annex emu-annex {
+  margin-top: 1.8em;
 }
 
-span.utils:before {
-    content: "⤷";
-    display: inline-block;
-    padding: 0 5px;
-}
-
-span.utils > * {
-  display: inline-block;
-  margin-right: 20px;
-}
-
-h1 span.utils span.anchor a,
-h2 span.utils span.anchor a,
-h3 span.utils span.anchor a,
-h4 span.utils span.anchor a,
-h5 span.utils span.anchor a,
-h6 span.utils span.anchor a {
-  text-decoration: none;
-  font-variant: small-caps;
-}
-
-h1 span.utils span.anchor a:hover,
-h2 span.utils span.anchor a:hover,
-h3 span.utils span.anchor a:hover,
-h4 span.utils span.anchor a:hover,
-h5 span.utils span.anchor a:hover,
-h6 span.utils span.anchor a:hover {
-  color: #333;
-}
-
-emu-intro h1, emu-clause h1, emu-annex h1 { font-size: 2em; }
-emu-intro h2, emu-clause h2, emu-annex h2 { font-size: 1.56em; }
-emu-intro h3, emu-clause h3, emu-annex h3 { font-size: 1.25em; }
-emu-intro h4, emu-clause h4, emu-annex h4 { font-size: 1.11em; }
-emu-intro h5, emu-clause h5, emu-annex h5 { font-size: 1em; }
-emu-intro h6, emu-clause h6, emu-annex h6 { font-size: 0.9em; }
-emu-intro emu-intro h1, emu-clause emu-clause h1, emu-annex emu-annex h1 { font-size: 1.56em; }
-emu-intro emu-intro h2, emu-clause emu-clause h2, emu-annex emu-annex h2 { font-size: 1.25em; }
-emu-intro emu-intro h3, emu-clause emu-clause h3, emu-annex emu-annex h3 { font-size: 1.11em; }
-emu-intro emu-intro h4, emu-clause emu-clause h4, emu-annex emu-annex h4 { font-size: 1em; }
-emu-intro emu-intro h5, emu-clause emu-clause h5, emu-annex emu-annex h5 { font-size: 0.9em; }
-emu-intro emu-intro emu-intro h1, emu-clause emu-clause emu-clause h1, emu-annex emu-annex emu-annex h1 { font-size: 1.25em; }
-emu-intro emu-intro emu-intro h2, emu-clause emu-clause emu-clause h2, emu-annex emu-annex emu-annex h2 { font-size: 1.11em; }
-emu-intro emu-intro emu-intro h3, emu-clause emu-clause emu-clause h3, emu-annex emu-annex emu-annex h3 { font-size: 1em; }
-emu-intro emu-intro emu-intro h4, emu-clause emu-clause emu-clause h4, emu-annex emu-annex emu-annex h4 { font-size: 0.9em; }
-emu-intro emu-intro emu-intro emu-intro h1, emu-clause emu-clause emu-clause emu-clause h1, emu-annex emu-annex emu-annex emu-annex h1 { font-size: 1.11em; }
-emu-intro emu-intro emu-intro emu-intro h2, emu-clause emu-clause emu-clause emu-clause h2, emu-annex emu-annex emu-annex emu-annex h2 { font-size: 1em; }
-emu-intro emu-intro emu-intro emu-intro h3, emu-clause emu-clause emu-clause emu-clause h3, emu-annex emu-annex emu-annex emu-annex h3 { font-size: 0.9em; }
-emu-intro emu-intro emu-intro emu-intro emu-intro h1, emu-clause emu-clause emu-clause emu-clause emu-clause h1, emu-annex emu-annex emu-annex emu-annex emu-annex h1 { font-size: 1em; }
-emu-intro emu-intro emu-intro emu-intro emu-intro h2, emu-clause emu-clause emu-clause emu-clause emu-clause h2, emu-annex emu-annex emu-annex emu-annex emu-annex h2 { font-size: 0.9em; }
-emu-intro emu-intro emu-intro emu-intro emu-intro emu-intro h1, emu-clause emu-clause emu-clause emu-clause emu-clause emu-clause h1, emu-annex emu-annex emu-annex emu-annex emu-annex emu-annex h1 { font-size: 0.9em }
-
-emu-clause, emu-intro, emu-annex {
-    display: block;
+#spec-container > emu-intro:first-of-type,
+#spec-container > emu-clause:first-of-type,
+#spec-container > emu-annex:first-of-type {
+  margin-top: 0;
 }
 
 /* Figures and tables */
-figure { display: block; margin: 1em 0 3em 0; }
-figure object { display: block; margin: 0 auto; }
-figure table.real-table { margin: 0 auto; }
+figure {
+  display: block;
+  margin: 1em 0 3em 0;
+}
+figure object {
+  display: block;
+  margin: 0 auto;
+}
+figure table.real-table {
+  margin: 0 auto;
+}
 figure figcaption {
-    display: block;
-    color: #555555;
-    font-weight: bold;
-    text-align: center;
+  display: block;
+  color: #555555;
+  font-weight: bold;
+  text-align: center;
 }
 
 emu-table table {
   margin: 0 auto;
 }
 
-emu-table table, table.real-table {
-    border-collapse: collapse;
+emu-table table,
+table.real-table {
+  border-collapse: collapse;
 }
 
-emu-table td, emu-table th, table.real-table td, table.real-table th {
-    border: 1px solid black;
-    padding: 0.4em;
-    vertical-align: baseline;
+emu-table td,
+emu-table th,
+table.real-table td,
+table.real-table th {
+  border: 1px solid black;
+  padding: 0.4em;
+  vertical-align: baseline;
 }
-emu-table th, emu-table thead td, table.real-table th {
-    background-color: #eeeeee;
+emu-table th,
+emu-table thead td,
+table.real-table th {
+  background-color: #eeeeee;
+}
+
+emu-table td {
+  background: #fff;
 }
 
 /* Note: the left content edges of table.lightweight-table >tbody >tr >td
    and div.display line up. */
 table.lightweight-table {
-    border-collapse: collapse;
-    margin: 0 0 0 1.5em;
+  border-collapse: collapse;
+  margin: 0 0 0 1.5em;
 }
-table.lightweight-table td, table.lightweight-table th {
-    border: none;
-    padding: 0 0.5em;
-    vertical-align: baseline;
+table.lightweight-table td,
+table.lightweight-table th {
+  border: none;
+  padding: 0 0.5em;
+  vertical-align: baseline;
 }
 
 /* diff styles */
 ins {
-    background-color: #e0f8e0;
-    text-decoration: none;
-    border-bottom: 1px solid #396;
+  background-color: #e0f8e0;
+  text-decoration: none;
+  border-bottom: 1px solid #396;
 }
 
 del {
-    background-color: #fee;
+  background-color: #fee;
 }
 
-ins.block, del.block,
-emu-production > ins, emu-production > del,
-emu-grammar > ins, emu-grammar > del {
+ins.block,
+del.block,
+emu-production > ins,
+emu-production > del,
+emu-grammar > ins,
+emu-grammar > del {
   display: block;
 }
-emu-rhs > ins, emu-rhs > del { 
+emu-rhs > ins,
+emu-rhs > del {
   display: inline;
 }
 
@@ -1405,7 +2078,7 @@ tr.del > td {
   -khtml-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
-  user-select: none;;
+  user-select: none;
 
   cursor: pointer;
 }
@@ -1413,7 +2086,8 @@ tr.del > td {
 #menu {
   display: flex;
   flex-direction: column;
-  width: 33%; height: 100vh;
+  width: 33%;
+  height: 100vh;
   max-width: 500px;
   box-sizing: border-box;
   background-color: #ddd;
@@ -1421,13 +2095,14 @@ tr.del > td {
   transition: opacity 0.1s linear;
   padding: 0 5px;
   position: fixed;
-  left: 0; top: 0;
+  left: 0;
+  top: 0;
   border-right: 2px solid #bbb;
 
   z-index: 2;
 }
 
-#menu-spacer {
+.menu-spacer {
   flex-basis: 33%;
   max-width: 500px;
   flex-grow: 0;
@@ -1482,7 +2157,8 @@ tr.del > td {
   padding: 0;
 }
 
-#menu-toc > ol , #menu-toc > ol ol {
+#menu-toc > ol,
+#menu-toc > ol ol {
   list-style-type: none;
   margin: 0;
   padding: 0;
@@ -1512,7 +2188,7 @@ tr.del > td {
   -khtml-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
-  user-select: none;;
+  user-select: none;
 
   cursor: pointer;
 }
@@ -1543,7 +2219,7 @@ tr.del > td {
   */
 }
 
-#menu-toc li.revealed-leaf> a {
+#menu-toc li.revealed-leaf > a {
   color: #206ca7;
   /*
   background-color: #222;
@@ -1579,6 +2255,34 @@ tr.del > td {
   font-size: 0.8em;
 }
 
+.menu-pane-header emu-opt,
+.menu-pane-header emu-t,
+.menu-pane-header emu-nt {
+  margin-right: 0px;
+  display: inline;
+  color: inherit;
+}
+
+.menu-pane-header emu-rhs {
+  display: inline;
+  padding-left: 0px;
+  text-indent: 0px;
+}
+
+.menu-pane-header emu-geq {
+  margin-left: 0px;
+}
+
+a.menu-pane-header-production {
+  color: inherit;
+}
+
+.menu-pane-header-production {
+  text-transform: none;
+  letter-spacing: 1.5px;
+  padding-left: 0.5em;
+}
+
 #menu-toc {
   display: flex;
   flex-direction: column;
@@ -1597,10 +2301,10 @@ tr.del > td {
   flex-grow: 0;
   flex-shrink: 0;
   width: 100%;
-  
+
   display: flex;
   flex-direction: column;
-  
+
   max-height: 300px;
 }
 
@@ -1625,43 +2329,42 @@ tr.del > td {
 }
 
 li.menu-search-result-clause:before {
-    content: 'clause';
-    width: 40px;
-    display: inline-block;
-    text-align: right;
-    padding-right: 1ex;
-    color: #666;
-    font-size: 75%;
+  content: 'clause';
+  width: 40px;
+  display: inline-block;
+  text-align: right;
+  padding-right: 1ex;
+  color: #666;
+  font-size: 75%;
 }
 li.menu-search-result-op:before {
-    content: 'op';
-    width: 40px;
-    display: inline-block;
-    text-align: right;
-    padding-right: 1ex;
-    color: #666;
-    font-size: 75%;
+  content: 'op';
+  width: 40px;
+  display: inline-block;
+  text-align: right;
+  padding-right: 1ex;
+  color: #666;
+  font-size: 75%;
 }
 
 li.menu-search-result-prod:before {
-    content: 'prod';
-    width: 40px;
-    display: inline-block;
-    text-align: right;
-    padding-right: 1ex;
-    color: #666;
-    font-size: 75%
+  content: 'prod';
+  width: 40px;
+  display: inline-block;
+  text-align: right;
+  padding-right: 1ex;
+  color: #666;
+  font-size: 75%;
 }
 
-
 li.menu-search-result-term:before {
-    content: 'term';
-    width: 40px;
-    display: inline-block;
-    text-align: right;
-    padding-right: 1ex;
-    color: #666;
-    font-size: 75%
+  content: 'term';
+  width: 40px;
+  display: inline-block;
+  text-align: right;
+  padding-right: 1ex;
+  color: #666;
+  font-size: 75%;
 }
 
 #menu-search-results ul {
@@ -1674,7 +2377,6 @@ li.menu-search-result-term:before {
   text-overflow: ellipsis;
 }
 
-
 #menu-trace-list {
   counter-reset: item;
   margin: 0 0 0 20px;
@@ -1686,19 +2388,19 @@ li.menu-search-result-term:before {
 }
 
 #menu-trace-list li .secnum:after {
-  content: " ";
+  content: ' ';
 }
 #menu-trace-list li:before {
-    content: counter(item) " ";
-    background-color: #222;
-    counter-increment: item;
-    color: #999;
-    width: 20px;
-    height: 20px;
-    line-height: 20px;
-    display: inline-block;
-    text-align: center;
-    margin: 2px 4px 2px 0;
+  content: counter(item) ' ';
+  background-color: #222;
+  counter-increment: item;
+  color: #999;
+  width: 20px;
+  height: 20px;
+  line-height: 20px;
+  display: inline-block;
+  text-align: center;
+  margin: 2px 4px 2px 0;
 }
 
 @media (max-width: 1000px) {
@@ -1740,24 +2442,29 @@ li.menu-search-result-term:before {
   }
 
   h1 .secnum:empty {
-    margin: 0; padding: 0;
+    margin: 0;
+    padding: 0;
   }
 }
 
-
 /* Toolbox */
-.toolbox {
-	position: absolute;
-	background: #ddd;
-	border: 1px solid #aaa;
+.toolbox-container {
+  position: absolute;
   display: none;
+  padding-bottom: 7px;
+}
+
+.toolbox-container.active {
+  display: inline-block;
+}
+
+.toolbox {
+  position: relative;
+  background: #ddd;
+  border: 1px solid #aaa;
   color: #eee;
   padding: 5px;
   border-radius: 3px;
-}
-
-.toolbox.active {
-  display: inline-block;
 }
 
 .toolbox a {
@@ -1769,28 +2476,29 @@ li.menu-search-result-term:before {
   text-decoration: underline;
 }
 
-.toolbox:after, .toolbox:before {
-	top: 100%;
-	left: 15px;
-	border: solid transparent;
-	content: " ";
-	height: 0;
-	width: 0;
-	position: absolute;
-	pointer-events: none;
+.toolbox:after,
+.toolbox:before {
+  top: 100%;
+  left: 15px;
+  border: solid transparent;
+  content: ' ';
+  height: 0;
+  width: 0;
+  position: absolute;
+  pointer-events: none;
 }
 
 .toolbox:after {
-	border-color: rgba(0, 0, 0, 0);
-	border-top-color: #ddd;
-	border-width: 10px;
-	margin-left: -10px;
+  border-color: rgba(0, 0, 0, 0);
+  border-top-color: #ddd;
+  border-width: 10px;
+  margin-left: -10px;
 }
 .toolbox:before {
-	border-color: rgba(204, 204, 204, 0);
-	border-top-color: #aaa;
-	border-width: 12px;
-	margin-left: -12px;
+  border-color: rgba(204, 204, 204, 0);
+  border-top-color: #aaa;
+  border-width: 12px;
+  margin-left: -12px;
 }
 
 #references-pane-container {
@@ -1807,11 +2515,6 @@ li.menu-search-result-term:before {
 #references-pane-table-container {
   overflow-x: hidden;
   overflow-y: auto;
-}
-
-#references-pane-spacer {
-  flex-basis: 33%;
-  max-width: 500px;
 }
 
 #references-pane {
@@ -1831,6 +2534,10 @@ li.menu-search-result-term:before {
   cursor: pointer;
 }
 
+#references-pane table tbody {
+  vertical-align: baseline;
+}
+
 #references-pane table tr td:first-child {
   text-align: right;
   padding-right: 5px;
@@ -1838,27 +2545,84 @@ li.menu-search-result-term:before {
 
 @media print {
   #menu-toggle {
-    display: none; 
+    display: none;
   }
 }
-</style></head><body><div id="menu-toggle">☰</div><div id="menu-spacer"></div><div id="menu"><div id="menu-search"><input type="text" id="menu-search-box" placeholder="Search..."><div id="menu-search-results" class="inactive"></div></div><div id="menu-pins"><div class="menu-pane-header">Pins</div><ul id="menu-pins-list"></ul></div><div class="menu-pane-header">Table of Contents</div><div id="menu-toc"><ol class="toc"><li><span class="item-toggle">◢</span><a href="#numberformat-objects" title="NumberFormat Objects"><span class="secnum">1</span> NumberFormat Objects</a><ol class="toc"><li><span class="item-toggle">◢</span><a href="#sec-intl-numberformat-constructor" title="The Intl.NumberFormat Constructor"><span class="secnum">1.1</span> The Intl.NumberFormat Constructor</a><ol class="toc"><li><span class="item-toggle">◢</span><a href="#sec-intl.numberformat" title="Intl.NumberFormat ( [ locales [ , options ] ] )"><span class="secnum">1.1.1</span> Intl.NumberFormat ( [ <var>locales</var> [ , <var>options</var> ] ] )</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-chainnumberformat" title="ChainNumberFormat ( numberFormat, newTarget, this )"><span class="secnum">1.1.1.1</span> ChainNumberFormat ( <var>numberFormat</var>, <var>newTarget</var>, <var>this</var> )</a></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-initializenumberformat" title="InitializeNumberFormat ( numberFormat, locales, options )"><span class="secnum">1.1.2</span> InitializeNumberFormat ( <var>numberFormat</var>, <var>locales</var>, <var>options</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-setnfdigitoptions" title="SetNumberFormatDigitOptions ( intlObj, options, mnfdDefault, mxfdDefault, notation )"><span class="secnum">1.1.3</span> SetNumberFormatDigitOptions ( <var>intlObj</var>, <var>options</var>, <var>mnfdDefault</var>, <var>mxfdDefault</var>, <var>notation</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-setnumberformatunitoptions" title="SetNumberFormatUnitOptions ( intlObj, options )"><span class="secnum">1.1.4</span> SetNumberFormatUnitOptions ( <var>intlObj</var>, <var>options</var> )</a></li></ol></li><li><span class="item-toggle">◢</span><a href="#sec-properties-of-intl-numberformat-constructor" title="Properties of the Intl.NumberFormat Constructor"><span class="secnum">1.2</span> Properties of the Intl.NumberFormat Constructor</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-intl.numberformat.prototype" title="Intl.NumberFormat.prototype"><span class="secnum">1.2.1</span> Intl.NumberFormat.prototype</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.numberformat.supportedlocalesof" title="Intl.NumberFormat.supportedLocalesOf ( locales [ , options ] )"><span class="secnum">1.2.2</span> Intl.NumberFormat.supportedLocalesOf ( <var>locales</var> [ , <var>options</var> ] )</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.numberformat-internal-slots" title="Internal slots"><span class="secnum">1.2.3</span> Internal slots</a></li></ol></li><li><span class="item-toggle">◢</span><a href="#sec-properties-of-intl-numberformat-prototype-object" title="Properties of the Intl.NumberFormat Prototype Object"><span class="secnum">1.3</span> Properties of the Intl.NumberFormat Prototype Object</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-intl.numberformat.prototype.constructor" title="Intl.NumberFormat.prototype.constructor"><span class="secnum">1.3.1</span> Intl.NumberFormat.prototype.constructor</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.numberformat.prototype-@@tostringtag" title="Intl.NumberFormat.prototype [ @@toStringTag ]"><span class="secnum">1.3.2</span> Intl.NumberFormat.prototype [ @@toStringTag ]</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.numberformat.prototype.format" title="get Intl.NumberFormat.prototype.format"><span class="secnum">1.3.3</span> get Intl.NumberFormat.prototype.format</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.numberformat.prototype.formattoparts" title="Intl.NumberFormat.prototype.formatToParts ( value )"><span class="secnum">1.3.4</span> Intl.NumberFormat.prototype.formatToParts ( <var>value</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.numberformat.prototype.formatrange" title="Intl.NumberFormat.prototype.formatRange ( start, end )"><span class="secnum">1.3.5</span> Intl.NumberFormat.prototype.formatRange ( <var>start</var>, <var>end</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.numberformat.prototype.formatrangetoparts" title="Intl.NumberFormat.prototype.formatRangeToParts ( start, end )"><span class="secnum">1.3.6</span> Intl.NumberFormat.prototype.formatRangeToParts ( <var>start</var>, <var>end</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.numberformat.prototype.resolvedoptions" title="Intl.NumberFormat.prototype.resolvedOptions ( )"><span class="secnum">1.3.7</span> Intl.NumberFormat.prototype.resolvedOptions ( )</a></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-properties-of-intl-numberformat-instances" title="Properties of Intl.NumberFormat Instances"><span class="secnum">1.4</span> Properties of Intl.NumberFormat Instances</a></li><li><span class="item-toggle">◢</span><a href="#sec-numberformat-abstracts" title="Abstract Operations for NumberFormat Objects"><span class="secnum">1.5</span> Abstract Operations for NumberFormat Objects</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-currencydigits" title="CurrencyDigits ( currency )"><span class="secnum">1.5.1</span> CurrencyDigits ( <var>currency</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-number-format-functions" title="Number Format Functions"><span class="secnum">1.5.2</span> Number Format Functions</a></li><li><span class="item-toggle-none"></span><a href="#sec-formatnumberstring" title="FormatNumericToString ( intlObject, x )"><span class="secnum">1.5.3</span> FormatNumericToString ( <var>intlObject</var>, <var>x</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-partitionnumberpattern" title="
-        PartitionNumberPattern (
-          numberFormat: an object initialized as a NumberFormat,
-          x: an Intl mathematical value,
-        )
-      "><span class="secnum">1.5.4</span> 
-        PartitionNumberPattern (
-          <var>numberFormat</var>: an object initialized as a NumberFormat,
-          <var>x</var>: an Intl mathematical value,
-        )
-      </a></li><li><span class="item-toggle-none"></span><a href="#sec-partitionnotationsubpattern" title="PartitionNotationSubPattern ( numberFormat, x, n, exponent )"><span class="secnum">1.5.5</span> PartitionNotationSubPattern ( <var>numberFormat</var>, <var>x</var>, <var>n</var>, <var>exponent</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-formatnumber" title="FormatNumeric ( numberFormat, x )"><span class="secnum">1.5.6</span> FormatNumeric ( <var>numberFormat</var>, <var>x</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-formatnumbertoparts" title="FormatNumericToParts ( numberFormat, x )"><span class="secnum">1.5.7</span> FormatNumericToParts ( <var>numberFormat</var>, <var>x</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-torawprecision" title="ToRawPrecision ( x, minPrecision, maxPrecision, unsignedRoundingMode )"><span class="secnum">1.5.8</span> ToRawPrecision ( <var>x</var>, <var>minPrecision</var>, <var>maxPrecision</var>, <var>unsignedRoundingMode</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-torawfixed" title="ToRawFixed ( x, minFraction, maxFraction, roundingIncrement, unsignedRoundingMode )"><span class="secnum">1.5.9</span> ToRawFixed ( <var>x</var>, <var>minFraction</var>, <var>maxFraction</var>, <var>roundingIncrement</var>, <var>unsignedRoundingMode</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-unwrapnumberformat" title="UnwrapNumberFormat ( nf )"><span class="secnum">1.5.10</span> UnwrapNumberFormat ( <var>nf</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-getnumberformatpattern" title="GetNumberFormatPattern ( numberFormat, x )"><span class="secnum">1.5.11</span> GetNumberFormatPattern ( <var>numberFormat</var>, <var>x</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-getnotationsubpattern" title="GetNotationSubPattern ( numberFormat, exponent )"><span class="secnum">1.5.12</span> GetNotationSubPattern ( <var>numberFormat</var>, <var>exponent</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-computeexponent" title="ComputeExponent ( numberFormat, x )"><span class="secnum">1.5.13</span> ComputeExponent ( <var>numberFormat</var>, <var>x</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-computeexponentformagnitude" title="ComputeExponentForMagnitude ( numberFormat, magnitude )"><span class="secnum">1.5.14</span> ComputeExponentForMagnitude ( <var>numberFormat</var>, <var>magnitude</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-runtime-semantics-stringintlmv" title="Runtime Semantics: StringIntlMV"><span class="secnum">1.5.15</span> RS: StringIntlMV</a></li><li><span class="item-toggle-none"></span><a href="#sec-tointlmathematicalvalue" title="ToIntlMathematicalValue ( value )"><span class="secnum">1.5.16</span> ToIntlMathematicalValue ( <var>value</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-getunsignedroundingmode" title="GetUnsignedRoundingMode ( roundingMode, isNegative )"><span class="secnum">1.5.17</span> GetUnsignedRoundingMode ( <var>roundingMode</var>, <var>isNegative</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-applyunsignedroundingmode" title="ApplyUnsignedRoundingMode ( x, r1, r2, unsignedRoundingMode )"><span class="secnum">1.5.18</span> ApplyUnsignedRoundingMode ( <var>x</var>, <var>r1</var>, <var>r2</var>, <var>unsignedRoundingMode</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-partitionnumberrangepattern" title="PartitionNumberRangePattern ( numberFormat, x, y )"><span class="secnum">1.5.19</span> PartitionNumberRangePattern ( <var>numberFormat</var>, <var>x</var>, <var>y</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-formatapproximately" title="FormatApproximately ( numberFormat, result )"><span class="secnum">1.5.20</span> FormatApproximately ( <var>numberFormat</var>, <var>result</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-collapsenumberrange" title="CollapseNumberRange ( result )"><span class="secnum">1.5.21</span> CollapseNumberRange ( <var>result</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-formatnumericrange" title="FormatNumericRange( numberFormat, x, y )"><span class="secnum">1.5.22</span> FormatNumericRange( <var>numberFormat</var>, <var>x</var>, <var>y</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-formatnumericrangetoparts" title="FormatNumericRangeToParts( numberFormat, x, y )"><span class="secnum">1.5.23</span> FormatNumericRangeToParts( <var>numberFormat</var>, <var>x</var>, <var>y</var> )</a></li></ol></li></ol></li></ol></div></div><div id="spec-container"><emu-clause id="numberformat-objects">
-  <h1 class="first"><span class="secnum">1</span> NumberFormat Objects</h1>
+
+[normative-optional],
+[legacy] {
+  border-left: 5px solid #ff6600;
+  padding: 0.5em;
+  display: block;
+  background: #ffeedd;
+}
+
+.clause-attributes-tag {
+  text-transform: uppercase;
+  color: #884400;
+}
+
+.clause-attributes-tag a {
+  color: #884400;
+}
+
+/* Shortcuts help dialog */
+
+#shortcuts-help {
+  position: fixed;
+  left: 5%;
+  margin: 0 auto;
+  right: 5%;
+  z-index: 10;
+  top: 10%;
+  top: calc(5vw + 5vh);
+  padding: 30px 90px;
+  max-width: 500px;
+  outline: solid 10000px rgba(255, 255, 255, 0.6);
+  border-radius: 5px;
+  border-width: 1px 1px 0 1px;
+  background-color: #ddd;
+  display: none;
+}
+
+#shortcuts-help.active {
+  display: block;
+}
+
+#shortcuts-help ul {
+  padding: 0;
+}
+
+#shortcuts-help li {
+  display: flex;
+  justify-content: space-between;
+}
+
+#shortcuts-help code {
+  padding: 3px 10px;
+  border-radius: 3px;
+  border-width: 1px 1px 0 1px;
+  border-color: #bbb;
+  background-color: #eee;
+  box-shadow: inset 0 -1px 0 #ccc;
+}
+</style></head><body><div id="shortcuts-help">
+<ul>
+  <li><span>Toggle shortcuts help</span><code>?</code></li>
+  <li><span>Toggle "can call user code" annotations</span><code>u</code></li>
+
+  <li><span>Jump to search box</span><code>/</code></li>
+</ul></div><div id="menu-toggle"><svg xmlns="http://www.w3.org/2000/svg" style="width:100%; height:100%; stroke:currentColor" viewBox="0 0 120 120">
+      <title>Menu</title>
+      <path stroke-width="10" stroke-linecap="round" d="M30,60 h60  M30,30 m0,5 h60  M30,90 m0,-5 h60"></path>
+    </svg></div><div id="menu-spacer" class="menu-spacer"></div><div id="menu"><div id="menu-search"><input type="text" id="menu-search-box" placeholder="Search..."><div id="menu-search-results" class="inactive"></div></div><div id="menu-pins"><div class="menu-pane-header">Pins</div><ul id="menu-pins-list"></ul></div><div class="menu-pane-header">Table of Contents</div><div id="menu-toc"><ol class="toc"><li><span class="item-toggle">◢</span><a href="#numberformat-objects" title="NumberFormat Objects"><span class="secnum">1</span> NumberFormat Objects</a><ol class="toc"><li><span class="item-toggle">◢</span><a href="#sec-intl-numberformat-constructor" title="The Intl.NumberFormat Constructor"><span class="secnum">1.1</span> The Intl.NumberFormat Constructor</a><ol class="toc"><li><span class="item-toggle">◢</span><a href="#sec-intl.numberformat" title="Intl.NumberFormat ( [ locales [ , options ] ] )"><span class="secnum">1.1.1</span> Intl.NumberFormat ( [ <var>locales</var> [ , <var>options</var> ] ] )</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-chainnumberformat" title="ChainNumberFormat ( numberFormat, newTarget, this )"><span class="secnum">1.1.1.1</span> ChainNumberFormat ( <var>numberFormat</var>, <var>newTarget</var>, <var>this</var> )</a></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-initializenumberformat" title="InitializeNumberFormat ( numberFormat, locales, options )"><span class="secnum">1.1.2</span> InitializeNumberFormat ( <var>numberFormat</var>, <var>locales</var>, <var>options</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-setnfdigitoptions" title="SetNumberFormatDigitOptions ( intlObj, options, mnfdDefault, mxfdDefault, notation )"><span class="secnum">1.1.3</span> SetNumberFormatDigitOptions ( <var>intlObj</var>, <var>options</var>, <var>mnfdDefault</var>, <var>mxfdDefault</var>, <var>notation</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-setnumberformatunitoptions" title="SetNumberFormatUnitOptions ( intlObj, options )"><span class="secnum">1.1.4</span> SetNumberFormatUnitOptions ( <var>intlObj</var>, <var>options</var> )</a></li></ol></li><li><span class="item-toggle">◢</span><a href="#sec-properties-of-intl-numberformat-constructor" title="Properties of the Intl.NumberFormat Constructor"><span class="secnum">1.2</span> Properties of the Intl.NumberFormat Constructor</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-intl.numberformat.prototype" title="Intl.NumberFormat.prototype"><span class="secnum">1.2.1</span> Intl.NumberFormat.prototype</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.numberformat.supportedlocalesof" title="Intl.NumberFormat.supportedLocalesOf ( locales [ , options ] )"><span class="secnum">1.2.2</span> Intl.NumberFormat.supportedLocalesOf ( <var>locales</var> [ , <var>options</var> ] )</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.numberformat-internal-slots" title="Internal slots"><span class="secnum">1.2.3</span> Internal slots</a></li></ol></li><li><span class="item-toggle">◢</span><a href="#sec-properties-of-intl-numberformat-prototype-object" title="Properties of the Intl.NumberFormat Prototype Object"><span class="secnum">1.3</span> Properties of the Intl.NumberFormat Prototype Object</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-intl.numberformat.prototype.constructor" title="Intl.NumberFormat.prototype.constructor"><span class="secnum">1.3.1</span> Intl.NumberFormat.prototype.constructor</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.numberformat.prototype-@@tostringtag" title="Intl.NumberFormat.prototype [ @@toStringTag ]"><span class="secnum">1.3.2</span> Intl.NumberFormat.prototype [ @@toStringTag ]</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.numberformat.prototype.format" title="get Intl.NumberFormat.prototype.format"><span class="secnum">1.3.3</span> get Intl.NumberFormat.prototype.format</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.numberformat.prototype.formattoparts" title="Intl.NumberFormat.prototype.formatToParts ( value )"><span class="secnum">1.3.4</span> Intl.NumberFormat.prototype.formatToParts ( <var>value</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.numberformat.prototype.formatrange" title="Intl.NumberFormat.prototype.formatRange ( start, end )"><span class="secnum">1.3.5</span> Intl.NumberFormat.prototype.formatRange ( <var>start</var>, <var>end</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.numberformat.prototype.formatrangetoparts" title="Intl.NumberFormat.prototype.formatRangeToParts ( start, end )"><span class="secnum">1.3.6</span> Intl.NumberFormat.prototype.formatRangeToParts ( <var>start</var>, <var>end</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.numberformat.prototype.resolvedoptions" title="Intl.NumberFormat.prototype.resolvedOptions ( )"><span class="secnum">1.3.7</span> Intl.NumberFormat.prototype.resolvedOptions ( )</a></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-properties-of-intl-numberformat-instances" title="Properties of Intl.NumberFormat Instances"><span class="secnum">1.4</span> Properties of Intl.NumberFormat Instances</a></li><li><span class="item-toggle">◢</span><a href="#sec-numberformat-abstracts" title="Abstract Operations for NumberFormat Objects"><span class="secnum">1.5</span> Abstract Operations for NumberFormat Objects</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-currencydigits" title="CurrencyDigits ( currency )"><span class="secnum">1.5.1</span> CurrencyDigits ( <var>currency</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-number-format-functions" title="Number Format Functions"><span class="secnum">1.5.2</span> Number Format Functions</a></li><li><span class="item-toggle-none"></span><a href="#sec-formatnumberstring" title="FormatNumericToString ( intlObject, x )"><span class="secnum">1.5.3</span> FormatNumericToString ( <var>intlObject</var>, <var>x</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-partitionnumberpattern" title="PartitionNumberPattern ( numberFormat, x )"><span class="secnum">1.5.4</span> PartitionNumberPattern ( <var>numberFormat</var>, <var>x</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-partitionnotationsubpattern" title="PartitionNotationSubPattern ( numberFormat, x, n, exponent )"><span class="secnum">1.5.5</span> PartitionNotationSubPattern ( <var>numberFormat</var>, <var>x</var>, <var>n</var>, <var>exponent</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-formatnumber" title="FormatNumeric ( numberFormat, x )"><span class="secnum">1.5.6</span> FormatNumeric ( <var>numberFormat</var>, <var>x</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-formatnumbertoparts" title="FormatNumericToParts ( numberFormat, x )"><span class="secnum">1.5.7</span> FormatNumericToParts ( <var>numberFormat</var>, <var>x</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-torawprecision" title="ToRawPrecision ( x, minPrecision, maxPrecision, unsignedRoundingMode )"><span class="secnum">1.5.8</span> ToRawPrecision ( <var>x</var>, <var>minPrecision</var>, <var>maxPrecision</var>, <var>unsignedRoundingMode</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-torawfixed" title="ToRawFixed ( x, minFraction, maxFraction, roundingIncrement, unsignedRoundingMode )"><span class="secnum">1.5.9</span> ToRawFixed ( <var>x</var>, <var>minFraction</var>, <var>maxFraction</var>, <var>roundingIncrement</var>, <var>unsignedRoundingMode</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-unwrapnumberformat" title="UnwrapNumberFormat ( nf )"><span class="secnum">1.5.10</span> UnwrapNumberFormat ( <var>nf</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-getnumberformatpattern" title="GetNumberFormatPattern ( numberFormat, x )"><span class="secnum">1.5.11</span> GetNumberFormatPattern ( <var>numberFormat</var>, <var>x</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-getnotationsubpattern" title="GetNotationSubPattern ( numberFormat, exponent )"><span class="secnum">1.5.12</span> GetNotationSubPattern ( <var>numberFormat</var>, <var>exponent</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-computeexponent" title="ComputeExponent ( numberFormat, x )"><span class="secnum">1.5.13</span> ComputeExponent ( <var>numberFormat</var>, <var>x</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-computeexponentformagnitude" title="ComputeExponentForMagnitude ( numberFormat, magnitude )"><span class="secnum">1.5.14</span> ComputeExponentForMagnitude ( <var>numberFormat</var>, <var>magnitude</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-runtime-semantics-stringintlmv" title="Runtime Semantics: StringIntlMV"><span class="secnum">1.5.15</span> RS: StringIntlMV</a></li><li><span class="item-toggle-none"></span><a href="#sec-tointlmathematicalvalue" title="ToIntlMathematicalValue ( value )"><span class="secnum">1.5.16</span> ToIntlMathematicalValue ( <var>value</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-getunsignedroundingmode" title="GetUnsignedRoundingMode ( roundingMode, isNegative )"><span class="secnum">1.5.17</span> GetUnsignedRoundingMode ( <var>roundingMode</var>, <var>isNegative</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-applyunsignedroundingmode" title="ApplyUnsignedRoundingMode ( x, r1, r2, unsignedRoundingMode )"><span class="secnum">1.5.18</span> ApplyUnsignedRoundingMode ( <var>x</var>, <var>r1</var>, <var>r2</var>, <var>unsignedRoundingMode</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-partitionnumberrangepattern" title="PartitionNumberRangePattern ( numberFormat, x, y )"><span class="secnum">1.5.19</span> PartitionNumberRangePattern ( <var>numberFormat</var>, <var>x</var>, <var>y</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-formatapproximately" title="FormatApproximately ( numberFormat, result )"><span class="secnum">1.5.20</span> FormatApproximately ( <var>numberFormat</var>, <var>result</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-collapsenumberrange" title="CollapseNumberRange ( result )"><span class="secnum">1.5.21</span> CollapseNumberRange ( <var>result</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-formatnumericrange" title="FormatNumericRange( numberFormat, x, y )"><span class="secnum">1.5.22</span> FormatNumericRange( <var>numberFormat</var>, <var>x</var>, <var>y</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-formatnumericrangetoparts" title="FormatNumericRangeToParts( numberFormat, x, y )"><span class="secnum">1.5.23</span> FormatNumericRangeToParts( <var>numberFormat</var>, <var>x</var>, <var>y</var> )</a></li></ol></li></ol></li></ol></div></div><div id="spec-container"><emu-clause id="numberformat-objects">
+  <h1><span class="secnum">1</span> NumberFormat Objects</h1>
 
   <emu-clause id="sec-intl-numberformat-constructor">
     <h1><span class="secnum">1.1</span> The Intl.NumberFormat Constructor</h1>
 
     <p>
-      The NumberFormat <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> is the <dfn>%NumberFormat%</dfn> intrinsic object and a standard built-in property of the Intl object. Behaviour common to all service <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> properties of the Intl object is specified in <emu-xref href="#sec-internal-slots"></emu-xref>.
+      The NumberFormat constructor is the <dfn>%NumberFormat%</dfn> intrinsic object and a standard built-in property of the Intl object. Behaviour common to all service constructor properties of the Intl object is specified in <emu-xref href="#sec-internal-slots"></emu-xref>.
     </p>
 
     <emu-clause id="sec-intl.numberformat">
@@ -1868,12 +2632,12 @@ li.menu-search-result-term:before {
         When the <code>Intl.NumberFormat</code> function is called with optional arguments <var>locales</var> and <var>options</var>, the following steps are taken:
       </p>
 
-      <emu-alg><ol><li>If NewTarget is <emu-val>undefined</emu-val>, let <var>newTarget</var> be the <emu-xref href="#active-function-object"><a href="https://tc39.es/ecma262/#active-function-object">active function object</a></emu-xref>, else let <var>newTarget</var> be NewTarget.</li><li>Let <var>numberFormat</var> be ?&nbsp;<emu-xref aoid="OrdinaryCreateFromConstructor" id="_ref_17"><a href="https://tc39.es/ecma262/#sec-ordinarycreatefromconstructor">OrdinaryCreateFromConstructor</a></emu-xref>(<var>newTarget</var>, <emu-val>"%NumberFormat.prototype%"</emu-val>, « [[InitializedNumberFormat]], [[Locale]], [[DataLocale]], [[NumberingSystem]], [[Style]], [[Unit]], [[UnitDisplay]], [[Currency]], [[CurrencyDisplay]], [[CurrencySign]], [[MinimumIntegerDigits]], [[MinimumFractionDigits]], [[MaximumFractionDigits]], [[MinimumSignificantDigits]], [[MaximumSignificantDigits]], [[RoundingType]], [[Notation]], [[CompactDisplay]], [[UseGrouping]], [[SignDisplay]], [[RoundingMode]], [[RoundingIncrement]], [[TrailingZeroDisplay]], [[BoundFormat]] »).</li><li>Perform ?&nbsp;<emu-xref aoid="InitializeNumberFormat" id="_ref_18"><a href="#sec-initializenumberformat">InitializeNumberFormat</a></emu-xref>(<var>numberFormat</var>, <var>locales</var>, <var>options</var>).</li><li>If the implementation supports the normative optional <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> mode of <emu-xref href="#legacy-constructor"></emu-xref>, then<ol><li>Let <var>this</var> be the <emu-val>this</emu-val> value.</li><li>Return ?&nbsp;<emu-xref aoid="ChainNumberFormat" id="_ref_19"><a href="#sec-chainnumberformat">ChainNumberFormat</a></emu-xref>(<var>numberFormat</var>, NewTarget, <var>this</var>).</li></ol></li><li>Return <var>numberFormat</var>.</li></ol></emu-alg>
+      <emu-alg><ol><li>If NewTarget is <emu-val>undefined</emu-val>, let <var>newTarget</var> be the active function object, else let <var>newTarget</var> be NewTarget.</li><li>Let <var>numberFormat</var> be ?&nbsp;OrdinaryCreateFromConstructor(<var>newTarget</var>, <emu-val>"%NumberFormat.prototype%"</emu-val>, « [[InitializedNumberFormat]], [[Locale]], [[DataLocale]], [[NumberingSystem]], [[Style]], [[Unit]], [[UnitDisplay]], [[Currency]], [[CurrencyDisplay]], [[CurrencySign]], [[MinimumIntegerDigits]], [[MinimumFractionDigits]], [[MaximumFractionDigits]], [[MinimumSignificantDigits]], [[MaximumSignificantDigits]], [[RoundingType]], [[Notation]], [[CompactDisplay]], [[UseGrouping]], [[SignDisplay]], [[RoundingMode]], [[RoundingIncrement]], [[TrailingZeroDisplay]], [[BoundFormat]] »).</li><li>Perform ?&nbsp;<emu-xref aoid="InitializeNumberFormat" id="_ref_17"><a href="#sec-initializenumberformat">InitializeNumberFormat</a></emu-xref>(<var>numberFormat</var>, <var>locales</var>, <var>options</var>).</li><li>If the implementation supports the normative optional constructor mode of <emu-xref href="#legacy-constructor"></emu-xref>, then<ol><li>Let <var>this</var> be the <emu-val>this</emu-val> value.</li><li>Return ?&nbsp;<emu-xref aoid="ChainNumberFormat" id="_ref_18"><a href="#sec-chainnumberformat">ChainNumberFormat</a></emu-xref>(<var>numberFormat</var>, NewTarget, <var>this</var>).</li></ol></li><li>Return <var>numberFormat</var>.</li></ol></emu-alg>
 
       <emu-normative-optional>
       <emu-clause id="sec-chainnumberformat" aoid="ChainNumberFormat">
         <h1><span class="secnum">1.1.1.1</span> ChainNumberFormat ( <var>numberFormat</var>, <var>newTarget</var>, <var>this</var> )</h1>
-        <emu-alg><ol><li>If <var>newTarget</var> is <emu-val>undefined</emu-val> and ?&nbsp;<emu-xref aoid="OrdinaryHasInstance" id="_ref_20"><a href="https://tc39.es/ecma262/#sec-ordinaryhasinstance">OrdinaryHasInstance</a></emu-xref>(<emu-xref href="#sec-intl-numberformat-constructor" id="_ref_21"><a href="#sec-intl-numberformat-constructor">%NumberFormat%</a></emu-xref>, <var>this</var>) is <emu-val>true</emu-val>, then<ol><li>Perform ?&nbsp;<emu-xref aoid="DefinePropertyOrThrow" id="_ref_22"><a href="https://tc39.es/ecma262/#sec-definepropertyorthrow">DefinePropertyOrThrow</a></emu-xref>(<var>this</var>, %Intl%.[[FallbackSymbol]], PropertyDescriptor{ [[Value]]: <var>numberFormat</var>, [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>false</emu-val> }).</li><li>Return <var>this</var>.</li></ol></li><li>Return <var>numberFormat</var>.</li></ol></emu-alg>
+        <emu-alg><ol><li>If <var>newTarget</var> is <emu-val>undefined</emu-val> and ?&nbsp;OrdinaryHasInstance(<emu-xref href="#sec-intl-numberformat-constructor" id="_ref_19"><a href="#sec-intl-numberformat-constructor">%NumberFormat%</a></emu-xref>, <var>this</var>) is <emu-val>true</emu-val>, then<ol><li>Perform ?&nbsp;DefinePropertyOrThrow(<var>this</var>, %Intl%.[[FallbackSymbol]], PropertyDescriptor{ [[Value]]: <var>numberFormat</var>, [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>false</emu-val> }).</li><li>Return <var>this</var>.</li></ol></li><li>Return <var>numberFormat</var>.</li></ol></emu-alg>
       </emu-clause>
       </emu-normative-optional>
     </emu-clause>
@@ -1889,7 +2653,7 @@ li.menu-search-result-term:before {
         The following algorithm refers to the <code>type</code> nonterminal from <a href="https://www.unicode.org/reports/tr35/#Unicode_locale_identifier">UTS 35's Unicode Locale Identifier grammar</a>.
       </p>
 
-      <emu-alg><ol><li>Let <var>requestedLocales</var> be ?&nbsp;CanonicalizeLocaleList(<var>locales</var>).</li><li>Set <var>options</var> to ?&nbsp;CoerceOptionsToObject(<var>options</var>).</li><li>Let <var>opt</var> be a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref>.</li><li>Let <var>matcher</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"localeMatcher"</emu-val>, <emu-const>string</emu-const>, « <emu-val>"lookup"</emu-val>, <emu-val>"best fit"</emu-val> », <emu-val>"best fit"</emu-val>).</li><li>Set <var>opt</var>.[[localeMatcher]] to <var>matcher</var>.</li><li>Let <var>numberingSystem</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"numberingSystem"</emu-val>, <emu-const>string</emu-const>, <emu-const>empty</emu-const>, <emu-val>undefined</emu-val>).</li><li>If <var>numberingSystem</var> is not <emu-val>undefined</emu-val>, then<ol><li>If <var>numberingSystem</var> does not match the Unicode Locale Identifier <code>type</code> nonterminal, throw a <emu-val>RangeError</emu-val> exception.</li></ol></li><li>Set <var>opt</var>.[[nu]] to <var>numberingSystem</var>.</li><li>Let <var>localeData</var> be <emu-xref href="#sec-intl-numberformat-constructor" id="_ref_23"><a href="#sec-intl-numberformat-constructor">%NumberFormat%</a></emu-xref>.[[LocaleData]].</li><li>Let <var>r</var> be ResolveLocale(<emu-xref href="#sec-intl-numberformat-constructor" id="_ref_24"><a href="#sec-intl-numberformat-constructor">%NumberFormat%</a></emu-xref>.[[AvailableLocales]], <var>requestedLocales</var>, <var>opt</var>, <emu-xref href="#sec-intl-numberformat-constructor" id="_ref_25"><a href="#sec-intl-numberformat-constructor">%NumberFormat%</a></emu-xref>.[[RelevantExtensionKeys]], <var>localeData</var>).</li><li>Set <var>numberFormat</var>.[[Locale]] to <var>r</var>.[[locale]].</li><li>Set <var>numberFormat</var>.[[DataLocale]] to <var>r</var>.[[dataLocale]].</li><li>Set <var>numberFormat</var>.[[NumberingSystem]] to <var>r</var>.[[nu]].</li><li>Perform ?&nbsp;<emu-xref aoid="SetNumberFormatUnitOptions" id="_ref_26"><a href="#sec-setnumberformatunitoptions">SetNumberFormatUnitOptions</a></emu-xref>(<var>numberFormat</var>, <var>options</var>).</li><li>Let <var>style</var> be <var>numberFormat</var>.[[Style]].</li><li>If <var>style</var> is <emu-val>"currency"</emu-val>, then<ol><li>Let <var>currency</var> be <var>numberFormat</var>.[[Currency]].</li><li>Let <var>cDigits</var> be <emu-xref aoid="CurrencyDigits" id="_ref_27"><a href="#sec-currencydigits">CurrencyDigits</a></emu-xref>(<var>currency</var>).</li><li>Let <var>mnfdDefault</var> be <var>cDigits</var>.</li><li>Let <var>mxfdDefault</var> be <var>cDigits</var>.</li></ol></li><li>Else,<ol><li>Let <var>mnfdDefault</var> be 0.</li><li>If <var>style</var> is <emu-val>"percent"</emu-val>, then<ol><li>Let <var>mxfdDefault</var> be 0.</li></ol></li><li>Else,<ol><li>Let <var>mxfdDefault</var> be 3.</li></ol></li></ol></li><li>Let <var>roundingIncrement</var> be ?&nbsp;GetNumberOption(<var>options</var>, <emu-val>"roundingIncrement"</emu-val>, 1, 5000, 1).</li><li>If <var>roundingIncrement</var> is not in « 1, 2, 5, 10, 20, 25, 50, 100, 200, 250, 500, 1000, 2000, 2500, 5000 », throw a <emu-val>RangeError</emu-val> exception.</li><li>If <var>roundingIncrement</var> is not 1, set <var>mxfdDefault</var> to <var>mnfdDefault</var>.</li><li>Let <var>notation</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"notation"</emu-val>, <emu-const>string</emu-const>, « <emu-val>"standard"</emu-val>, <emu-val>"scientific"</emu-val>, <emu-val>"engineering"</emu-val>, <emu-val>"compact"</emu-val> », <emu-val>"standard"</emu-val>).</li><li>Set <var>numberFormat</var>.[[Notation]] to <var>notation</var>.</li><li>Perform ?&nbsp;<emu-xref aoid="SetNumberFormatDigitOptions" id="_ref_28"><a href="#sec-setnfdigitoptions">SetNumberFormatDigitOptions</a></emu-xref>(<var>numberFormat</var>, <var>options</var>, <var>mnfdDefault</var>, <var>mxfdDefault</var>, <var>notation</var>).</li><li>If <var>roundingIncrement</var> is not 1, then<ol><li>If <var>numberFormat</var>.[[RoundingType]] is not <emu-const>fractionDigits</emu-const>, throw a <emu-val>TypeError</emu-val> exception.</li><li>If <var>numberFormat</var>.[[MaximumFractionDigits]] is not equal to <var>numberFormat</var>.[[MinimumFractionDigits]], throw a <emu-val>RangeError</emu-val> exception.</li></ol></li><li>Set <var>numberFormat</var>.[[RoundingIncrement]] to <var>roundingIncrement</var>.</li><li>Let <var>trailingZeroDisplay</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"trailingZeroDisplay"</emu-val>, <emu-const>string</emu-const>, « <emu-val>"auto"</emu-val>, <emu-val>"stripIfInteger"</emu-val> », <emu-val>"auto"</emu-val>).</li><li>Set <var>numberFormat</var>.[[TrailingZeroDisplay]] to <var>trailingZeroDisplay</var>.</li><li>Let <var>compactDisplay</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"compactDisplay"</emu-val>, <emu-const>string</emu-const>, « <emu-val>"short"</emu-val>, <emu-val>"long"</emu-val> », <emu-val>"short"</emu-val>).</li><li>Let <var>defaultUseGrouping</var> be <emu-val>"auto"</emu-val>.</li><li>If <var>notation</var> is <emu-val>"compact"</emu-val>, then<ol><li>Set <var>numberFormat</var>.[[CompactDisplay]] to <var>compactDisplay</var>.</li><li>Set <var>defaultUseGrouping</var> to <emu-val>"min2"</emu-val>.</li></ol></li><li>Let <var>useGrouping</var> be ?&nbsp;GetStringOrBooleanOption(<var>options</var>, <emu-val>"useGrouping"</emu-val>, « <emu-val>"min2"</emu-val>, <emu-val>"auto"</emu-val>, <emu-val>"always"</emu-val> », <emu-val>"always"</emu-val>, <emu-val>false</emu-val>, <var>defaultUseGrouping</var>).</li><li>Set <var>numberFormat</var>.[[UseGrouping]] to <var>useGrouping</var>.</li><li>Let <var>signDisplay</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"signDisplay"</emu-val>, <emu-const>string</emu-const>, « <emu-val>"auto"</emu-val>, <emu-val>"never"</emu-val>, <emu-val>"always"</emu-val>, <emu-val>"exceptZero"</emu-val>, <emu-val>"negative"</emu-val> », <emu-val>"auto"</emu-val>).</li><li>Set <var>numberFormat</var>.[[SignDisplay]] to <var>signDisplay</var>.</li><li>Let <var>roundingMode</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"roundingMode"</emu-val>, <emu-const>string</emu-const>, « <emu-val>"ceil"</emu-val>, <emu-val>"floor"</emu-val>, <emu-val>"expand"</emu-val>, <emu-val>"trunc"</emu-val>, <emu-val>"halfCeil"</emu-val>, <emu-val>"halfFloor"</emu-val>, <emu-val>"halfExpand"</emu-val>, <emu-val>"halfTrunc"</emu-val>, <emu-val>"halfEven"</emu-val> », <emu-val>"halfExpand"</emu-val>).</li><li>Set <var>numberFormat</var>.[[RoundingMode]] to <var>roundingMode</var>.</li><li>Return <var>numberFormat</var>.</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>requestedLocales</var> be ?&nbsp;CanonicalizeLocaleList(<var>locales</var>).</li><li>Set <var>options</var> to ?&nbsp;CoerceOptionsToObject(<var>options</var>).</li><li>Let <var>opt</var> be a new Record.</li><li>Let <var>matcher</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"localeMatcher"</emu-val>, <emu-const>string</emu-const>, « <emu-val>"lookup"</emu-val>, <emu-val>"best fit"</emu-val> », <emu-val>"best fit"</emu-val>).</li><li>Set <var>opt</var>.[[localeMatcher]] to <var>matcher</var>.</li><li>Let <var>numberingSystem</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"numberingSystem"</emu-val>, <emu-const>string</emu-const>, <emu-const>empty</emu-const>, <emu-val>undefined</emu-val>).</li><li>If <var>numberingSystem</var> is not <emu-val>undefined</emu-val>, then<ol><li>If <var>numberingSystem</var> does not match the Unicode Locale Identifier <code>type</code> nonterminal, throw a <emu-val>RangeError</emu-val> exception.</li></ol></li><li>Set <var>opt</var>.[[nu]] to <var>numberingSystem</var>.</li><li>Let <var>localeData</var> be <emu-xref href="#sec-intl-numberformat-constructor" id="_ref_20"><a href="#sec-intl-numberformat-constructor">%NumberFormat%</a></emu-xref>.[[LocaleData]].</li><li>Let <var>r</var> be ResolveLocale(<emu-xref href="#sec-intl-numberformat-constructor" id="_ref_21"><a href="#sec-intl-numberformat-constructor">%NumberFormat%</a></emu-xref>.[[AvailableLocales]], <var>requestedLocales</var>, <var>opt</var>, <emu-xref href="#sec-intl-numberformat-constructor" id="_ref_22"><a href="#sec-intl-numberformat-constructor">%NumberFormat%</a></emu-xref>.[[RelevantExtensionKeys]], <var>localeData</var>).</li><li>Set <var>numberFormat</var>.[[Locale]] to <var>r</var>.[[locale]].</li><li>Set <var>numberFormat</var>.[[DataLocale]] to <var>r</var>.[[dataLocale]].</li><li>Set <var>numberFormat</var>.[[NumberingSystem]] to <var>r</var>.[[nu]].</li><li>Perform ?&nbsp;<emu-xref aoid="SetNumberFormatUnitOptions" id="_ref_23"><a href="#sec-setnumberformatunitoptions">SetNumberFormatUnitOptions</a></emu-xref>(<var>numberFormat</var>, <var>options</var>).</li><li>Let <var>style</var> be <var>numberFormat</var>.[[Style]].</li><li>If <var>style</var> is <emu-val>"currency"</emu-val>, then<ol><li>Let <var>currency</var> be <var>numberFormat</var>.[[Currency]].</li><li>Let <var>cDigits</var> be <emu-xref aoid="CurrencyDigits" id="_ref_24"><a href="#sec-currencydigits">CurrencyDigits</a></emu-xref>(<var>currency</var>).</li><li>Let <var>mnfdDefault</var> be <var>cDigits</var>.</li><li>Let <var>mxfdDefault</var> be <var>cDigits</var>.</li></ol></li><li>Else,<ol><li>Let <var>mnfdDefault</var> be 0.</li><li>If <var>style</var> is <emu-val>"percent"</emu-val>, then<ol><li>Let <var>mxfdDefault</var> be 0.</li></ol></li><li>Else,<ol><li>Let <var>mxfdDefault</var> be 3.</li></ol></li></ol></li><li>Let <var>notation</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"notation"</emu-val>, <emu-const>string</emu-const>, « <emu-val>"standard"</emu-val>, <emu-val>"scientific"</emu-val>, <emu-val>"engineering"</emu-val>, <emu-val>"compact"</emu-val> », <emu-val>"standard"</emu-val>).</li><li>Set <var>numberFormat</var>.[[Notation]] to <var>notation</var>.</li><li>Perform ?&nbsp;<emu-xref aoid="SetNumberFormatDigitOptions" id="_ref_25"><a href="#sec-setnfdigitoptions">SetNumberFormatDigitOptions</a></emu-xref>(<var>numberFormat</var>, <var>options</var>, <var>mnfdDefault</var>, <var>mxfdDefault</var>, <var>notation</var>).</li><li>Let <var>compactDisplay</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"compactDisplay"</emu-val>, <emu-const>string</emu-const>, « <emu-val>"short"</emu-val>, <emu-val>"long"</emu-val> », <emu-val>"short"</emu-val>).</li><li>Let <var>defaultUseGrouping</var> be <emu-val>"auto"</emu-val>.</li><li>If <var>notation</var> is <emu-val>"compact"</emu-val>, then<ol><li>Set <var>numberFormat</var>.[[CompactDisplay]] to <var>compactDisplay</var>.</li><li>Set <var>defaultUseGrouping</var> to <emu-val>"min2"</emu-val>.</li></ol></li><li>NOTE: For historical reasons, the strings <emu-val>"true"</emu-val> and <emu-val>"false"</emu-val> are accepted and replaced with the default value.</li><li>Let <var>useGrouping</var> be ?&nbsp;GetBooleanOrStringNumberFormatOption(<var>options</var>, <emu-val>"useGrouping"</emu-val>, « <emu-val>"min2"</emu-val>, <emu-val>"auto"</emu-val>, <emu-val>"always"</emu-val>, <emu-val>"true"</emu-val>, <emu-val>"false"</emu-val> », <var>defaultUseGrouping</var>).</li><li>If <var>useGrouping</var> is <emu-val>"true"</emu-val> or <var>useGrouping</var> is <emu-val>"false"</emu-val>, set <var>useGrouping</var> to <var>defaultUseGrouping</var>.</li><li>If <var>useGrouping</var> is <emu-val>true</emu-val>, set <var>useGrouping</var> to <emu-val>"always"</emu-val>.</li><li>Set <var>numberFormat</var>.[[UseGrouping]] to <var>useGrouping</var>.</li><li>Let <var>signDisplay</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"signDisplay"</emu-val>, <emu-const>string</emu-const>, « <emu-val>"auto"</emu-val>, <emu-val>"never"</emu-val>, <emu-val>"always"</emu-val>, <emu-val>"exceptZero"</emu-val>, <emu-val>"negative"</emu-val> », <emu-val>"auto"</emu-val>).</li><li>Set <var>numberFormat</var>.[[SignDisplay]] to <var>signDisplay</var>.</li><li>Return <var>numberFormat</var>.</li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-setnfdigitoptions" aoid="SetNumberFormatDigitOptions">
@@ -1898,8 +2662,9 @@ li.menu-search-result-term:before {
       <p>
         The abstract operation SetNumberFormatDigitOptions applies digit
         options used for number formatting onto the intl object.
+        It is used by both Intl.NumberFormat and Intl.PluralRules.
       </p>
-      <emu-alg><ol><li>Let <var>mnid</var> be ?&nbsp;GetNumberOption(<var>options</var>, <emu-val>"minimumIntegerDigits,"</emu-val>, 1, 21, 1).</li><li>Let <var>mnfd</var> be ?&nbsp;<emu-xref aoid="Get" id="_ref_29"><a href="https://tc39.es/ecma262/#sec-get-o-p">Get</a></emu-xref>(<var>options</var>, <emu-val>"minimumFractionDigits"</emu-val>).</li><li>Let <var>mxfd</var> be ?&nbsp;<emu-xref aoid="Get" id="_ref_30"><a href="https://tc39.es/ecma262/#sec-get-o-p">Get</a></emu-xref>(<var>options</var>, <emu-val>"maximumFractionDigits"</emu-val>).</li><li>Let <var>mnsd</var> be ?&nbsp;<emu-xref aoid="Get" id="_ref_31"><a href="https://tc39.es/ecma262/#sec-get-o-p">Get</a></emu-xref>(<var>options</var>, <emu-val>"minimumSignificantDigits"</emu-val>).</li><li>Let <var>mxsd</var> be ?&nbsp;<emu-xref aoid="Get" id="_ref_32"><a href="https://tc39.es/ecma262/#sec-get-o-p">Get</a></emu-xref>(<var>options</var>, <emu-val>"maximumSignificantDigits"</emu-val>).</li><li>Set <var>intlObj</var>.[[MinimumIntegerDigits]] to <var>mnid</var>.</li><li>Let <var>roundingPriority</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"roundingPriority"</emu-val>, <emu-const>string</emu-const>, « <emu-val>"auto"</emu-val>, <emu-val>"morePrecision"</emu-val>, <emu-val>"lessPrecision"</emu-val> », <emu-val>"auto"</emu-val>).</li><li>If <var>mnsd</var> is not <emu-val>undefined</emu-val> or <var>mxsd</var> is not <emu-val>undefined</emu-val>, then<ol><li>Let <var>hasSd</var> be <emu-val>true</emu-val>.</li></ol></li><li>Else,<ol><li>Let <var>hasSd</var> be <emu-val>false</emu-val>.</li></ol></li><li>If <var>mnfd</var> is not <emu-val>undefined</emu-val> or <var>mxfd</var> is not <emu-val>undefined</emu-val>, then<ol><li>Let <var>hasFd</var> be <emu-val>true</emu-val>.</li></ol></li><li>Else,<ol><li>Let <var>hasFd</var> be <emu-val>false</emu-val>.</li></ol></li><li>Let <var>needSd</var> be <emu-val>true</emu-val>.</li><li>Let <var>needFd</var> be <emu-val>true</emu-val>.</li><li>If <var>roundingPriority</var> is <emu-val>"auto"</emu-val>, then<ol><li>Set <var>needSd</var> to <var>hasSd</var>.</li><li>If <var>hasSd</var> is <emu-val>true</emu-val>, or <var>hasFd</var> is <emu-val>false</emu-val> and <var>notation</var> is <emu-val>"compact"</emu-val>, then<ol><li>Set <var>needFd</var> to <emu-val>false</emu-val>.</li></ol></li></ol></li><li>If <var>needSd</var> is <emu-val>true</emu-val>, then<ol><li>If <var>hasSd</var> is <emu-val>true</emu-val>, then<ol><li>Set <var>mnsd</var> to ?&nbsp;DefaultNumberOption(<var>mnsd</var>, 1, 21, 1).</li><li>Set <var>mxsd</var> to ?&nbsp;DefaultNumberOption(<var>mxsd</var>, <var>mnsd</var>, 21, 21).</li><li>Set <var>intlObj</var>.[[MinimumSignificantDigits]] to <var>mnsd</var>.</li><li>Set <var>intlObj</var>.[[MaximumSignificantDigits]] to <var>mxsd</var>.</li></ol></li><li>Else,<ol><li>Set <var>intlObj</var>.[[MinimumSignificantDigits]] to 1.</li><li>Set <var>intlObj</var>.[[MaximumSignificantDigits]] to 21.</li></ol></li></ol></li><li>If <var>needFd</var> is <emu-val>true</emu-val>, then<ol><li>If <var>hasFd</var> is <emu-val>true</emu-val>, then<ol><li>Set <var>mnfd</var> to ?&nbsp;DefaultNumberOption(<var>mnfd</var>, 0, 20, <emu-val>undefined</emu-val>).</li><li>Set <var>mxfd</var> to ?&nbsp;DefaultNumberOption(<var>mxfd</var>, 0, 20, <emu-val>undefined</emu-val>).</li><li>If <var>mnfd</var> is <emu-val>undefined</emu-val>, set <var>mnfd</var> to <emu-xref aoid="min"><a href="https://tc39.es/ecma262/#eqn-min">min</a></emu-xref>(<var>mnfdDefault</var>, <var>mxfd</var>).</li><li>Else if <var>mxfd</var> is <emu-val>undefined</emu-val>, set <var>mxfd</var> to <emu-xref aoid="max"><a href="https://tc39.es/ecma262/#eqn-max">max</a></emu-xref>(<var>mxfdDefault</var>, <var>mnfd</var>).</li><li>Else if <var>mnfd</var> is greater than <var>mxfd</var>, throw a <emu-val>RangeError</emu-val> exception.</li><li>Set <var>intlObj</var>.[[MinimumFractionDigits]] to <var>mnfd</var>.</li><li>Set <var>intlObj</var>.[[MaximumFractionDigits]] to <var>mxfd</var>.</li></ol></li><li>Else,<ol><li>Set <var>intlObj</var>.[[MinimumFractionDigits]] to <var>mnfdDefault</var>.</li><li>Set <var>intlObj</var>.[[MaximumFractionDigits]] to <var>mxfdDefault</var>.</li></ol></li></ol></li><li>If <var>needSd</var> is <emu-val>true</emu-val> or <var>needFd</var> is <emu-val>true</emu-val>, then<ol><li>If <var>roundingPriority</var> is <emu-val>"morePrecision"</emu-val>, then<ol><li>Set <var>intlObj</var>.[[RoundingType]] to <emu-const>morePrecision</emu-const>.</li></ol></li><li>Else if <var>roundingPriority</var> is <emu-val>"lessPrecision"</emu-val>, then<ol><li>Set <var>intlObj</var>.[[RoundingType]] to <emu-const>lessPrecision</emu-const>.</li></ol></li><li>Else if <var>hasSd</var> is <emu-val>true</emu-val>, then<ol><li>Set <var>intlObj</var>.[[RoundingType]] to <emu-const>significantDigits</emu-const>.</li></ol></li><li>Else,<ol><li>Set <var>intlObj</var>.[[RoundingType]] to <emu-const>fractionDigits</emu-const>.</li></ol></li></ol></li><li>Else,<ol><li>Set <var>intlObj</var>.[[RoundingType]] to <emu-const>morePrecision</emu-const>.</li><li>Set <var>intlObj</var>.[[MinimumFractionDigits]] to 0.</li><li>Set <var>intlObj</var>.[[MaximumFractionDigits]] to 0.</li><li>Set <var>intlObj</var>.[[MinimumSignificantDigits]] to 1.</li><li>Set <var>intlObj</var>.[[MaximumSignificantDigits]] to 2.</li></ol></li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>mnid</var> be ?&nbsp;GetNumberOption(<var>options</var>, <emu-val>"minimumIntegerDigits,"</emu-val>, 1, 21, 1).</li><li>Let <var>mnfd</var> be ?&nbsp;Get(<var>options</var>, <emu-val>"minimumFractionDigits"</emu-val>).</li><li>Let <var>mxfd</var> be ?&nbsp;Get(<var>options</var>, <emu-val>"maximumFractionDigits"</emu-val>).</li><li>Let <var>mnsd</var> be ?&nbsp;Get(<var>options</var>, <emu-val>"minimumSignificantDigits"</emu-val>).</li><li>Let <var>mxsd</var> be ?&nbsp;Get(<var>options</var>, <emu-val>"maximumSignificantDigits"</emu-val>).</li><li>Set <var>intlObj</var>.[[MinimumIntegerDigits]] to <var>mnid</var>.</li><li>Let <var>roundingPriority</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"roundingPriority"</emu-val>, <emu-const>string</emu-const>, « <emu-val>"auto"</emu-val>, <emu-val>"morePrecision"</emu-val>, <emu-val>"lessPrecision"</emu-val> », <emu-val>"auto"</emu-val>).</li><li>Let <var>roundingIncrement</var> be ?&nbsp;GetNumberOption(<var>options</var>, <emu-val>"roundingIncrement"</emu-val>, 1, 5000, 1).</li><li>If <var>roundingIncrement</var> is not in « 1, 2, 5, 10, 20, 25, 50, 100, 200, 250, 500, 1000, 2000, 2500, 5000 », throw a <emu-val>RangeError</emu-val> exception.</li><li>Let <var>roundingMode</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"roundingMode"</emu-val>, <emu-const>string</emu-const>, « <emu-val>"ceil"</emu-val>, <emu-val>"floor"</emu-val>, <emu-val>"expand"</emu-val>, <emu-val>"trunc"</emu-val>, <emu-val>"halfCeil"</emu-val>, <emu-val>"halfFloor"</emu-val>, <emu-val>"halfExpand"</emu-val>, <emu-val>"halfTrunc"</emu-val>, <emu-val>"halfEven"</emu-val> », <emu-val>"halfExpand"</emu-val>).</li><li>Let <var>trailingZeroDisplay</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"trailingZeroDisplay"</emu-val>, <emu-const>string</emu-const>, « <emu-val>"auto"</emu-val>, <emu-val>"stripIfInteger"</emu-val> », <emu-val>"auto"</emu-val>).</li><li>NOTE: All fields required by <emu-xref aoid="SetNumberFormatDigitOptions" id="_ref_26"><a href="#sec-setnfdigitoptions">SetNumberFormatDigitOptions</a></emu-xref> have now been read from <var>options</var>. The remainder of this AO interprets the options and may throw exceptions.</li><li>If <var>roundingIncrement</var> is not 1, set <var>mxfdDefault</var> to <var>mnfdDefault</var>.</li><li>Set <var>intlObj</var>.[[RoundingIncrement]] to <var>roundingIncrement</var>.</li><li>Set <var>intlObj</var>.[[RoundingMode]] to <var>roundingMode</var>.</li><li>Set <var>intlObj</var>.[[TrailingZeroDisplay]] to <var>trailingZeroDisplay</var>.</li><li>If <var>mnsd</var> is not <emu-val>undefined</emu-val> or <var>mxsd</var> is not <emu-val>undefined</emu-val>, then<ol><li>Let <var>hasSd</var> be <emu-val>true</emu-val>.</li></ol></li><li>Else,<ol><li>Let <var>hasSd</var> be <emu-val>false</emu-val>.</li></ol></li><li>If <var>mnfd</var> is not <emu-val>undefined</emu-val> or <var>mxfd</var> is not <emu-val>undefined</emu-val>, then<ol><li>Let <var>hasFd</var> be <emu-val>true</emu-val>.</li></ol></li><li>Else,<ol><li>Let <var>hasFd</var> be <emu-val>false</emu-val>.</li></ol></li><li>Let <var>needSd</var> be <emu-val>true</emu-val>.</li><li>Let <var>needFd</var> be <emu-val>true</emu-val>.</li><li>If <var>roundingPriority</var> is <emu-val>"auto"</emu-val>, then<ol><li>Set <var>needSd</var> to <var>hasSd</var>.</li><li>If <var>hasSd</var> is <emu-val>true</emu-val>, or <var>hasFd</var> is <emu-val>false</emu-val> and <var>notation</var> is <emu-val>"compact"</emu-val>, then<ol><li>Set <var>needFd</var> to <emu-val>false</emu-val>.</li></ol></li></ol></li><li>If <var>needSd</var> is <emu-val>true</emu-val>, then<ol><li>If <var>hasSd</var> is <emu-val>true</emu-val>, then<ol><li>Set <var>mnsd</var> to ?&nbsp;DefaultNumberOption(<var>mnsd</var>, 1, 21, 1).</li><li>Set <var>mxsd</var> to ?&nbsp;DefaultNumberOption(<var>mxsd</var>, <var>mnsd</var>, 21, 21).</li><li>Set <var>intlObj</var>.[[MinimumSignificantDigits]] to <var>mnsd</var>.</li><li>Set <var>intlObj</var>.[[MaximumSignificantDigits]] to <var>mxsd</var>.</li></ol></li><li>Else,<ol><li>Set <var>intlObj</var>.[[MinimumSignificantDigits]] to 1.</li><li>Set <var>intlObj</var>.[[MaximumSignificantDigits]] to 21.</li></ol></li></ol></li><li>If <var>needFd</var> is <emu-val>true</emu-val>, then<ol><li>If <var>hasFd</var> is <emu-val>true</emu-val>, then<ol><li>Set <var>mnfd</var> to ?&nbsp;DefaultNumberOption(<var>mnfd</var>, 0, 20, <emu-val>undefined</emu-val>).</li><li>Set <var>mxfd</var> to ?&nbsp;DefaultNumberOption(<var>mxfd</var>, 0, 20, <emu-val>undefined</emu-val>).</li><li>If <var>mnfd</var> is <emu-val>undefined</emu-val>, set <var>mnfd</var> to min(<var>mnfdDefault</var>, <var>mxfd</var>).</li><li>Else if <var>mxfd</var> is <emu-val>undefined</emu-val>, set <var>mxfd</var> to max(<var>mxfdDefault</var>, <var>mnfd</var>).</li><li>Else if <var>mnfd</var> is greater than <var>mxfd</var>, throw a <emu-val>RangeError</emu-val> exception.</li><li>Set <var>intlObj</var>.[[MinimumFractionDigits]] to <var>mnfd</var>.</li><li>Set <var>intlObj</var>.[[MaximumFractionDigits]] to <var>mxfd</var>.</li></ol></li><li>Else,<ol><li>Set <var>intlObj</var>.[[MinimumFractionDigits]] to <var>mnfdDefault</var>.</li><li>Set <var>intlObj</var>.[[MaximumFractionDigits]] to <var>mxfdDefault</var>.</li></ol></li></ol></li><li>If <var>needSd</var> is <emu-val>true</emu-val> or <var>needFd</var> is <emu-val>true</emu-val>, then<ol><li>If <var>roundingPriority</var> is <emu-val>"morePrecision"</emu-val>, then<ol><li>Set <var>intlObj</var>.[[RoundingType]] to <emu-const>morePrecision</emu-const>.</li></ol></li><li>Else if <var>roundingPriority</var> is <emu-val>"lessPrecision"</emu-val>, then<ol><li>Set <var>intlObj</var>.[[RoundingType]] to <emu-const>lessPrecision</emu-const>.</li></ol></li><li>Else if <var>hasSd</var> is <emu-val>true</emu-val>, then<ol><li>Set <var>intlObj</var>.[[RoundingType]] to <emu-const>significantDigits</emu-const>.</li></ol></li><li>Else,<ol><li>Set <var>intlObj</var>.[[RoundingType]] to <emu-const>fractionDigits</emu-const>.</li></ol></li></ol></li><li>Else,<ol><li>Set <var>intlObj</var>.[[RoundingType]] to <emu-const>morePrecision</emu-const>.</li><li>Set <var>intlObj</var>.[[MinimumFractionDigits]] to 0.</li><li>Set <var>intlObj</var>.[[MaximumFractionDigits]] to 0.</li><li>Set <var>intlObj</var>.[[MinimumSignificantDigits]] to 1.</li><li>Set <var>intlObj</var>.[[MaximumSignificantDigits]] to 2.</li></ol></li><li>If <var>roundingIncrement</var> is not 1, then<ol><li>If <var>intlObj</var>.[[RoundingType]] is not <emu-const>fractionDigits</emu-const>, throw a <emu-val>TypeError</emu-val> exception.</li><li>If <var>intlObj</var>.[[MaximumFractionDigits]] is not equal to <var>intlObj</var>.[[MinimumFractionDigits]], throw a <emu-val>RangeError</emu-val> exception.</li></ol></li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-setnumberformatunitoptions" aoid="SetNumberFormatUnitOptions">
@@ -1907,7 +2672,7 @@ li.menu-search-result-term:before {
       <p>
         The abstract operation SetNumberFormatUnitOptions resolves the user-specified options relating to units onto the intl object.
       </p>
-      <emu-alg><ol><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <emu-xref aoid="Type" id="_ref_33"><a href="https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>intlObj</var>) is Object.</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <emu-xref aoid="Type" id="_ref_34"><a href="https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>options</var>) is Object.</li><li>Let <var>style</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"style"</emu-val>, <emu-const>string</emu-const>, « <emu-val>"decimal"</emu-val>, <emu-val>"percent"</emu-val>, <emu-val>"currency"</emu-val>, <emu-val>"unit"</emu-val> », <emu-val>"decimal"</emu-val>).</li><li>Set <var>intlObj</var>.[[Style]] to <var>style</var>.</li><li>Let <var>currency</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"currency"</emu-val>, <emu-const>string</emu-const>, <emu-const>empty</emu-const>, <emu-val>undefined</emu-val>).</li><li>If <var>currency</var> is <emu-val>undefined</emu-val>, then<ol><li>If <var>style</var> is <emu-val>"currency"</emu-val>, throw a <emu-val>TypeError</emu-val> exception.</li></ol></li><li>Else,<ol><li>If the result of IsWellFormedCurrencyCode(<var>currency</var>) is <emu-val>false</emu-val>, throw a <emu-val>RangeError</emu-val> exception.</li></ol></li><li>Let <var>currencyDisplay</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"currencyDisplay"</emu-val>, <emu-const>string</emu-const>, « <emu-val>"code"</emu-val>, <emu-val>"symbol"</emu-val>, <emu-val>"narrowSymbol"</emu-val>, <emu-val>"name"</emu-val> », <emu-val>"symbol"</emu-val>).</li><li>Let <var>currencySign</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"currencySign"</emu-val>, <emu-const>string</emu-const>, « <emu-val>"standard"</emu-val>, <emu-val>"accounting"</emu-val> », <emu-val>"standard"</emu-val>).</li><li>Let <var>unit</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"unit"</emu-val>, <emu-const>string</emu-const>, <emu-const>empty</emu-const>, <emu-val>undefined</emu-val>).</li><li>If <var>unit</var> is <emu-val>undefined</emu-val>, then<ol><li>If <var>style</var> is <emu-val>"unit"</emu-val>, throw a <emu-val>TypeError</emu-val> exception.</li></ol></li><li>Else,<ol><li>If !&nbsp;IsWellFormedUnitIdentifier(<var>unit</var>) is <emu-val>false</emu-val>, throw a <emu-val>RangeError</emu-val> exception.</li></ol></li><li>Let <var>unitDisplay</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"unitDisplay"</emu-val>, <emu-const>string</emu-const>, « <emu-val>"short"</emu-val>, <emu-val>"narrow"</emu-val>, <emu-val>"long"</emu-val> », <emu-val>"short"</emu-val>).</li><li>If <var>style</var> is <emu-val>"currency"</emu-val>, then<ol><li>Set <var>intlObj</var>.[[Currency]] to the ASCII-uppercase of <var>currency</var>.</li><li>Set <var>intlObj</var>.[[CurrencyDisplay]] to <var>currencyDisplay</var>.</li><li>Set <var>intlObj</var>.[[CurrencySign]] to <var>currencySign</var>.</li></ol></li><li>If <var>style</var> is <emu-val>"unit"</emu-val>, then<ol><li>Set <var>intlObj</var>.[[Unit]] to <var>unit</var>.</li><li>Set <var>intlObj</var>.[[UnitDisplay]] to <var>unitDisplay</var>.</li></ol></li></ol></emu-alg>
+      <emu-alg><ol><li>Assert: Type(<var>intlObj</var>) is Object.</li><li>Assert: Type(<var>options</var>) is Object.</li><li>Let <var>style</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"style"</emu-val>, <emu-const>string</emu-const>, « <emu-val>"decimal"</emu-val>, <emu-val>"percent"</emu-val>, <emu-val>"currency"</emu-val>, <emu-val>"unit"</emu-val> », <emu-val>"decimal"</emu-val>).</li><li>Set <var>intlObj</var>.[[Style]] to <var>style</var>.</li><li>Let <var>currency</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"currency"</emu-val>, <emu-const>string</emu-const>, <emu-const>empty</emu-const>, <emu-val>undefined</emu-val>).</li><li>If <var>currency</var> is <emu-val>undefined</emu-val>, then<ol><li>If <var>style</var> is <emu-val>"currency"</emu-val>, throw a <emu-val>TypeError</emu-val> exception.</li></ol></li><li>Else,<ol><li>If the result of IsWellFormedCurrencyCode(<var>currency</var>) is <emu-val>false</emu-val>, throw a <emu-val>RangeError</emu-val> exception.</li></ol></li><li>Let <var>currencyDisplay</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"currencyDisplay"</emu-val>, <emu-const>string</emu-const>, « <emu-val>"code"</emu-val>, <emu-val>"symbol"</emu-val>, <emu-val>"narrowSymbol"</emu-val>, <emu-val>"name"</emu-val> », <emu-val>"symbol"</emu-val>).</li><li>Let <var>currencySign</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"currencySign"</emu-val>, <emu-const>string</emu-const>, « <emu-val>"standard"</emu-val>, <emu-val>"accounting"</emu-val> », <emu-val>"standard"</emu-val>).</li><li>Let <var>unit</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"unit"</emu-val>, <emu-const>string</emu-const>, <emu-const>empty</emu-const>, <emu-val>undefined</emu-val>).</li><li>If <var>unit</var> is <emu-val>undefined</emu-val>, then<ol><li>If <var>style</var> is <emu-val>"unit"</emu-val>, throw a <emu-val>TypeError</emu-val> exception.</li></ol></li><li>Else,<ol><li>If !&nbsp;IsWellFormedUnitIdentifier(<var>unit</var>) is <emu-val>false</emu-val>, throw a <emu-val>RangeError</emu-val> exception.</li></ol></li><li>Let <var>unitDisplay</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"unitDisplay"</emu-val>, <emu-const>string</emu-const>, « <emu-val>"short"</emu-val>, <emu-val>"narrow"</emu-val>, <emu-val>"long"</emu-val> », <emu-val>"short"</emu-val>).</li><li>If <var>style</var> is <emu-val>"currency"</emu-val>, then<ol><li>Set <var>intlObj</var>.[[Currency]] to the ASCII-uppercase of <var>currency</var>.</li><li>Set <var>intlObj</var>.[[CurrencyDisplay]] to <var>currencyDisplay</var>.</li><li>Set <var>intlObj</var>.[[CurrencySign]] to <var>currencySign</var>.</li></ol></li><li>If <var>style</var> is <emu-val>"unit"</emu-val>, then<ol><li>Set <var>intlObj</var>.[[Unit]] to <var>unit</var>.</li><li>Set <var>intlObj</var>.[[UnitDisplay]] to <var>unitDisplay</var>.</li></ol></li></ol></emu-alg>
     </emu-clause>
   </emu-clause>
 
@@ -1915,14 +2680,14 @@ li.menu-search-result-term:before {
     <h1><span class="secnum">1.2</span> Properties of the Intl.NumberFormat Constructor</h1>
 
     <p>
-      The Intl.NumberFormat <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> has the following properties:
+      The Intl.NumberFormat constructor has the following properties:
     </p>
 
     <emu-clause id="sec-intl.numberformat.prototype">
       <h1><span class="secnum">1.2.1</span> Intl.NumberFormat.prototype</h1>
 
       <p>
-        The value of <code>Intl.NumberFormat.prototype</code> is <emu-xref href="#sec-properties-of-intl-numberformat-prototype-object" id="_ref_35"><a href="#sec-properties-of-intl-numberformat-prototype-object">%NumberFormat.prototype%</a></emu-xref>.
+        The value of <code>Intl.NumberFormat.prototype</code> is <emu-xref href="#sec-properties-of-intl-numberformat-prototype-object" id="_ref_27"><a href="#sec-properties-of-intl-numberformat-prototype-object">%NumberFormat.prototype%</a></emu-xref>.
       </p>
       <p>
         This property has the attributes { [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>false</emu-val> }.
@@ -1936,7 +2701,7 @@ li.menu-search-result-term:before {
         When the <code>supportedLocalesOf</code> method is called with arguments <var>locales</var> and <var>options</var>, the following steps are taken:
       </p>
 
-      <emu-alg><ol><li>Let <var>availableLocales</var> be <emu-xref href="#sec-intl-numberformat-constructor" id="_ref_36"><a href="#sec-intl-numberformat-constructor">%NumberFormat%</a></emu-xref>.[[AvailableLocales]].</li><li>Let <var>requestedLocales</var> be ?&nbsp;CanonicalizeLocaleList(<var>locales</var>).</li><li>Return ?&nbsp;SupportedLocales(<var>availableLocales</var>, <var>requestedLocales</var>, <var>options</var>).</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>availableLocales</var> be <emu-xref href="#sec-intl-numberformat-constructor" id="_ref_28"><a href="#sec-intl-numberformat-constructor">%NumberFormat%</a></emu-xref>.[[AvailableLocales]].</li><li>Let <var>requestedLocales</var> be ?&nbsp;CanonicalizeLocaleList(<var>locales</var>).</li><li>Return ?&nbsp;SupportedLocales(<var>availableLocales</var>, <var>requestedLocales</var>, <var>options</var>).</li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-intl.numberformat-internal-slots">
@@ -1960,22 +2725,22 @@ li.menu-search-result-term:before {
 
       <ul>
         <li>The list that is the value of the <emu-val>"nu"</emu-val> field of any locale field of [[LocaleData]] must not include the values <emu-val>"native"</emu-val>, <emu-val>"traditio"</emu-val>, or <emu-val>"finance"</emu-val>.</li>
-        <li>[[LocaleData]].[[&lt;<var>locale</var>&gt;]] must have a [[patterns]] field for all locale values <var>locale</var>. The value of this field must be a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref>, which must have fields with the names of the four number format styles: <emu-val>"decimal"</emu-val>, <emu-val>"percent"</emu-val>, <emu-val>"currency"</emu-val>, and <emu-val>"unit"</emu-val>.</li>
+        <li>[[LocaleData]].[[&lt;<var>locale</var>&gt;]] must have a [[patterns]] field for all locale values <var>locale</var>. The value of this field must be a Record, which must have fields with the names of the four number format styles: <emu-val>"decimal"</emu-val>, <emu-val>"percent"</emu-val>, <emu-val>"currency"</emu-val>, and <emu-val>"unit"</emu-val>.</li>
         <li>
           The two fields <emu-val>"currency"</emu-val> and <emu-val>"unit"</emu-val> noted above must be Records with at least one field, <emu-val>"fallback"</emu-val>.
           The <emu-val>"currency"</emu-val> may have additional fields with keys corresponding to currency codes according to <emu-xref href="#sec-currency-codes"></emu-xref>.
-          Each field of <emu-val>"currency"</emu-val> must be a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> with fields corresponding to the possible currencyDisplay values: <emu-val>"code"</emu-val>, <emu-val>"symbol"</emu-val>, <emu-val>"narrowSymbol"</emu-val>, and <emu-val>"name"</emu-val>.
-          Each of those fields must contain a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> with fields corresponding to the possible currencySign values: <emu-val>"standard"</emu-val> or <emu-val>"accounting"</emu-val>. The <emu-val>"unit"</emu-val> field (of [[LocaleData]].[[&lt;<var>locale</var>&gt;]]) may have additional fields beyond the required field <emu-val>"fallback"</emu-val> with keys corresponding to core measurement unit identifiers corresponding to <emu-xref href="#sec-measurement-unit-identifiers"></emu-xref>.
-          Each field of <emu-val>"unit"</emu-val> must be a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> with fields corresponding to the possible unitDisplay values: <emu-val>"narrow"</emu-val>, <emu-val>"short"</emu-val>, and <emu-val>"long"</emu-val>.
+          Each field of <emu-val>"currency"</emu-val> must be a Record with fields corresponding to the possible currencyDisplay values: <emu-val>"code"</emu-val>, <emu-val>"symbol"</emu-val>, <emu-val>"narrowSymbol"</emu-val>, and <emu-val>"name"</emu-val>.
+          Each of those fields must contain a Record with fields corresponding to the possible currencySign values: <emu-val>"standard"</emu-val> or <emu-val>"accounting"</emu-val>. The <emu-val>"unit"</emu-val> field (of [[LocaleData]].[[&lt;<var>locale</var>&gt;]]) may have additional fields beyond the required field <emu-val>"fallback"</emu-val> with keys corresponding to core measurement unit identifiers corresponding to <emu-xref href="#sec-measurement-unit-identifiers"></emu-xref>.
+          Each field of <emu-val>"unit"</emu-val> must be a Record with fields corresponding to the possible unitDisplay values: <emu-val>"narrow"</emu-val>, <emu-val>"short"</emu-val>, and <emu-val>"long"</emu-val>.
         </li>
         <li>All of the leaf fields so far described for the patterns tree (<emu-val>"decimal"</emu-val>, <emu-val>"percent"</emu-val>, great-grandchildren of <emu-val>"currency"</emu-val>, and grandchildren of <emu-val>"unit"</emu-val>) must be Records with the keys <emu-val>"positivePattern"</emu-val>, <emu-val>"zeroPattern"</emu-val>, and <emu-val>"negativePattern"</emu-val>.</li>
         <li>
           The value of the aforementioned fields (the sign-dependent pattern fields) must be string values that must contain the substring <emu-val>"{number}"</emu-val>.
           <emu-val>"positivePattern"</emu-val> must contain the substring <emu-val>"{plusSign}"</emu-val> but not <emu-val>"{minusSign}"</emu-val>; <emu-val>"negativePattern"</emu-val> must contain the substring <emu-val>"{minusSign}"</emu-val> but not <emu-val>"{plusSign}"</emu-val>; and <emu-val>"zeroPattern"</emu-val> must not contain either <emu-val>"{plusSign}"</emu-val> or <emu-val>"{minusSign}"</emu-val>.
           Additionally, the values within the <emu-val>"percent"</emu-val> field must also contain the substring <emu-val>"{percentSign}"</emu-val>; the values within the <emu-val>"currency"</emu-val> field must also contain one or more of the following substrings: <emu-val>"{currencyCode}"</emu-val>, <emu-val>"{currencyPrefix}"</emu-val>, or <emu-val>"{currencySuffix}"</emu-val>; and the values within the <emu-val>"unit"</emu-val> field must also contain one or more of the following substrings: <emu-val>"{unitPrefix}"</emu-val> or <emu-val>"{unitSuffix}"</emu-val>.
-          The pattern strings, when interpreted as a sequence of UTF-16 encoded code points as described in es2023, <emu-xref href="#sec-ecmascript-language-types-string-type"><a href="https://tc39.es/ecma262/#sec-ecmascript-language-types-string-type">6.1.4</a></emu-xref>, must not contain any code points in the General Category "Number, decimal digit" as specified by the Unicode Standard.
+          The pattern strings, when interpreted as a sequence of UTF-16 encoded code points as described in es2023, <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>, must not contain any code points in the General Category "Number, decimal digit" as specified by the Unicode Standard.
         </li>
-        <li>[[LocaleData]].[[&lt;<var>locale</var>&gt;]] must also have a [[notationSubPatterns]] field for all locale values <var>locale</var>. The value of this field must be a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref>, which must have two fields: [[scientific]] and [[compact]]. The [[scientific]] field must be a string value containing the substrings <emu-val>"{number}"</emu-val>, <emu-val>"{scientificSeparator}"</emu-val>, and <emu-val>"{scientificExponent}"</emu-val>. The [[compact]] field must be a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> with two fields: <emu-val>"short"</emu-val> and <emu-val>"long"</emu-val>. Each of these fields must be a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> with <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref> keys corresponding to all discrete magnitudes the implementation supports for compact notation. Each of these fields must be a string value which may contain the substring <emu-val>"{number}"</emu-val>. Strings descended from <emu-val>"short"</emu-val> must contain the substring <emu-val>"{compactSymbol}"</emu-val>, and strings descended from <emu-val>"long"</emu-val> must contain the substring <emu-val>"{compactName}"</emu-val>.</li>
+        <li>[[LocaleData]].[[&lt;<var>locale</var>&gt;]] must also have a [[notationSubPatterns]] field for all locale values <var>locale</var>. The value of this field must be a Record, which must have two fields: [[scientific]] and [[compact]]. The [[scientific]] field must be a string value containing the substrings <emu-val>"{number}"</emu-val>, <emu-val>"{scientificSeparator}"</emu-val>, and <emu-val>"{scientificExponent}"</emu-val>. The [[compact]] field must be a Record with two fields: <emu-val>"short"</emu-val> and <emu-val>"long"</emu-val>. Each of these fields must be a Record with integer keys corresponding to all discrete magnitudes the implementation supports for compact notation. Each of these fields must be a string value which may contain the substring <emu-val>"{number}"</emu-val>. Strings descended from <emu-val>"short"</emu-val> must contain the substring <emu-val>"{compactSymbol}"</emu-val>, and strings descended from <emu-val>"long"</emu-val> must contain the substring <emu-val>"{compactName}"</emu-val>.</li>
       </ul>
 
       <emu-note><span class="note">Note 2</span><div class="note-contents">
@@ -1995,7 +2760,7 @@ li.menu-search-result-term:before {
       <h1><span class="secnum">1.3.1</span> Intl.NumberFormat.prototype.constructor</h1>
 
       <p>
-        The initial value of <code>Intl.NumberFormat.prototype.constructor</code> is <emu-xref href="#sec-intl-numberformat-constructor" id="_ref_37"><a href="#sec-intl-numberformat-constructor">%NumberFormat%</a></emu-xref>.
+        The initial value of <code>Intl.NumberFormat.prototype.constructor</code> is <emu-xref href="#sec-intl-numberformat-constructor" id="_ref_29"><a href="#sec-intl-numberformat-constructor">%NumberFormat%</a></emu-xref>.
       </p>
     </emu-clause>
 
@@ -2014,10 +2779,10 @@ li.menu-search-result-term:before {
       <h1><span class="secnum">1.3.3</span> get Intl.NumberFormat.prototype.format</h1>
 
       <p>
-        Intl.NumberFormat.prototype.format is an <emu-xref href="#sec-object-type"><a href="https://tc39.es/ecma262/#sec-object-type">accessor property</a></emu-xref> whose set accessor function is <emu-val>undefined</emu-val>. Its get accessor function performs the following steps:
+        Intl.NumberFormat.prototype.format is an accessor property whose set accessor function is <emu-val>undefined</emu-val>. Its get accessor function performs the following steps:
       </p>
 
-      <emu-alg><ol><li>Let <var>nf</var> be the <emu-val>this</emu-val> value.</li><li>If the implementation supports the normative optional <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> mode of <emu-xref href="#legacy-constructor"></emu-xref>, then<ol><li>Set <var>nf</var> to ?&nbsp;<emu-xref aoid="UnwrapNumberFormat" id="_ref_38"><a href="#sec-unwrapnumberformat">UnwrapNumberFormat</a></emu-xref>(<var>nf</var>).</li></ol></li><li>Perform ?&nbsp;<emu-xref aoid="RequireInternalSlot" id="_ref_39"><a href="https://tc39.es/ecma262/#sec-requireinternalslot">RequireInternalSlot</a></emu-xref>(<var>nf</var>, [[InitializedNumberFormat]]).</li><li>If <var>nf</var>.[[BoundFormat]] is <emu-val>undefined</emu-val>, then<ol><li>Let <var>F</var> be a new built-in <emu-xref href="#function-object"><a href="https://tc39.es/ecma262/#function-object">function object</a></emu-xref> as defined in Number Format Functions (<emu-xref href="#sec-number-format-functions" id="_ref_0"><a href="#sec-number-format-functions">1.5.2</a></emu-xref>).</li><li>Set <var>F</var>.[[NumberFormat]] to <var>nf</var>.</li><li>Set <var>nf</var>.[[BoundFormat]] to <var>F</var>.</li></ol></li><li>Return <var>nf</var>.[[BoundFormat]].</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>nf</var> be the <emu-val>this</emu-val> value.</li><li>If the implementation supports the normative optional constructor mode of <emu-xref href="#legacy-constructor"></emu-xref>, then<ol><li>Set <var>nf</var> to ?&nbsp;<emu-xref aoid="UnwrapNumberFormat" id="_ref_30"><a href="#sec-unwrapnumberformat">UnwrapNumberFormat</a></emu-xref>(<var>nf</var>).</li></ol></li><li>Perform ?&nbsp;RequireInternalSlot(<var>nf</var>, [[InitializedNumberFormat]]).</li><li>If <var>nf</var>.[[BoundFormat]] is <emu-val>undefined</emu-val>, then<ol><li>Let <var>F</var> be a new built-in function object as defined in Number Format Functions (<emu-xref href="#sec-number-format-functions" id="_ref_0"><a href="#sec-number-format-functions">1.5.2</a></emu-xref>).</li><li>Set <var>F</var>.[[NumberFormat]] to <var>nf</var>.</li><li>Set <var>nf</var>.[[BoundFormat]] to <var>F</var>.</li></ol></li><li>Return <var>nf</var>.[[BoundFormat]].</li></ol></emu-alg>
 
       <emu-note><span class="note">Note</span><div class="note-contents">
         The returned function is bound to <var>nf</var> so that it can be passed directly to <code>Array.prototype.map</code> or other functions.
@@ -2032,7 +2797,7 @@ li.menu-search-result-term:before {
         When the <code>formatToParts</code> method is called with an optional argument <var>value</var>, the following steps are taken:
       </p>
 
-      <emu-alg><ol><li>Let <var>nf</var> be the <emu-val>this</emu-val> value.</li><li>Perform ?&nbsp;<emu-xref aoid="RequireInternalSlot" id="_ref_40"><a href="https://tc39.es/ecma262/#sec-requireinternalslot">RequireInternalSlot</a></emu-xref>(<var>nf</var>, [[InitializedNumberFormat]]).</li><li>Let <var>x</var> be ?&nbsp;<emu-xref aoid="ToIntlMathematicalValue" id="_ref_41"><a href="#sec-tointlmathematicalvalue">ToIntlMathematicalValue</a></emu-xref>(<var>value</var>).</li><li>Return ?&nbsp;<emu-xref aoid="FormatNumericToParts" id="_ref_42"><a href="#sec-formatnumbertoparts">FormatNumericToParts</a></emu-xref>(<var>nf</var>, <var>x</var>).</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>nf</var> be the <emu-val>this</emu-val> value.</li><li>Perform ?&nbsp;RequireInternalSlot(<var>nf</var>, [[InitializedNumberFormat]]).</li><li>Let <var>x</var> be ?&nbsp;<emu-xref aoid="ToIntlMathematicalValue" id="_ref_31"><a href="#sec-tointlmathematicalvalue">ToIntlMathematicalValue</a></emu-xref>(<var>value</var>).</li><li>Return ?&nbsp;<emu-xref aoid="FormatNumericToParts" id="_ref_32"><a href="#sec-formatnumbertoparts">FormatNumericToParts</a></emu-xref>(<var>nf</var>, <var>x</var>).</li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-intl.numberformat.prototype.formatrange">
@@ -2042,7 +2807,7 @@ li.menu-search-result-term:before {
         When the <code>formatRange</code> method is called with arguments <var>start</var> and <var>end</var>, the following steps are taken:
       </p>
 
-      <emu-alg><ol><li>Let <var>nf</var> be the <emu-val>this</emu-val> value.</li><li>Perform ?&nbsp;<emu-xref aoid="RequireInternalSlot" id="_ref_43"><a href="https://tc39.es/ecma262/#sec-requireinternalslot">RequireInternalSlot</a></emu-xref>(<var>nf</var>, [[InitializedNumberFormat]]).</li><li>If <var>start</var> is <emu-val>undefined</emu-val> or <var>end</var> is <emu-val>undefined</emu-val>, throw a <emu-val>TypeError</emu-val> exception.</li><li>Let <var>x</var> be ?&nbsp;<emu-xref aoid="ToIntlMathematicalValue" id="_ref_44"><a href="#sec-tointlmathematicalvalue">ToIntlMathematicalValue</a></emu-xref>(<var>start</var>).</li><li>Let <var>y</var> be ?&nbsp;<emu-xref aoid="ToIntlMathematicalValue" id="_ref_45"><a href="#sec-tointlmathematicalvalue">ToIntlMathematicalValue</a></emu-xref>(<var>end</var>).</li><li>Return ?&nbsp;<emu-xref aoid="FormatNumericRange" id="_ref_46"><a href="#sec-formatnumericrange">FormatNumericRange</a></emu-xref>(<var>nf</var>, <var>x</var>, <var>y</var>).</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>nf</var> be the <emu-val>this</emu-val> value.</li><li>Perform ?&nbsp;RequireInternalSlot(<var>nf</var>, [[InitializedNumberFormat]]).</li><li>If <var>start</var> is <emu-val>undefined</emu-val> or <var>end</var> is <emu-val>undefined</emu-val>, throw a <emu-val>TypeError</emu-val> exception.</li><li>Let <var>x</var> be ?&nbsp;<emu-xref aoid="ToIntlMathematicalValue" id="_ref_33"><a href="#sec-tointlmathematicalvalue">ToIntlMathematicalValue</a></emu-xref>(<var>start</var>).</li><li>Let <var>y</var> be ?&nbsp;<emu-xref aoid="ToIntlMathematicalValue" id="_ref_34"><a href="#sec-tointlmathematicalvalue">ToIntlMathematicalValue</a></emu-xref>(<var>end</var>).</li><li>Return ?&nbsp;<emu-xref aoid="FormatNumericRange" id="_ref_35"><a href="#sec-formatnumericrange">FormatNumericRange</a></emu-xref>(<var>nf</var>, <var>x</var>, <var>y</var>).</li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-intl.numberformat.prototype.formatrangetoparts">
@@ -2052,7 +2817,7 @@ li.menu-search-result-term:before {
         When the <code>formatRangeToParts</code> method is called with arguments <var>start</var> and <var>end</var>, the following steps are taken:
       </p>
 
-      <emu-alg><ol><li>Let <var>nf</var> be the <emu-val>this</emu-val> value.</li><li>Perform ?&nbsp;<emu-xref aoid="RequireInternalSlot" id="_ref_47"><a href="https://tc39.es/ecma262/#sec-requireinternalslot">RequireInternalSlot</a></emu-xref>(<var>nf</var>, [[InitializedNumberFormat]]).</li><li>If <var>start</var> is <emu-val>undefined</emu-val> or <var>end</var> is <emu-val>undefined</emu-val>, throw a <emu-val>TypeError</emu-val> exception.</li><li>Let <var>x</var> be ?&nbsp;<emu-xref aoid="ToIntlMathematicalValue" id="_ref_48"><a href="#sec-tointlmathematicalvalue">ToIntlMathematicalValue</a></emu-xref>(<var>start</var>).</li><li>Let <var>y</var> be ?&nbsp;<emu-xref aoid="ToIntlMathematicalValue" id="_ref_49"><a href="#sec-tointlmathematicalvalue">ToIntlMathematicalValue</a></emu-xref>(<var>end</var>).</li><li>Return ?&nbsp;<emu-xref aoid="FormatNumericRangeToParts" id="_ref_50"><a href="#sec-formatnumericrangetoparts">FormatNumericRangeToParts</a></emu-xref>(<var>nf</var>, <var>x</var>, <var>y</var>).</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>nf</var> be the <emu-val>this</emu-val> value.</li><li>Perform ?&nbsp;RequireInternalSlot(<var>nf</var>, [[InitializedNumberFormat]]).</li><li>If <var>start</var> is <emu-val>undefined</emu-val> or <var>end</var> is <emu-val>undefined</emu-val>, throw a <emu-val>TypeError</emu-val> exception.</li><li>Let <var>x</var> be ?&nbsp;<emu-xref aoid="ToIntlMathematicalValue" id="_ref_36"><a href="#sec-tointlmathematicalvalue">ToIntlMathematicalValue</a></emu-xref>(<var>start</var>).</li><li>Let <var>y</var> be ?&nbsp;<emu-xref aoid="ToIntlMathematicalValue" id="_ref_37"><a href="#sec-tointlmathematicalvalue">ToIntlMathematicalValue</a></emu-xref>(<var>end</var>).</li><li>Return ?&nbsp;<emu-xref aoid="FormatNumericRangeToParts" id="_ref_38"><a href="#sec-formatnumericrangetoparts">FormatNumericRangeToParts</a></emu-xref>(<var>nf</var>, <var>x</var>, <var>y</var>).</li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-intl.numberformat.prototype.resolvedoptions">
@@ -2062,7 +2827,7 @@ li.menu-search-result-term:before {
         This function provides access to the locale and options computed during initialization of the object.
       </p>
 
-      <emu-alg><ol><li>Let <var>nf</var> be the <emu-val>this</emu-val> value.</li><li>If the implementation supports the normative optional <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> mode of <emu-xref href="#legacy-constructor"></emu-xref>, then<ol><li>Set <var>nf</var> to ?&nbsp;<emu-xref aoid="UnwrapNumberFormat" id="_ref_51"><a href="#sec-unwrapnumberformat">UnwrapNumberFormat</a></emu-xref>(<var>nf</var>).</li></ol></li><li>Perform ?&nbsp;<emu-xref aoid="RequireInternalSlot" id="_ref_52"><a href="https://tc39.es/ecma262/#sec-requireinternalslot">RequireInternalSlot</a></emu-xref>(<var>nf</var>, [[InitializedNumberFormat]]).</li><li>Let <var>options</var> be OrdinaryObjectCreate(%Object.prototype%).</li><li>For each row of <emu-xref href="#table-numberformat-resolvedoptions-properties" id="_ref_1"><a href="#table-numberformat-resolvedoptions-properties">Table 1</a></emu-xref>, except the header row, in table order, do<ol><li>Let <var>p</var> be the Property value of the current row.</li><li>Let <var>v</var> be the value of <var>nf</var>'s internal slot whose name is the Internal Slot value of the current row.</li><li>If <var>v</var> is not <emu-val>undefined</emu-val>, then<ol><li>Perform !&nbsp;<emu-xref aoid="CreateDataPropertyOrThrow" id="_ref_53"><a href="https://tc39.es/ecma262/#sec-createdatapropertyorthrow">CreateDataPropertyOrThrow</a></emu-xref>(<var>options</var>, <var>p</var>, <var>v</var>).</li></ol></li></ol></li><li>If <var>nf</var>.[[RoundingType]] is <emu-const>morePrecision</emu-const>, then<ol><li>Perform !&nbsp;<emu-xref aoid="CreateDataPropertyOrThrow" id="_ref_54"><a href="https://tc39.es/ecma262/#sec-createdatapropertyorthrow">CreateDataPropertyOrThrow</a></emu-xref>(<var>options</var>, <emu-val>"roundingPriority"</emu-val>, <emu-val>"morePrecision"</emu-val>).</li></ol></li><li>Else if <var>nf</var>.[[RoundingType]] is <emu-const>lessPrecision</emu-const>, then<ol><li>Perform !&nbsp;<emu-xref aoid="CreateDataPropertyOrThrow" id="_ref_55"><a href="https://tc39.es/ecma262/#sec-createdatapropertyorthrow">CreateDataPropertyOrThrow</a></emu-xref>(<var>options</var>, <emu-val>"roundingPriority"</emu-val>, <emu-val>"lessPrecision"</emu-val>).</li></ol></li><li>Else,<ol><li>Perform !&nbsp;<emu-xref aoid="CreateDataPropertyOrThrow" id="_ref_56"><a href="https://tc39.es/ecma262/#sec-createdatapropertyorthrow">CreateDataPropertyOrThrow</a></emu-xref>(<var>options</var>, <emu-val>"roundingPriority"</emu-val>, <emu-val>"auto"</emu-val>).</li></ol></li><li>Return <var>options</var>.</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>nf</var> be the <emu-val>this</emu-val> value.</li><li>If the implementation supports the normative optional constructor mode of <emu-xref href="#legacy-constructor"></emu-xref>, then<ol><li>Set <var>nf</var> to ?&nbsp;<emu-xref aoid="UnwrapNumberFormat" id="_ref_39"><a href="#sec-unwrapnumberformat">UnwrapNumberFormat</a></emu-xref>(<var>nf</var>).</li></ol></li><li>Perform ?&nbsp;RequireInternalSlot(<var>nf</var>, [[InitializedNumberFormat]]).</li><li>Let <var>options</var> be OrdinaryObjectCreate(%Object.prototype%).</li><li>For each row of <emu-xref href="#table-numberformat-resolvedoptions-properties" id="_ref_1"><a href="#table-numberformat-resolvedoptions-properties">Table 1</a></emu-xref>, except the header row, in table order, do<ol><li>Let <var>p</var> be the Property value of the current row.</li><li>Let <var>v</var> be the value of <var>nf</var>'s internal slot whose name is the Internal Slot value of the current row.</li><li>If <var>v</var> is not <emu-val>undefined</emu-val>, then<ol><li>Perform !&nbsp;CreateDataPropertyOrThrow(<var>options</var>, <var>p</var>, <var>v</var>).</li></ol></li></ol></li><li>If <var>nf</var>.[[RoundingType]] is <emu-const>morePrecision</emu-const>, then<ol><li>Perform !&nbsp;CreateDataPropertyOrThrow(<var>options</var>, <emu-val>"roundingPriority"</emu-val>, <emu-val>"morePrecision"</emu-val>).</li></ol></li><li>Else if <var>nf</var>.[[RoundingType]] is <emu-const>lessPrecision</emu-const>, then<ol><li>Perform !&nbsp;CreateDataPropertyOrThrow(<var>options</var>, <emu-val>"roundingPriority"</emu-val>, <emu-val>"lessPrecision"</emu-val>).</li></ol></li><li>Else,<ol><li>Perform !&nbsp;CreateDataPropertyOrThrow(<var>options</var>, <emu-val>"roundingPriority"</emu-val>, <emu-val>"auto"</emu-val>).</li></ol></li><li>Return <var>options</var>.</li></ol></emu-alg>
 
       <emu-table id="table-numberformat-resolvedoptions-properties"><figure><figcaption>Table 1: Resolved Options of NumberFormat Instances</figcaption>
         
@@ -2162,7 +2927,7 @@ li.menu-search-result-term:before {
     <h1><span class="secnum">1.4</span> Properties of Intl.NumberFormat Instances</h1>
 
     <p>
-      Intl.NumberFormat instances are ordinary objects that inherit properties from <emu-xref href="#sec-properties-of-intl-numberformat-prototype-object" id="_ref_57"><a href="#sec-properties-of-intl-numberformat-prototype-object">%NumberFormat.prototype%</a></emu-xref>.
+      Intl.NumberFormat instances are ordinary objects that inherit properties from <emu-xref href="#sec-properties-of-intl-numberformat-prototype-object" id="_ref_40"><a href="#sec-properties-of-intl-numberformat-prototype-object">%NumberFormat.prototype%</a></emu-xref>.
     </p>
 
     <p>
@@ -2170,7 +2935,7 @@ li.menu-search-result-term:before {
     </p>
 
     <p>
-      Intl.NumberFormat instances also have several internal slots that are computed by the <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref>:
+      Intl.NumberFormat instances also have several internal slots that are computed by the constructor:
     </p>
 
     <ul>
@@ -2183,9 +2948,9 @@ li.menu-search-result-term:before {
       <li>[[CurrencySign]] is one of the String values <emu-val>"standard"</emu-val> or <emu-val>"accounting"</emu-val>, specifying whether to render negative numbers in accounting format, often signified by parenthesis. It is only used when [[Style]] has the value <emu-val>"currency"</emu-val> and when [[SignDisplay]] is not <emu-val>"never"</emu-val>.</li>
       <li>[[Unit]] is a core unit identifier. It is only used when [[Style]] has the value <emu-val>"unit"</emu-val>.</li>
       <li>[[UnitDisplay]] is one of the String values <emu-val>"short"</emu-val>, <emu-val>"narrow"</emu-val>, or <emu-val>"long"</emu-val>, specifying whether to display the unit as a symbol, narrow symbol, or localized long name if formatting with the <emu-val>"unit"</emu-val> style. It is only used when [[Style]] has the value <emu-val>"unit"</emu-val>.</li>
-      <li>[[MinimumIntegerDigits]] is a non-negative <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref> <emu-xref href="#number-value"><a href="https://tc39.es/ecma262/#number-value">Number value</a></emu-xref> indicating the minimum <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref> digits to be used. Numbers will be padded with leading zeroes if necessary.</li>
-      <li>[[MinimumFractionDigits]] and [[MaximumFractionDigits]] are non-negative <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref> Number values indicating the minimum and maximum fraction digits to be used. Numbers will be rounded or padded with trailing zeroes if necessary. These properties are only used when [[RoundingType]] is <emu-const>fractionDigits</emu-const>, <emu-const>morePrecision</emu-const>, or <emu-const>lessPrecision</emu-const>.</li>
-      <li>[[MinimumSignificantDigits]] and [[MaximumSignificantDigits]] are positive <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref> Number values indicating the minimum and maximum fraction digits to be shown. If present, the formatter uses however many fraction digits are required to display the specified number of significant digits. These properties are only used when [[RoundingType]] is <emu-const>significantDigits</emu-const>, <emu-const>morePrecision</emu-const>, or <emu-const>lessPrecision</emu-const>.</li>
+      <li>[[MinimumIntegerDigits]] is a non-negative integer Number value indicating the minimum integer digits to be used. Numbers will be padded with leading zeroes if necessary.</li>
+      <li>[[MinimumFractionDigits]] and [[MaximumFractionDigits]] are non-negative integer Number values indicating the minimum and maximum fraction digits to be used. Numbers will be rounded or padded with trailing zeroes if necessary. These properties are only used when [[RoundingType]] is <emu-const>fractionDigits</emu-const>, <emu-const>morePrecision</emu-const>, or <emu-const>lessPrecision</emu-const>.</li>
+      <li>[[MinimumSignificantDigits]] and [[MaximumSignificantDigits]] are positive integer Number values indicating the minimum and maximum fraction digits to be shown. If present, the formatter uses however many fraction digits are required to display the specified number of significant digits. These properties are only used when [[RoundingType]] is <emu-const>significantDigits</emu-const>, <emu-const>morePrecision</emu-const>, or <emu-const>lessPrecision</emu-const>.</li>
       <li>[[UseGrouping]] is a Boolean or String value indicating the conditions under which a grouping separator should be used. The positions of grouping separators, and whether to display grouping separators for a given number, is implementation-defined. A value <emu-val>"always"</emu-val> hints the implementation to display grouping separators if possible; <emu-val>"min2"</emu-val>, if there are at least 2 digits in a group; <emu-val>"auto"</emu-val>, if the locale prefers to use grouping separators for the number. A value <emu-val>false</emu-val> disables grouping separators.</li>
       <li>[[RoundingType]] is one of the values <emu-const>fractionDigits</emu-const>, <emu-const>significantDigits</emu-const>, <emu-const>morePrecision</emu-const>, or <emu-const>lessPrecision</emu-const>, indicating which rounding strategy to use. If <emu-const>fractionDigits</emu-const>, the number is rounded according to [[MinimumFractionDigits]] and [[MaximumFractionDigits]], as described above. If <emu-const>significantDigits</emu-const>, the number is rounded according to [[MinimumSignificantDigits]] and [[MaximumSignificantDigits]] as described above. If <emu-const>morePrecision</emu-const> or <emu-const>lessPrecision</emu-const>, all four of those settings are used, with specific rules for disambiguating when to use one set versus the other. [[RoundingType]] is derived from the <emu-val>"roundingPriority"</emu-val> option and is converted back to <emu-val>"roundingPriority"</emu-val> in <emu-xref href="#sec-intl.numberformat.prototype.resolvedoptions" id="_ref_2"><a href="#sec-intl.numberformat.prototype.resolvedoptions">1.3.7</a></emu-xref>.</li>
       <li>[[Notation]] is one of the String values <emu-val>"standard"</emu-val>, <emu-val>"scientific"</emu-val>, <emu-val>"engineering"</emu-val>, or <emu-val>"compact"</emu-val>, specifying whether the number should be displayed without scaling, scaled to the units place with the power of ten in scientific notation, scaled to the nearest thousand with the power of ten in scientific notation, or scaled to the nearest locale-dependent compact decimal notation power of ten with the corresponding compact decimal notation affix.</li>
@@ -2194,9 +2959,9 @@ li.menu-search-result-term:before {
         [[SignDisplay]] is one of the String values <emu-val>"auto"</emu-val>, <emu-val>"always"</emu-val>, <emu-val>"never"</emu-val>, <emu-val>"exceptZero"</emu-val>, or <emu-val>"negative"</emu-val>, specifying when to include a sign (with non-<emu-val>"auto"</emu-val> options respectively corresponding with inclusion always, never, only for nonzero numbers, or only for nonzero negative numbers).
         In scientific notation, this slot affects the sign display of the mantissa but not the exponent.
       </li>
-      <li>[[RoundingMode]] is one of the String values in the <emu-val>Identifier</emu-val> column of <emu-xref href="#table-intl-rounding-modes" id="_ref_3"><a href="#table-intl-rounding-modes">Table 2</a></emu-xref>, specifying the rounding strategy for the number.</li>
-      <li>[[RoundingIncrement]] is an <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref>-valued Number that evenly divides 10, 100, 1000, or 10000 into tenths, fifths, quarters, or halves. It indicates the increment at which rounding should take place relative to the calculated rounding magnitude. For example, if [[MaximumFractionDigits]] is 2 and [[RoundingIncrement]] is 5, then the number is rounded to the nearest 0.05 ("nickel rounding").</li>
-      <li>[[TrailingZeroDisplay]] is one of the String values <emu-val>"auto"</emu-val> or <emu-val>"stripIfInteger"</emu-val>, indicating whether to strip trailing zeros if the formatted number is an <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref> (i.e., has no nonzero fraction digit).</li>
+      <li>[[RoundingMode]] is one of the String values in the Identifier column of <emu-xref href="#table-intl-rounding-modes" id="_ref_3"><a href="#table-intl-rounding-modes">Table 2</a></emu-xref>, specifying which rounding mode to use.</li>
+      <li>[[RoundingIncrement]] is an integer-valued Number that evenly divides 10, 100, 1000, or 10000 into tenths, fifths, quarters, or halves. It indicates the increment at which rounding should take place relative to the calculated rounding magnitude. For example, if [[MaximumFractionDigits]] is 2 and [[RoundingIncrement]] is 5, then the number is rounded to the nearest 0.05 ("nickel rounding").</li>
+      <li>[[TrailingZeroDisplay]] is one of the String values <emu-val>"auto"</emu-val> or <emu-val>"stripIfInteger"</emu-val>, indicating whether to strip trailing zeros if the formatted number is an integer (i.e., has no nonzero fraction digit).</li>
     </ul>
 
     <emu-table id="table-intl-rounding-modes"><figure><figcaption>Table 2: Rounding modes in Intl.NumberFormat</figcaption>
@@ -2326,7 +3091,7 @@ li.menu-search-result-term:before {
       <p>A Number format function is an anonymous built-in function that has a [[NumberFormat]] internal slot.</p>
       <p>When a Number format function <var>F</var> is called with optional argument <var>value</var>, the following steps are taken:</p>
 
-      <emu-alg><ol><li>Let <var>nf</var> be <var>F</var>.[[NumberFormat]].</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <emu-xref aoid="Type" id="_ref_58"><a href="https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>nf</var>) is Object and <var>nf</var> has an [[InitializedNumberFormat]] internal slot.</li><li>If <var>value</var> is not provided, let <var>value</var> be <emu-val>undefined</emu-val>.</li><li>Let <var>x</var> be ?&nbsp;<emu-xref aoid="ToIntlMathematicalValue" id="_ref_59"><a href="#sec-tointlmathematicalvalue">ToIntlMathematicalValue</a></emu-xref>(<var>value</var>).</li><li>Return ?&nbsp;<emu-xref aoid="FormatNumeric" id="_ref_60"><a href="#sec-formatnumber">FormatNumeric</a></emu-xref>(<var>nf</var>, <var>x</var>).</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>nf</var> be <var>F</var>.[[NumberFormat]].</li><li>Assert: Type(<var>nf</var>) is Object and <var>nf</var> has an [[InitializedNumberFormat]] internal slot.</li><li>If <var>value</var> is not provided, let <var>value</var> be <emu-val>undefined</emu-val>.</li><li>Let <var>x</var> be ?&nbsp;<emu-xref aoid="ToIntlMathematicalValue" id="_ref_41"><a href="#sec-tointlmathematicalvalue">ToIntlMathematicalValue</a></emu-xref>(<var>value</var>).</li><li>Return ?&nbsp;<emu-xref aoid="FormatNumeric" id="_ref_42"><a href="#sec-formatnumber">FormatNumeric</a></emu-xref>(<var>nf</var>, <var>x</var>).</li></ol></emu-alg>
 
       <p>
         The <emu-val>"length"</emu-val> property of a Number format function is 1.
@@ -2337,33 +3102,25 @@ li.menu-search-result-term:before {
       <h1><span class="secnum">1.5.3</span> FormatNumericToString ( <var>intlObject</var>, <var>x</var> )</h1>
 
       <p>
-        The FormatNumericToString abstract operation is called with arguments <var>intlObject</var> (which must be an object with [[RoundingType]], [[MinimumSignificantDigits]], [[MaximumSignificantDigits]], [[MinimumIntegerDigits]], [[MinimumFractionDigits]], [[MaximumFractionDigits]], [[RoundingIncrement]], and [[TrailingZeroDisplay]] internal slots), and <var>x</var> (which must be a <emu-xref href="#mathematical-value"><a href="https://tc39.es/ecma262/#mathematical-value">mathematical value</a></emu-xref> or <emu-const>negative-zero</emu-const>), and returns a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> containing two values: <var>x</var> as a String value with digits formatted according to the five formatting parameters in the field [[FormattedString]], and the final <emu-xref href="#mathematical-value"><a href="https://tc39.es/ecma262/#mathematical-value">mathematical value</a></emu-xref> (or <emu-val>-0</emu-val><sub>𝔽</sub>) of <var>x</var> after rounding has been performed in the field [[RoundedNumber]].
+        The FormatNumericToString abstract operation is called with arguments <var>intlObject</var> (which must be an object with [[RoundingMode]], [[RoundingType]], [[MinimumSignificantDigits]], [[MaximumSignificantDigits]], [[MinimumIntegerDigits]], [[MinimumFractionDigits]], [[MaximumFractionDigits]], [[RoundingIncrement]], and [[TrailingZeroDisplay]] internal slots), and <var>x</var> (which must be a mathematical value or <emu-const>negative-zero</emu-const>). It rounds <var>x</var> to an <emu-xref href="#intl-mathematical-value" id="_ref_43"><a href="#intl-mathematical-value">Intl mathematical value</a></emu-xref> according to the internal slots of <var>intlObject</var> and returns a Record with a [[RoundedNumber]] field containing containing that result and a [[FormattedString]] field containing a String value representation of that result formatted according to the internal slots of <var>intlObject</var>.
       </p>
 
-      <emu-alg><ol><li>If <var>x</var> is <emu-const>negative-zero</emu-const>, then<ol><li>Let <var>isNegative</var> be <emu-val>true</emu-val>.</li><li>Let <var>x</var> be the <emu-xref href="#mathematical-value"><a href="https://tc39.es/ecma262/#mathematical-value">mathematical value</a></emu-xref> 0.</li></ol></li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>x</var> is a <emu-xref href="#mathematical-value"><a href="https://tc39.es/ecma262/#mathematical-value">mathematical value</a></emu-xref>.</li><li>If <emu-xref href="#ℝ"><a href="https://tc39.es/ecma262/#ℝ">ℝ</a></emu-xref>(<var>x</var>) &lt; 0, let <var>isNegative</var> be <emu-val>true</emu-val>; else let <var>isNegative</var> be <emu-val>false</emu-val>.</li><li>If <var>isNegative</var>, then<ol><li>Let <var>x</var> be -<var>x</var>.</li></ol></li><li>Let <var>unsignedRoundingMode</var> be <emu-xref aoid="GetUnsignedRoundingMode" id="_ref_61"><a href="#sec-getunsignedroundingmode">GetUnsignedRoundingMode</a></emu-xref>(<var>intlObject</var>.[[RoundingMode]], <var>isNegative</var>).</li><li>If <var>intlObject</var>.[[RoundingType]] is <emu-const>significantDigits</emu-const>, then<ol><li>Let <var>result</var> be <emu-xref aoid="ToRawPrecision" id="_ref_62"><a href="#sec-torawprecision">ToRawPrecision</a></emu-xref>(<var>x</var>, <var>intlObject</var>.[[MinimumSignificantDigits]], <var>intlObject</var>.[[MaximumSignificantDigits]], <var>unsignedRoundingMode</var>).</li></ol></li><li>Else if <var>intlObject</var>.[[RoundingType]] is <emu-const>fractionDigits</emu-const>, then<ol><li>Let <var>result</var> be <emu-xref aoid="ToRawFixed" id="_ref_63"><a href="#sec-torawfixed">ToRawFixed</a></emu-xref>(<var>x</var>, <var>intlObject</var>.[[MinimumFractionDigits]], <var>intlObject</var>.[[MaximumFractionDigits]], <var>intlObject</var>.[[RoundingIncrement]], <var>unsignedRoundingMode</var>).</li></ol></li><li>Else,<ol><li>Let <var>sResult</var> be <emu-xref aoid="ToRawPrecision" id="_ref_64"><a href="#sec-torawprecision">ToRawPrecision</a></emu-xref>(<var>x</var>, <var>intlObject</var>.[[MinimumSignificantDigits]], <var>intlObject</var>.[[MaximumSignificantDigits]], <var>unsignedRoundingMode</var>).</li><li>Let <var>fResult</var> be <emu-xref aoid="ToRawFixed" id="_ref_65"><a href="#sec-torawfixed">ToRawFixed</a></emu-xref>(<var>x</var>, <var>intlObject</var>.[[MinimumFractionDigits]], <var>intlObject</var>.[[MaximumFractionDigits]], <var>intlObject</var>.[[RoundingIncrement]], <var>unsignedRoundingMode</var>).</li><li>If <var>intlObj</var>.[[RoundingType]] is <emu-const>morePrecision</emu-const>, then<ol><li>If <var>sResult</var>.[[RoundingMagnitude]] ≤ <var>fResult</var>.[[RoundingMagnitude]], then<ol><li>Let <var>result</var> be <var>sResult</var>.</li></ol></li><li>Else,<ol><li>Let <var>result</var> be <var>fResult</var>.</li></ol></li></ol></li><li>Else,<ol><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>intlObj</var>.[[RoundingType]] is <emu-const>lessPrecision</emu-const>.</li><li>If <var>sResult</var>.[[RoundingMagnitude]] ≤ <var>fResult</var>.[[RoundingMagnitude]], then<ol><li>Let <var>result</var> be <var>fResult</var>.</li></ol></li><li>Else,<ol><li>Let <var>result</var> be <var>sResult</var>.</li></ol></li></ol></li></ol></li><li>Let <var>x</var> be <var>result</var>.[[RoundedNumber]].</li><li>Let <var>string</var> be <var>result</var>.[[FormattedString]].</li><li>If <var>intlObject</var>.[[TrailingZeroDisplay]] is <emu-val>"stripIfInteger"</emu-val> and <emu-eqn class="inline"><var>x</var> <emu-xref aoid="modulo"><a href="https://tc39.es/ecma262/#eqn-modulo">modulo</a></emu-xref> 1 = 0</emu-eqn>, then<ol><li>If <var>string</var> contains <emu-val>"."</emu-val>, then<ol><li>Set <var>string</var> to the substring of <var>string</var> from index 0 to the index of <emu-val>"."</emu-val>.</li></ol></li></ol></li><li>Let <var>int</var> be <var>result</var>.[[IntegerDigitsCount]].</li><li>Let <var>minInteger</var> be <var>intlObject</var>.[[MinimumIntegerDigits]].</li><li>If <var>int</var> &lt; <var>minInteger</var>, then<ol><li>Let <var>forwardZeros</var> be the String consisting of <var>minInteger</var> - <var>int</var> occurrences of the code unit 0x0030 (DIGIT ZERO).</li><li>Set <var>string</var> to the <emu-xref href="#sec-ecmascript-language-types-string-type"><a href="https://tc39.es/ecma262/#sec-ecmascript-language-types-string-type">string-concatenation</a></emu-xref> of <var>forwardZeros</var> and <var>string</var>.</li></ol></li><li>If <var>isNegative</var> and <var>x</var> is 0, then<ol><li>Let <var>x</var> be <emu-val>-0</emu-val>.</li></ol></li><li>Else if <var>isNegative</var>, then<ol><li>Let <var>x</var> be -<var>x</var>.</li></ol></li><li>Return the <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[RoundedNumber]]: <var>x</var>, [[FormattedString]]: <var>string</var> }.</li></ol></emu-alg>
+      <emu-alg><ol><li>If <var>x</var> is <emu-const>negative-zero</emu-const>, then<ol><li>Let <var>isNegative</var> be <emu-val>true</emu-val>.</li><li>Set <var>x</var> to 0.</li></ol></li><li>Else,<ol><li>Assert: <var>x</var> is a mathematical value.</li><li>If <var>x</var> &lt; 0, let <var>isNegative</var> be <emu-val>true</emu-val>; else let <var>isNegative</var> be <emu-val>false</emu-val>.</li><li>If <var>isNegative</var> is <emu-val>true</emu-val>, then<ol><li>Set <var>x</var> to -<var>x</var>.</li></ol></li></ol></li><li>Let <var>unsignedRoundingMode</var> be <emu-xref aoid="GetUnsignedRoundingMode" id="_ref_44"><a href="#sec-getunsignedroundingmode">GetUnsignedRoundingMode</a></emu-xref>(<var>intlObject</var>.[[RoundingMode]], <var>isNegative</var>).</li><li>If <var>intlObject</var>.[[RoundingType]] is <emu-const>significantDigits</emu-const>, then<ol><li>Let <var>result</var> be <emu-xref aoid="ToRawPrecision" id="_ref_45"><a href="#sec-torawprecision">ToRawPrecision</a></emu-xref>(<var>x</var>, <var>intlObject</var>.[[MinimumSignificantDigits]], <var>intlObject</var>.[[MaximumSignificantDigits]], <var>unsignedRoundingMode</var>).</li></ol></li><li>Else if <var>intlObject</var>.[[RoundingType]] is <emu-const>fractionDigits</emu-const>, then<ol><li>Let <var>result</var> be <emu-xref aoid="ToRawFixed" id="_ref_46"><a href="#sec-torawfixed">ToRawFixed</a></emu-xref>(<var>x</var>, <var>intlObject</var>.[[MinimumFractionDigits]], <var>intlObject</var>.[[MaximumFractionDigits]], <var>intlObject</var>.[[RoundingIncrement]], <var>unsignedRoundingMode</var>).</li></ol></li><li>Else,<ol><li>Let <var>sResult</var> be <emu-xref aoid="ToRawPrecision" id="_ref_47"><a href="#sec-torawprecision">ToRawPrecision</a></emu-xref>(<var>x</var>, <var>intlObject</var>.[[MinimumSignificantDigits]], <var>intlObject</var>.[[MaximumSignificantDigits]], <var>unsignedRoundingMode</var>).</li><li>Let <var>fResult</var> be <emu-xref aoid="ToRawFixed" id="_ref_48"><a href="#sec-torawfixed">ToRawFixed</a></emu-xref>(<var>x</var>, <var>intlObject</var>.[[MinimumFractionDigits]], <var>intlObject</var>.[[MaximumFractionDigits]], <var>intlObject</var>.[[RoundingIncrement]], <var>unsignedRoundingMode</var>).</li><li>If <var>intlObj</var>.[[RoundingType]] is <emu-const>morePrecision</emu-const>, then<ol><li>If <var>sResult</var>.[[RoundingMagnitude]] ≤ <var>fResult</var>.[[RoundingMagnitude]], then<ol><li>Let <var>result</var> be <var>sResult</var>.</li></ol></li><li>Else,<ol><li>Let <var>result</var> be <var>fResult</var>.</li></ol></li></ol></li><li>Else,<ol><li>Assert: <var>intlObj</var>.[[RoundingType]] is <emu-const>lessPrecision</emu-const>.</li><li>If <var>sResult</var>.[[RoundingMagnitude]] ≤ <var>fResult</var>.[[RoundingMagnitude]], then<ol><li>Let <var>result</var> be <var>fResult</var>.</li></ol></li><li>Else,<ol><li>Let <var>result</var> be <var>sResult</var>.</li></ol></li></ol></li></ol></li><li>Set <var>x</var> to <var>result</var>.[[RoundedNumber]].</li><li>Let <var>string</var> be <var>result</var>.[[FormattedString]].</li><li>If <var>intlObject</var>.[[TrailingZeroDisplay]] is <emu-val>"stripIfInteger"</emu-val> and <emu-eqn class="inline"><var>x</var> modulo 1 = 0</emu-eqn>, then<ol><li>Let <var>i</var> be StringIndexOf(<var>string</var>, <emu-val>"."</emu-val>, 0).</li><li>If <var>i</var> ≠ -1, set <var>string</var> to the substring of <var>string</var> from 0 to <var>i</var>.</li></ol></li><li>Let <var>int</var> be <var>result</var>.[[IntegerDigitsCount]].</li><li>Let <var>minInteger</var> be <var>intlObject</var>.[[MinimumIntegerDigits]].</li><li>If <var>int</var> &lt; <var>minInteger</var>, then<ol><li>Let <var>forwardZeros</var> be the String consisting of <var>minInteger</var> - <var>int</var> occurrences of the code unit 0x0030 (DIGIT ZERO).</li><li>Set <var>string</var> to the string-concatenation of <var>forwardZeros</var> and <var>string</var>.</li></ol></li><li>If <var>isNegative</var> is <emu-val>true</emu-val>, then<ol><li>If <var>x</var> is 0, set <var>x</var> to <emu-const>negative-zero</emu-const>. Otherwise, set <var>x</var> to -<var>x</var>.</li></ol></li><li>Return the Record { [[RoundedNumber]]: <var>x</var>, [[FormattedString]]: <var>string</var> }.</li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-partitionnumberpattern" aoid="PartitionNumberPattern">
-      <h1><span class="secnum">1.5.4</span> 
-        PartitionNumberPattern (
-          <var>numberFormat</var>: an object initialized as a NumberFormat,
-          <var>x</var>: an Intl mathematical value,
-        )
-      </h1>
-      <dl class="header">
-        <dt>description</dt>
-        <dd>It creates the parts representing the <emu-xref href="#mathematical-value"><a href="https://tc39.es/ecma262/#mathematical-value">mathematical value</a></emu-xref> of <var>x</var> according to the effective locale and the formatting options of <var>numberFormat</var>.</dd>
-      </dl>
+      <h1><span class="secnum">1.5.4</span> PartitionNumberPattern ( <var>numberFormat</var>, <var>x</var> )</h1>
+      <p> takes arguments <var>numberFormat</var> (an object initialized as a NumberFormat) and <var>x</var> (an <emu-xref href="#intl-mathematical-value" id="_ref_49"><a href="#intl-mathematical-value">Intl mathematical value</a></emu-xref>). It creates the parts representing the mathematical value of <var>x</var> according to the effective locale and the formatting options of <var>numberFormat</var>. It performs the following steps when called:</p>
 
-      <emu-alg><ol><li>Let <var>exponent</var> be 0.</li><li>If <var>x</var> is <emu-const>not-a-number</emu-const>, then<ol><li>Let <var>n</var> be an implementation- and locale-dependent (ILD) String value indicating the <emu-val>NaN</emu-val> value.</li></ol></li><li>Else if <var>x</var> is <emu-const>positive-infinity</emu-const>, then<ol><li>Let <var>n</var> be an ILD String value indicating positive infinity.</li></ol></li><li>Else if <var>x</var> is <emu-const>negative-infinity</emu-const>, then<ol><li>Let <var>n</var> be an ILD String value indicating negative infinity.</li></ol></li><li>Else,<ol><li>If <var>x</var> is not <emu-const>negative-zero</emu-const>,<ol><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>x</var> is a <emu-xref href="#mathematical-value"><a href="https://tc39.es/ecma262/#mathematical-value">mathematical value</a></emu-xref>.</li><li>If <var>numberFormat</var>.[[Style]] is <emu-val>"percent"</emu-val>, set <var>x</var> be 100 × <var>x</var>.</li><li>Let <var>exponent</var> be <emu-xref aoid="ComputeExponent" id="_ref_66"><a href="#sec-computeexponent">ComputeExponent</a></emu-xref>(<var>numberFormat</var>, <var>x</var>).</li><li>Set <var>x</var> to <var>x</var> × 10<sup>-<var>exponent</var></sup>.</li></ol></li><li>Let <var>formatNumberResult</var> be <emu-xref aoid="FormatNumericToString" id="_ref_67"><a href="#sec-formatnumberstring">FormatNumericToString</a></emu-xref>(<var>numberFormat</var>, <var>x</var>).</li><li>Let <var>n</var> be <var>formatNumberResult</var>.[[FormattedString]].</li><li>Set <var>x</var> to <var>formatNumberResult</var>.[[RoundedNumber]].</li></ol></li><li>Let <var>pattern</var> be <emu-xref aoid="GetNumberFormatPattern" id="_ref_68"><a href="#sec-getnumberformatpattern">GetNumberFormatPattern</a></emu-xref>(<var>numberFormat</var>, <var>x</var>).</li><li>Let <var>result</var> be a new empty <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref>.</li><li>Let <var>patternParts</var> be PartitionPattern(<var>pattern</var>).</li><li>For each <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]], [[Value]] } <var>patternPart</var> of <var>patternParts</var>, do<ol><li>Let <var>p</var> be <var>patternPart</var>.[[Type]].</li><li>If <var>p</var> is <emu-val>"literal"</emu-val>, then<ol><li>Append a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]]: <emu-val>"literal"</emu-val>, [[Value]]: <var>patternPart</var>.[[Value]] } as the last element of <var>result</var>.</li></ol></li><li>Else if <var>p</var> is equal to <emu-val>"number"</emu-val>, then<ol><li>Let <var>notationSubParts</var> be <emu-xref aoid="PartitionNotationSubPattern" id="_ref_69"><a href="#sec-partitionnotationsubpattern">PartitionNotationSubPattern</a></emu-xref>(<var>numberFormat</var>, <var>x</var>, <var>n</var>, <var>exponent</var>).</li><li>Append all elements of <var>notationSubParts</var> to <var>result</var>.</li></ol></li><li>Else if <var>p</var> is equal to <emu-val>"plusSign"</emu-val>, then<ol><li>Let <var>plusSignSymbol</var> be the ILND String representing the plus sign.</li><li>Append a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]]: <emu-val>"plusSign"</emu-val>, [[Value]]: <var>plusSignSymbol</var> } as the last element of <var>result</var>.</li></ol></li><li>Else if <var>p</var> is equal to <emu-val>"minusSign"</emu-val>, then<ol><li>Let <var>minusSignSymbol</var> be the ILND String representing the minus sign.</li><li>Append a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]]: <emu-val>"minusSign"</emu-val>, [[Value]]: <var>minusSignSymbol</var> } as the last element of <var>result</var>.</li></ol></li><li>Else if <var>p</var> is equal to <emu-val>"percentSign"</emu-val> and <var>numberFormat</var>.[[Style]] is <emu-val>"percent"</emu-val>, then<ol><li>Let <var>percentSignSymbol</var> be the ILND String representing the percent sign.</li><li>Append a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]]: <emu-val>"percentSign"</emu-val>, [[Value]]: <var>percentSignSymbol</var> } as the last element of <var>result</var>.</li></ol></li><li>Else if <var>p</var> is equal to <emu-val>"unitPrefix"</emu-val> and <var>numberFormat</var>.[[Style]] is <emu-val>"unit"</emu-val>, then<ol><li>Let <var>unit</var> be <var>numberFormat</var>.[[Unit]].</li><li>Let <var>unitDisplay</var> be <var>numberFormat</var>.[[UnitDisplay]].</li><li>Let <var>mu</var> be an ILD String value representing <var>unit</var> before <var>x</var> in <var>unitDisplay</var> form, which may depend on <var>x</var> in languages having different plural forms.</li><li>Append a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]]: <emu-val>"unit"</emu-val>, [[Value]]: <var>mu</var> } as the last element of <var>result</var>.</li></ol></li><li>Else if <var>p</var> is equal to <emu-val>"unitSuffix"</emu-val> and <var>numberFormat</var>.[[Style]] is <emu-val>"unit"</emu-val>, then<ol><li>Let <var>unit</var> be <var>numberFormat</var>.[[Unit]].</li><li>Let <var>unitDisplay</var> be <var>numberFormat</var>.[[UnitDisplay]].</li><li>Let <var>mu</var> be an ILD String value representing <var>unit</var> after <var>x</var> in <var>unitDisplay</var> form, which may depend on <var>x</var> in languages having different plural forms.</li><li>Append a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]]: <emu-val>"unit"</emu-val>, [[Value]]: <var>mu</var> } as the last element of <var>result</var>.</li></ol></li><li>Else if <var>p</var> is equal to <emu-val>"currencyCode"</emu-val> and <var>numberFormat</var>.[[Style]] is <emu-val>"currency"</emu-val>, then<ol><li>Let <var>currency</var> be <var>numberFormat</var>.[[Currency]].</li><li>Let <var>cd</var> be <var>currency</var>.</li><li>Append a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]]: <emu-val>"currency"</emu-val>, [[Value]]: <var>cd</var> } as the last element of <var>result</var>.</li></ol></li><li>Else if <var>p</var> is equal to <emu-val>"currencyPrefix"</emu-val> and <var>numberFormat</var>.[[Style]] is <emu-val>"currency"</emu-val>, then<ol><li>Let <var>currency</var> be <var>numberFormat</var>.[[Currency]].</li><li>Let <var>currencyDisplay</var> be <var>numberFormat</var>.[[CurrencyDisplay]].</li><li>Let <var>cd</var> be an ILD String value representing <var>currency</var> before <var>x</var> in <var>currencyDisplay</var> form, which may depend on <var>x</var> in languages having different plural forms.</li><li>Append a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]]: <emu-val>"currency"</emu-val>, [[Value]]: <var>cd</var> } as the last element of <var>result</var>.</li></ol></li><li>Else if <var>p</var> is equal to <emu-val>"currencySuffix"</emu-val> and <var>numberFormat</var>.[[Style]] is <emu-val>"currency"</emu-val>, then<ol><li>Let <var>currency</var> be <var>numberFormat</var>.[[Currency]].</li><li>Let <var>currencyDisplay</var> be <var>numberFormat</var>.[[CurrencyDisplay]].</li><li>Let <var>cd</var> be an ILD String value representing <var>currency</var> after <var>x</var> in <var>currencyDisplay</var> form, which may depend on <var>x</var> in languages having different plural forms. If the implementation does not have such a representation of <var>currency</var>, use <var>currency</var> itself.</li><li>Append a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]]: <emu-val>"currency"</emu-val>, [[Value]]: <var>cd</var> } as the last element of <var>result</var>.</li></ol></li><li>Else,<ol><li>Let <var>unknown</var> be an ILND String based on <var>x</var> and <var>p</var>.</li><li>Append a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]]: <emu-val>"unknown"</emu-val>, [[Value]]: <var>unknown</var> } as the last element of <var>result</var>.</li></ol></li></ol></li><li>Return <var>result</var>.</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>exponent</var> be 0.</li><li>If <var>x</var> is <emu-const>not-a-number</emu-const>, then<ol><li>Let <var>n</var> be an implementation- and locale-dependent (ILD) String value indicating the <emu-val>NaN</emu-val> value.</li></ol></li><li>Else if <var>x</var> is <emu-const>positive-infinity</emu-const>, then<ol><li>Let <var>n</var> be an ILD String value indicating positive infinity.</li></ol></li><li>Else if <var>x</var> is <emu-const>negative-infinity</emu-const>, then<ol><li>Let <var>n</var> be an ILD String value indicating negative infinity.</li></ol></li><li>Else,<ol><li>If <var>x</var> is not <emu-const>negative-zero</emu-const>,<ol><li>Assert: <var>x</var> is a mathematical value.</li><li>If <var>numberFormat</var>.[[Style]] is <emu-val>"percent"</emu-val>, set <var>x</var> be 100 × <var>x</var>.</li><li>Let <var>exponent</var> be <emu-xref aoid="ComputeExponent" id="_ref_50"><a href="#sec-computeexponent">ComputeExponent</a></emu-xref>(<var>numberFormat</var>, <var>x</var>).</li><li>Set <var>x</var> to <var>x</var> × 10<sup>-<var>exponent</var></sup>.</li></ol></li><li>Let <var>formatNumberResult</var> be <emu-xref aoid="FormatNumericToString" id="_ref_51"><a href="#sec-formatnumberstring">FormatNumericToString</a></emu-xref>(<var>numberFormat</var>, <var>x</var>).</li><li>Let <var>n</var> be <var>formatNumberResult</var>.[[FormattedString]].</li><li>Set <var>x</var> to <var>formatNumberResult</var>.[[RoundedNumber]].</li></ol></li><li>Let <var>pattern</var> be <emu-xref aoid="GetNumberFormatPattern" id="_ref_52"><a href="#sec-getnumberformatpattern">GetNumberFormatPattern</a></emu-xref>(<var>numberFormat</var>, <var>x</var>).</li><li>Let <var>result</var> be a new empty List.</li><li>Let <var>patternParts</var> be PartitionPattern(<var>pattern</var>).</li><li>For each Record { [[Type]], [[Value]] } <var>patternPart</var> of <var>patternParts</var>, do<ol><li>Let <var>p</var> be <var>patternPart</var>.[[Type]].</li><li>If <var>p</var> is <emu-val>"literal"</emu-val>, then<ol><li>Append a new Record { [[Type]]: <emu-val>"literal"</emu-val>, [[Value]]: <var>patternPart</var>.[[Value]] } as the last element of <var>result</var>.</li></ol></li><li>Else if <var>p</var> is equal to <emu-val>"number"</emu-val>, then<ol><li>Let <var>notationSubParts</var> be <emu-xref aoid="PartitionNotationSubPattern" id="_ref_53"><a href="#sec-partitionnotationsubpattern">PartitionNotationSubPattern</a></emu-xref>(<var>numberFormat</var>, <var>x</var>, <var>n</var>, <var>exponent</var>).</li><li>Append all elements of <var>notationSubParts</var> to <var>result</var>.</li></ol></li><li>Else if <var>p</var> is equal to <emu-val>"plusSign"</emu-val>, then<ol><li>Let <var>plusSignSymbol</var> be the ILND String representing the plus sign.</li><li>Append a new Record { [[Type]]: <emu-val>"plusSign"</emu-val>, [[Value]]: <var>plusSignSymbol</var> } as the last element of <var>result</var>.</li></ol></li><li>Else if <var>p</var> is equal to <emu-val>"minusSign"</emu-val>, then<ol><li>Let <var>minusSignSymbol</var> be the ILND String representing the minus sign.</li><li>Append a new Record { [[Type]]: <emu-val>"minusSign"</emu-val>, [[Value]]: <var>minusSignSymbol</var> } as the last element of <var>result</var>.</li></ol></li><li>Else if <var>p</var> is equal to <emu-val>"percentSign"</emu-val> and <var>numberFormat</var>.[[Style]] is <emu-val>"percent"</emu-val>, then<ol><li>Let <var>percentSignSymbol</var> be the ILND String representing the percent sign.</li><li>Append a new Record { [[Type]]: <emu-val>"percentSign"</emu-val>, [[Value]]: <var>percentSignSymbol</var> } as the last element of <var>result</var>.</li></ol></li><li>Else if <var>p</var> is equal to <emu-val>"unitPrefix"</emu-val> and <var>numberFormat</var>.[[Style]] is <emu-val>"unit"</emu-val>, then<ol><li>Let <var>unit</var> be <var>numberFormat</var>.[[Unit]].</li><li>Let <var>unitDisplay</var> be <var>numberFormat</var>.[[UnitDisplay]].</li><li>Let <var>mu</var> be an ILD String value representing <var>unit</var> before <var>x</var> in <var>unitDisplay</var> form, which may depend on <var>x</var> in languages having different plural forms.</li><li>Append a new Record { [[Type]]: <emu-val>"unit"</emu-val>, [[Value]]: <var>mu</var> } as the last element of <var>result</var>.</li></ol></li><li>Else if <var>p</var> is equal to <emu-val>"unitSuffix"</emu-val> and <var>numberFormat</var>.[[Style]] is <emu-val>"unit"</emu-val>, then<ol><li>Let <var>unit</var> be <var>numberFormat</var>.[[Unit]].</li><li>Let <var>unitDisplay</var> be <var>numberFormat</var>.[[UnitDisplay]].</li><li>Let <var>mu</var> be an ILD String value representing <var>unit</var> after <var>x</var> in <var>unitDisplay</var> form, which may depend on <var>x</var> in languages having different plural forms.</li><li>Append a new Record { [[Type]]: <emu-val>"unit"</emu-val>, [[Value]]: <var>mu</var> } as the last element of <var>result</var>.</li></ol></li><li>Else if <var>p</var> is equal to <emu-val>"currencyCode"</emu-val> and <var>numberFormat</var>.[[Style]] is <emu-val>"currency"</emu-val>, then<ol><li>Let <var>currency</var> be <var>numberFormat</var>.[[Currency]].</li><li>Let <var>cd</var> be <var>currency</var>.</li><li>Append a new Record { [[Type]]: <emu-val>"currency"</emu-val>, [[Value]]: <var>cd</var> } as the last element of <var>result</var>.</li></ol></li><li>Else if <var>p</var> is equal to <emu-val>"currencyPrefix"</emu-val> and <var>numberFormat</var>.[[Style]] is <emu-val>"currency"</emu-val>, then<ol><li>Let <var>currency</var> be <var>numberFormat</var>.[[Currency]].</li><li>Let <var>currencyDisplay</var> be <var>numberFormat</var>.[[CurrencyDisplay]].</li><li>Let <var>cd</var> be an ILD String value representing <var>currency</var> before <var>x</var> in <var>currencyDisplay</var> form, which may depend on <var>x</var> in languages having different plural forms.</li><li>Append a new Record { [[Type]]: <emu-val>"currency"</emu-val>, [[Value]]: <var>cd</var> } as the last element of <var>result</var>.</li></ol></li><li>Else if <var>p</var> is equal to <emu-val>"currencySuffix"</emu-val> and <var>numberFormat</var>.[[Style]] is <emu-val>"currency"</emu-val>, then<ol><li>Let <var>currency</var> be <var>numberFormat</var>.[[Currency]].</li><li>Let <var>currencyDisplay</var> be <var>numberFormat</var>.[[CurrencyDisplay]].</li><li>Let <var>cd</var> be an ILD String value representing <var>currency</var> after <var>x</var> in <var>currencyDisplay</var> form, which may depend on <var>x</var> in languages having different plural forms. If the implementation does not have such a representation of <var>currency</var>, use <var>currency</var> itself.</li><li>Append a new Record { [[Type]]: <emu-val>"currency"</emu-val>, [[Value]]: <var>cd</var> } as the last element of <var>result</var>.</li></ol></li><li>Else,<ol><li>Let <var>unknown</var> be an ILND String based on <var>x</var> and <var>p</var>.</li><li>Append a new Record { [[Type]]: <emu-val>"unknown"</emu-val>, [[Value]]: <var>unknown</var> } as the last element of <var>result</var>.</li></ol></li></ol></li><li>Return <var>result</var>.</li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-partitionnotationsubpattern" aoid="PartitionNotationSubPattern">
       <h1><span class="secnum">1.5.5</span> PartitionNotationSubPattern ( <var>numberFormat</var>, <var>x</var>, <var>n</var>, <var>exponent</var> )</h1>
       <p>
-        The PartitionNotationSubPattern abstract operation is called with arguments <var>numberFormat</var> (which must be an object initialized as a NumberFormat), <var>x</var> (which is a numeric value after rounding is applied), <var>n</var> (which is an intermediate formatted string), and <var>exponent</var> (an <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref>), and creates the corresponding parts for the number and notation according to the effective locale and the formatting options of <var>numberFormat</var>. The following steps are taken:
+        The PartitionNotationSubPattern abstract operation is called with arguments <var>numberFormat</var> (which must be an object initialized as a NumberFormat), <var>x</var> (which is an <emu-xref href="#intl-mathematical-value" id="_ref_54"><a href="#intl-mathematical-value">Intl mathematical value</a></emu-xref> after rounding is applied), <var>n</var> (which is an intermediate formatted string), and <var>exponent</var> (an integer), and creates the corresponding parts for the number and notation according to the effective locale and the formatting options of <var>numberFormat</var>. The following steps are taken:
       </p>
-      <emu-alg><ol><li>Let <var>result</var> be a new empty <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref>.</li><li>If <var>x</var> is <emu-val>NaN</emu-val>, then<ol><li>Append a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]]: <emu-val>"nan"</emu-val>, [[Value]]: <var>n</var> } as the last element of <var>result</var>.</li></ol></li><li>Else if <var>x</var> is a non-finite Number, then<ol><li>Append a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]]: <emu-val>"infinity"</emu-val>, [[Value]]: <var>n</var> } as the last element of <var>result</var>.</li></ol></li><li>Else,<ol><li>Let <var>notationSubPattern</var> be <emu-xref aoid="GetNotationSubPattern" id="_ref_70"><a href="#sec-getnotationsubpattern">GetNotationSubPattern</a></emu-xref>(<var>numberFormat</var>, <var>exponent</var>).</li><li>Let <var>patternParts</var> be PartitionPattern(<var>notationSubPattern</var>).</li><li>For each <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]], [[Value]] } <var>patternPart</var> of <var>patternParts</var>, do<ol><li>Let <var>p</var> be <var>patternPart</var>.[[Type]].</li><li>If <var>p</var> is <emu-val>"literal"</emu-val>, then<ol><li>Append a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]]: <emu-val>"literal"</emu-val>, [[Value]]: <var>patternPart</var>.[[Value]] } as the last element of <var>result</var>.</li></ol></li><li>Else if <var>p</var> is equal to <emu-val>"number"</emu-val>, then<ol><li>If the <var>numberFormat</var>.[[NumberingSystem]] matches one of the values in the <emu-val>"Numbering System"</emu-val> column of <emu-xref href="#table-numbering-system-digits" id="_ref_5"><a href="#table-numbering-system-digits">Table 3</a></emu-xref> below, then<ol><li>Let <var>digits</var> be a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> whose elements are the code points specified in the <emu-val>"Digits"</emu-val> column of the matching row in <emu-xref href="#table-numbering-system-digits" id="_ref_6"><a href="#table-numbering-system-digits">Table 3</a></emu-xref>.</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: The length of <var>digits</var> is 10.</li><li>Let <var>transliterated</var> be the empty String.</li><li>Let <var>len</var> be the length of <var>n</var>.</li><li>Let <var>position</var> be 0.</li><li>Repeat, while <var>position</var> &lt; <var>len</var>,<ol><li>Let <var>c</var> be the code unit at index <var>position</var> within <var>n</var>.</li><li>If 0x0030 ≤ <var>c</var> ≤ 0x0039, then<ol><li>NOTE: <var>c</var> is an ASCII digit.</li><li>Let <var>i</var> be <var>c</var> - 0x0030.</li><li>Set <var>c</var> to CodePointsToString(« <var>digits</var>[<var>i</var>] »).</li></ol></li><li>Set <var>transliterated</var> to the <emu-xref href="#sec-ecmascript-language-types-string-type"><a href="https://tc39.es/ecma262/#sec-ecmascript-language-types-string-type">string-concatenation</a></emu-xref> of <var>transliterated</var> and <var>c</var>.</li><li>Set <var>position</var> to <var>position</var> + 1.</li></ol></li><li>Set <var>n</var> to <var>transliterated</var>.</li></ol></li><li>Else use an implementation dependent algorithm to map <var>n</var> to the appropriate representation of <var>n</var> in the given numbering system.</li><li>Let <var>decimalSepIndex</var> be StringIndexOf(<var>n</var>, <emu-val>"."</emu-val>, 0).</li><li>If <var>decimalSepIndex</var> &gt; 0, then<ol><li>Let <var>integer</var> be the substring of <var>n</var> from position 0, inclusive, to position <var>decimalSepIndex</var>, exclusive.</li><li>Let <var>fraction</var> be the substring of <var>n</var> from position <var>decimalSepIndex</var>, exclusive, to the end of <var>n</var>.</li></ol></li><li>Else,<ol><li>Let <var>integer</var> be <var>n</var>.</li><li>Let <var>fraction</var> be <emu-val>undefined</emu-val>.</li></ol></li><li>If the <var>numberFormat</var>.[[UseGrouping]] is <emu-val>false</emu-val>, then<ol><li>Append a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]]: <emu-val>"integer"</emu-val>, [[Value]]: <var>integer</var> } as the last element of <var>result</var>.</li></ol></li><li>Else,<ol><li>Let <var>groupSepSymbol</var> be the implementation-, locale-, and numbering system-dependent (ILND) String representing the grouping separator.</li><li>Let <var>groups</var> be a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> whose elements are, in left to right order, the substrings defined by ILND set of locations within the <var>integer</var>, which may depend on the value of <var>numberFormat</var>.[[UseGrouping]].</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: The number of elements in <var>groups</var> <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> is greater than 0.</li><li>Repeat, while <var>groups</var> <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> is not empty,<ol><li>Remove the first element from <var>groups</var> and let <var>integerGroup</var> be the value of that element.</li><li>Append a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]]: <emu-val>"integer"</emu-val>, [[Value]]: <var>integerGroup</var> } as the last element of <var>result</var>.</li><li>If <var>groups</var> <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> is not empty, then<ol><li>Append a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]]: <emu-val>"group"</emu-val>, [[Value]]: <var>groupSepSymbol</var> } as the last element of <var>result</var>.</li></ol></li></ol></li></ol></li><li>If <var>fraction</var> is not <emu-val>undefined</emu-val>, then<ol><li>Let <var>decimalSepSymbol</var> be the ILND String representing the decimal separator.</li><li>Append a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]]: <emu-val>"decimal"</emu-val>, [[Value]]: <var>decimalSepSymbol</var> } as the last element of <var>result</var>.</li><li>Append a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]]: <emu-val>"fraction"</emu-val>, [[Value]]: <var>fraction</var> } as the last element of <var>result</var>.</li></ol></li></ol></li><li>Else if <var>p</var> is equal to <emu-val>"compactSymbol"</emu-val>, then<ol><li>Let <var>compactSymbol</var> be an ILD string representing <var>exponent</var> in short form, which may depend on <var>x</var> in languages having different plural forms. The implementation must be able to provide this string, or else the pattern would not have a <emu-val>"{compactSymbol}"</emu-val> placeholder.</li><li>Append a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]]: <emu-val>"compact"</emu-val>, [[Value]]: <var>compactSymbol</var> } as the last element of <var>result</var>.</li></ol></li><li>Else if <var>p</var> is equal to <emu-val>"compactName"</emu-val>, then<ol><li>Let <var>compactName</var> be an ILD string representing <var>exponent</var> in long form, which may depend on <var>x</var> in languages having different plural forms. The implementation must be able to provide this string, or else the pattern would not have a <emu-val>"{compactName}"</emu-val> placeholder.</li><li>Append a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]]: <emu-val>"compact"</emu-val>, [[Value]]: <var>compactName</var> } as the last element of <var>result</var>.</li></ol></li><li>Else if <var>p</var> is equal to <emu-val>"scientificSeparator"</emu-val>, then<ol><li>Let <var>scientificSeparator</var> be the ILND String representing the exponent separator.</li><li>Append a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]]: <emu-val>"exponentSeparator"</emu-val>, [[Value]]: <var>scientificSeparator</var> } as the last element of <var>result</var>.</li></ol></li><li>Else if <var>p</var> is equal to <emu-val>"scientificExponent"</emu-val>, then<ol><li>If <var>exponent</var> &lt; 0, then<ol><li>Let <var>minusSignSymbol</var> be the ILND String representing the minus sign.</li><li>Append a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]]: <emu-val>"exponentMinusSign"</emu-val>, [[Value]]: <var>minusSignSymbol</var> } as the last element of <var>result</var>.</li><li>Let <var>exponent</var> be -<var>exponent</var>.</li></ol></li><li>Let <var>exponentResult</var> be <emu-xref aoid="ToRawFixed" id="_ref_71"><a href="#sec-torawfixed">ToRawFixed</a></emu-xref>(<var>exponent</var>, 0, 0, 1, <emu-val>undefined</emu-val>).</li><li>Append a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]]: <emu-val>"exponentInteger"</emu-val>, [[Value]]: <var>exponentResult</var>.[[FormattedString]] } as the last element of <var>result</var>.</li></ol></li><li>Else,<ol><li>Let <var>unknown</var> be an ILND String based on <var>x</var> and <var>p</var>.</li><li>Append a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]]: <emu-val>"unknown"</emu-val>, [[Value]]: <var>unknown</var> } as the last element of <var>result</var>.</li></ol></li></ol></li></ol></li><li>Return <var>result</var>.</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>result</var> be a new empty List.</li><li>If <var>x</var> is <emu-const>not-a-number</emu-const>, then<ol><li>Append a new Record { [[Type]]: <emu-val>"nan"</emu-val>, [[Value]]: <var>n</var> } as the last element of <var>result</var>.</li></ol></li><li>Else if <var>x</var> is <emu-const>positive-infinity</emu-const> or <emu-const>negative-infinity</emu-const>, then<ol><li>Append a new Record { [[Type]]: <emu-val>"infinity"</emu-val>, [[Value]]: <var>n</var> } as the last element of <var>result</var>.</li></ol></li><li>Else,<ol><li>Let <var>notationSubPattern</var> be <emu-xref aoid="GetNotationSubPattern" id="_ref_55"><a href="#sec-getnotationsubpattern">GetNotationSubPattern</a></emu-xref>(<var>numberFormat</var>, <var>exponent</var>).</li><li>Let <var>patternParts</var> be PartitionPattern(<var>notationSubPattern</var>).</li><li>For each Record { [[Type]], [[Value]] } <var>patternPart</var> of <var>patternParts</var>, do<ol><li>Let <var>p</var> be <var>patternPart</var>.[[Type]].</li><li>If <var>p</var> is <emu-val>"literal"</emu-val>, then<ol><li>Append a new Record { [[Type]]: <emu-val>"literal"</emu-val>, [[Value]]: <var>patternPart</var>.[[Value]] } as the last element of <var>result</var>.</li></ol></li><li>Else if <var>p</var> is equal to <emu-val>"number"</emu-val>, then<ol><li>If the <var>numberFormat</var>.[[NumberingSystem]] matches one of the values in the <emu-val>"Numbering System"</emu-val> column of <emu-xref href="#table-numbering-system-digits" id="_ref_5"><a href="#table-numbering-system-digits">Table 3</a></emu-xref> below, then<ol><li>Let <var>digits</var> be a List whose elements are the code points specified in the <emu-val>"Digits"</emu-val> column of the matching row in <emu-xref href="#table-numbering-system-digits" id="_ref_6"><a href="#table-numbering-system-digits">Table 3</a></emu-xref>.</li><li>Assert: The length of <var>digits</var> is 10.</li><li>Let <var>transliterated</var> be the empty String.</li><li>Let <var>len</var> be the length of <var>n</var>.</li><li>Let <var>position</var> be 0.</li><li>Repeat, while <var>position</var> &lt; <var>len</var>,<ol><li>Let <var>c</var> be the code unit at index <var>position</var> within <var>n</var>.</li><li>If 0x0030 ≤ <var>c</var> ≤ 0x0039, then<ol><li>NOTE: <var>c</var> is an ASCII digit.</li><li>Let <var>i</var> be <var>c</var> - 0x0030.</li><li>Set <var>c</var> to CodePointsToString(« <var>digits</var>[<var>i</var>] »).</li></ol></li><li>Set <var>transliterated</var> to the string-concatenation of <var>transliterated</var> and <var>c</var>.</li><li>Set <var>position</var> to <var>position</var> + 1.</li></ol></li><li>Set <var>n</var> to <var>transliterated</var>.</li></ol></li><li>Else use an implementation dependent algorithm to map <var>n</var> to the appropriate representation of <var>n</var> in the given numbering system.</li><li>Let <var>decimalSepIndex</var> be StringIndexOf(<var>n</var>, <emu-val>"."</emu-val>, 0).</li><li>If <var>decimalSepIndex</var> &gt; 0, then<ol><li>Let <var>integer</var> be the substring of <var>n</var> from position 0, inclusive, to position <var>decimalSepIndex</var>, exclusive.</li><li>Let <var>fraction</var> be the substring of <var>n</var> from position <var>decimalSepIndex</var>, exclusive, to the end of <var>n</var>.</li></ol></li><li>Else,<ol><li>Let <var>integer</var> be <var>n</var>.</li><li>Let <var>fraction</var> be <emu-val>undefined</emu-val>.</li></ol></li><li>If the <var>numberFormat</var>.[[UseGrouping]] is <emu-val>false</emu-val>, then<ol><li>Append a new Record { [[Type]]: <emu-val>"integer"</emu-val>, [[Value]]: <var>integer</var> } as the last element of <var>result</var>.</li></ol></li><li>Else,<ol><li>Let <var>groupSepSymbol</var> be the implementation-, locale-, and numbering system-dependent (ILND) String representing the grouping separator.</li><li>Let <var>groups</var> be a List whose elements are, in left to right order, the substrings defined by ILND set of locations within the <var>integer</var>, which may depend on the value of <var>numberFormat</var>.[[UseGrouping]].</li><li>Assert: The number of elements in <var>groups</var> List is greater than 0.</li><li>Repeat, while <var>groups</var> List is not empty,<ol><li>Remove the first element from <var>groups</var> and let <var>integerGroup</var> be the value of that element.</li><li>Append a new Record { [[Type]]: <emu-val>"integer"</emu-val>, [[Value]]: <var>integerGroup</var> } as the last element of <var>result</var>.</li><li>If <var>groups</var> List is not empty, then<ol><li>Append a new Record { [[Type]]: <emu-val>"group"</emu-val>, [[Value]]: <var>groupSepSymbol</var> } as the last element of <var>result</var>.</li></ol></li></ol></li></ol></li><li>If <var>fraction</var> is not <emu-val>undefined</emu-val>, then<ol><li>Let <var>decimalSepSymbol</var> be the ILND String representing the decimal separator.</li><li>Append a new Record { [[Type]]: <emu-val>"decimal"</emu-val>, [[Value]]: <var>decimalSepSymbol</var> } as the last element of <var>result</var>.</li><li>Append a new Record { [[Type]]: <emu-val>"fraction"</emu-val>, [[Value]]: <var>fraction</var> } as the last element of <var>result</var>.</li></ol></li></ol></li><li>Else if <var>p</var> is equal to <emu-val>"compactSymbol"</emu-val>, then<ol><li>Let <var>compactSymbol</var> be an ILD string representing <var>exponent</var> in short form, which may depend on <var>x</var> in languages having different plural forms. The implementation must be able to provide this string, or else the pattern would not have a <emu-val>"{compactSymbol}"</emu-val> placeholder.</li><li>Append a new Record { [[Type]]: <emu-val>"compact"</emu-val>, [[Value]]: <var>compactSymbol</var> } as the last element of <var>result</var>.</li></ol></li><li>Else if <var>p</var> is equal to <emu-val>"compactName"</emu-val>, then<ol><li>Let <var>compactName</var> be an ILD string representing <var>exponent</var> in long form, which may depend on <var>x</var> in languages having different plural forms. The implementation must be able to provide this string, or else the pattern would not have a <emu-val>"{compactName}"</emu-val> placeholder.</li><li>Append a new Record { [[Type]]: <emu-val>"compact"</emu-val>, [[Value]]: <var>compactName</var> } as the last element of <var>result</var>.</li></ol></li><li>Else if <var>p</var> is equal to <emu-val>"scientificSeparator"</emu-val>, then<ol><li>Let <var>scientificSeparator</var> be the ILND String representing the exponent separator.</li><li>Append a new Record { [[Type]]: <emu-val>"exponentSeparator"</emu-val>, [[Value]]: <var>scientificSeparator</var> } as the last element of <var>result</var>.</li></ol></li><li>Else if <var>p</var> is equal to <emu-val>"scientificExponent"</emu-val>, then<ol><li>If <var>exponent</var> &lt; 0, then<ol><li>Let <var>minusSignSymbol</var> be the ILND String representing the minus sign.</li><li>Append a new Record { [[Type]]: <emu-val>"exponentMinusSign"</emu-val>, [[Value]]: <var>minusSignSymbol</var> } as the last element of <var>result</var>.</li><li>Let <var>exponent</var> be -<var>exponent</var>.</li></ol></li><li>Let <var>exponentResult</var> be <emu-xref aoid="ToRawFixed" id="_ref_56"><a href="#sec-torawfixed">ToRawFixed</a></emu-xref>(<var>exponent</var>, 0, 0, 1, <emu-val>undefined</emu-val>).</li><li>Append a new Record { [[Type]]: <emu-val>"exponentInteger"</emu-val>, [[Value]]: <var>exponentResult</var>.[[FormattedString]] } as the last element of <var>result</var>.</li></ol></li><li>Else,<ol><li>Let <var>unknown</var> be an ILND String based on <var>x</var> and <var>p</var>.</li><li>Append a new Record { [[Type]]: <emu-val>"unknown"</emu-val>, [[Value]]: <var>unknown</var> } as the last element of <var>result</var>.</li></ol></li></ol></li></ol></li><li>Return <var>result</var>.</li></ol></emu-alg>
 
       <emu-table id="table-numbering-system-digits"><figure><figcaption>Table 3: Numbering systems with simple digit mappings</figcaption>
         
@@ -2658,52 +3415,52 @@ li.menu-search-result-term:before {
       <h1><span class="secnum">1.5.6</span> FormatNumeric ( <var>numberFormat</var>, <var>x</var> )</h1>
 
       <p>
-        The FormatNumeric abstract operation is called with arguments <var>numberFormat</var> (which must be an object initialized as a NumberFormat) and <var>x</var> (which must be an <emu-xref href="#intl-mathematical-value" id="_ref_72"><a href="#intl-mathematical-value">Intl mathematical value</a></emu-xref>), and performs the following steps:
+        The FormatNumeric abstract operation is called with arguments <var>numberFormat</var> (which must be an object initialized as a NumberFormat) and <var>x</var> (which must be an <emu-xref href="#intl-mathematical-value" id="_ref_57"><a href="#intl-mathematical-value">Intl mathematical value</a></emu-xref>), and performs the following steps:
       </p>
 
-      <emu-alg><ol><li>Let <var>parts</var> be ?&nbsp;<emu-xref aoid="PartitionNumberPattern" id="_ref_73"><a href="#sec-partitionnumberpattern">PartitionNumberPattern</a></emu-xref>(<var>numberFormat</var>, <var>x</var>).</li><li>Let <var>result</var> be the empty String.</li><li>For each <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]], [[Value]] } <var>part</var> in <var>parts</var>, do<ol><li>Set <var>result</var> to the <emu-xref href="#sec-ecmascript-language-types-string-type"><a href="https://tc39.es/ecma262/#sec-ecmascript-language-types-string-type">string-concatenation</a></emu-xref> of <var>result</var> and <var>part</var>.[[Value]].</li></ol></li><li>Return <var>result</var>.</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>parts</var> be ?&nbsp;<emu-xref aoid="PartitionNumberPattern" id="_ref_58"><a href="#sec-partitionnumberpattern">PartitionNumberPattern</a></emu-xref>(<var>numberFormat</var>, <var>x</var>).</li><li>Let <var>result</var> be the empty String.</li><li>For each Record { [[Type]], [[Value]] } <var>part</var> in <var>parts</var>, do<ol><li>Set <var>result</var> to the string-concatenation of <var>result</var> and <var>part</var>.[[Value]].</li></ol></li><li>Return <var>result</var>.</li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-formatnumbertoparts" aoid="FormatNumericToParts">
       <h1><span class="secnum">1.5.7</span> FormatNumericToParts ( <var>numberFormat</var>, <var>x</var> )</h1>
 
       <p>
-        The FormatNumericToParts abstract operation is called with arguments <var>numberFormat</var> (which must be an object initialized as a NumberFormat) and <var>x</var> (which must be an <emu-xref href="#intl-mathematical-value" id="_ref_74"><a href="#intl-mathematical-value">Intl mathematical value</a></emu-xref>), and performs the following steps:
+        The FormatNumericToParts abstract operation is called with arguments <var>numberFormat</var> (which must be an object initialized as a NumberFormat) and <var>x</var> (which must be an <emu-xref href="#intl-mathematical-value" id="_ref_59"><a href="#intl-mathematical-value">Intl mathematical value</a></emu-xref>), and performs the following steps:
       </p>
 
-      <emu-alg><ol><li>Let <var>parts</var> be ?&nbsp;<emu-xref aoid="PartitionNumberPattern" id="_ref_75"><a href="#sec-partitionnumberpattern">PartitionNumberPattern</a></emu-xref>(<var>numberFormat</var>, <var>x</var>).</li><li>Let <var>result</var> be !&nbsp;<emu-xref aoid="ArrayCreate" id="_ref_76"><a href="https://tc39.es/ecma262/#sec-arraycreate">ArrayCreate</a></emu-xref>(0).</li><li>Let <var>n</var> be 0.</li><li>For each <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]], [[Value]] } <var>part</var> in <var>parts</var>, do<ol><li>Let <var>O</var> be OrdinaryObjectCreate(%Object.prototype%).</li><li>Perform !&nbsp;<emu-xref aoid="CreateDataPropertyOrThrow" id="_ref_77"><a href="https://tc39.es/ecma262/#sec-createdatapropertyorthrow">CreateDataPropertyOrThrow</a></emu-xref>(<var>O</var>, <emu-val>"type"</emu-val>, <var>part</var>.[[Type]]).</li><li>Perform !&nbsp;<emu-xref aoid="CreateDataPropertyOrThrow" id="_ref_78"><a href="https://tc39.es/ecma262/#sec-createdatapropertyorthrow">CreateDataPropertyOrThrow</a></emu-xref>(<var>O</var>, <emu-val>"value"</emu-val>, <var>part</var>.[[Value]]).</li><li>Perform !&nbsp;<emu-xref aoid="CreateDataPropertyOrThrow" id="_ref_79"><a href="https://tc39.es/ecma262/#sec-createdatapropertyorthrow">CreateDataPropertyOrThrow</a></emu-xref>(<var>result</var>, !&nbsp;<emu-xref aoid="ToString" id="_ref_80"><a href="https://tc39.es/ecma262/#sec-tostring">ToString</a></emu-xref>(<var>n</var>), <var>O</var>).</li><li>Increment <var>n</var> by 1.</li></ol></li><li>Return <var>result</var>.</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>parts</var> be ?&nbsp;<emu-xref aoid="PartitionNumberPattern" id="_ref_60"><a href="#sec-partitionnumberpattern">PartitionNumberPattern</a></emu-xref>(<var>numberFormat</var>, <var>x</var>).</li><li>Let <var>result</var> be !&nbsp;ArrayCreate(0).</li><li>Let <var>n</var> be 0.</li><li>For each Record { [[Type]], [[Value]] } <var>part</var> in <var>parts</var>, do<ol><li>Let <var>O</var> be OrdinaryObjectCreate(%Object.prototype%).</li><li>Perform !&nbsp;CreateDataPropertyOrThrow(<var>O</var>, <emu-val>"type"</emu-val>, <var>part</var>.[[Type]]).</li><li>Perform !&nbsp;CreateDataPropertyOrThrow(<var>O</var>, <emu-val>"value"</emu-val>, <var>part</var>.[[Value]]).</li><li>Perform !&nbsp;CreateDataPropertyOrThrow(<var>result</var>, !&nbsp;ToString(<var>n</var>), <var>O</var>).</li><li>Increment <var>n</var> by 1.</li></ol></li><li>Return <var>result</var>.</li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-torawprecision" aoid="ToRawPrecision">
       <h1><span class="secnum">1.5.8</span> ToRawPrecision ( <var>x</var>, <var>minPrecision</var>, <var>maxPrecision</var>, <var>unsignedRoundingMode</var> )</h1>
 
       <p>
-        ToRawPrecision is an abstract operation that involves solving the following equation, which returns a valid <emu-xref href="#mathematical-value"><a href="https://tc39.es/ecma262/#mathematical-value">mathematical value</a></emu-xref> given <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref> inputs:
+        ToRawPrecision is an abstract operation that involves solving the following equation, which returns a valid mathematical value given integer inputs:
       </p>
 
       <emu-eqn id="eqn-ToRawPrecisionFn" aoid="ToRawPrecisionFn"><div>        ToRawPrecisionFn(<var>n</var>, <var>e</var>, <var>p</var>) = <var>n</var> × 10<sup><var>e</var>–<var>p</var>+1</sup></div><div>        where 10<sup><var>p</var>–1</sup> ≤ <var>n</var> &lt; 10<sup><var>p</var></sup></div></emu-eqn>
 
       <p>
-        When the ToRawPrecision abstract operation is called with arguments <var>x</var> (which must be a finite non-negative <emu-xref href="#mathematical-value"><a href="https://tc39.es/ecma262/#mathematical-value">mathematical value</a></emu-xref>), <var>minPrecision</var>, <var>maxPrecision</var> (both must be integers between 1 and 21), and <var>unsignedRoundingMode</var> (a specification type from the <emu-val>Unsigned Rounding Mode</emu-val> column of <emu-xref href="#table-intl-unsigned-rounding-modes" id="_ref_7"><a href="#table-intl-unsigned-rounding-modes">Table 4</a></emu-xref> or <emu-val>undefined</emu-val>), the following steps are taken:
+        When the ToRawPrecision abstract operation is called with arguments <var>x</var> (which must be a finite non-negative mathematical value), <var>minPrecision</var>, <var>maxPrecision</var> (both must be integers between 1 and 21), and <var>unsignedRoundingMode</var> (a specification type from the <emu-val>Unsigned Rounding Mode</emu-val> column of <emu-xref href="#table-intl-unsigned-rounding-modes" id="_ref_7"><a href="#table-intl-unsigned-rounding-modes">Table 4</a></emu-xref> or <emu-val>undefined</emu-val>), the following steps are taken:
       </p>
 
-      <emu-alg><ol><li>Let <var>p</var> be <var>maxPrecision</var>.</li><li>If <var>x</var> = 0, then<ol><li>Let <var>m</var> be the String consisting of <var>p</var> occurrences of the code unit 0x0030 (DIGIT ZERO).</li><li>Let <var>e</var> be 0.</li><li>Let <var>xFinal</var> be 0.</li></ol></li><li>Else,<ol><li>Let <var>n1</var> and <var>e1</var> each be an <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref> and <var>r1</var> a <emu-xref href="#mathematical-value"><a href="https://tc39.es/ecma262/#mathematical-value">mathematical value</a></emu-xref>, with <emu-eqn class="inline"><var>r1</var> = <emu-xref aoid="ToRawPrecisionFn" id="_ref_81"><a href="#eqn-ToRawPrecisionFn">ToRawPrecisionFn</a></emu-xref>(<var>n1</var>, <var>e1</var>, <var>p</var>)</emu-eqn>, such that <emu-eqn class="inline"><var>r1</var> ≤ <var>x</var></emu-eqn> and <var>r1</var> is maximized.</li><li>Let <var>n2</var> and <var>e2</var> each be an <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref> and <var>r2</var> a <emu-xref href="#mathematical-value"><a href="https://tc39.es/ecma262/#mathematical-value">mathematical value</a></emu-xref>, with <emu-eqn class="inline"><var>r2</var> = <emu-xref aoid="ToRawPrecisionFn" id="_ref_82"><a href="#eqn-ToRawPrecisionFn">ToRawPrecisionFn</a></emu-xref>(<var>n2</var>, <var>e2</var>, <var>p</var>)</emu-eqn>, such that <emu-eqn class="inline"><var>r2</var> ≥ <var>x</var></emu-eqn> and <var>r2</var> is minimized.</li><li>Let <var>r</var> be <emu-xref aoid="ApplyUnsignedRoundingMode" id="_ref_83"><a href="#sec-applyunsignedroundingmode">ApplyUnsignedRoundingMode</a></emu-xref>(<var>x</var>, <var>r1</var>, <var>r2</var>, <var>unsignedRoundingMode</var>).</li><li>If <var>r</var> is <var>r1</var>, then<ol><li>Let <var>n</var> be <var>n1</var>.</li><li>Let <var>e</var> be <var>e1</var>.</li><li>Let <var>xFinal</var> be <var>r1</var>.</li></ol></li><li>Else,<ol><li>Let <var>n</var> be <var>n2</var>.</li><li>Let <var>e</var> be <var>e2</var>.</li><li>Let <var>xFinal</var> be <var>r2</var>.</li></ol></li><li>Let <var>m</var> be the String consisting of the digits of the decimal representation of <var>n</var> (in order, with no leading zeroes).</li></ol></li><li>If <var>e</var> ≥ (<var>p</var> - 1), then<ol><li>Set <var>m</var> to the <emu-xref href="#sec-ecmascript-language-types-string-type"><a href="https://tc39.es/ecma262/#sec-ecmascript-language-types-string-type">string-concatenation</a></emu-xref> of <var>m</var> and <var>e</var> - <var>p</var> + 1 occurrences of the code unit 0x0030 (DIGIT ZERO).</li><li>Let <var>int</var> be <var>e</var> + 1.</li></ol></li><li>Else if <var>e</var> ≥ 0, then<ol><li>Set <var>m</var> to the <emu-xref href="#sec-ecmascript-language-types-string-type"><a href="https://tc39.es/ecma262/#sec-ecmascript-language-types-string-type">string-concatenation</a></emu-xref> of the first <var>e</var> + 1 code units of <var>m</var>, the code unit 0x002E (FULL STOP), and the remaining <var>p</var> - (<var>e</var> + 1) code units of <var>m</var>.</li><li>Let <var>int</var> be <var>e</var> + 1.</li></ol></li><li>Else,<ol><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>e</var> &lt; 0.</li><li>Set <var>m</var> to the <emu-xref href="#sec-ecmascript-language-types-string-type"><a href="https://tc39.es/ecma262/#sec-ecmascript-language-types-string-type">string-concatenation</a></emu-xref> of <emu-val>"0."</emu-val>, -(<var>e</var> + 1) occurrences of the code unit 0x0030 (DIGIT ZERO), and <var>m</var>.</li><li>Let <var>int</var> be 1.</li></ol></li><li>If <var>m</var> contains the code unit 0x002E (FULL STOP) and <var>maxPrecision</var> &gt; <var>minPrecision</var>, then<ol><li>Let <var>cut</var> be <var>maxPrecision</var> - <var>minPrecision</var>.</li><li>Repeat, while <var>cut</var> &gt; 0 and the last code unit of <var>m</var> is 0x0030 (DIGIT ZERO),<ol><li>Remove the last code unit from <var>m</var>.</li><li>Decrease <var>cut</var> by 1.</li></ol></li><li>If the last code unit of <var>m</var> is 0x002E (FULL STOP), then<ol><li>Remove the last code unit from <var>m</var>.</li></ol></li></ol></li><li>Return the <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[FormattedString]]: <var>m</var>, [[RoundedNumber]]: <var>xFinal</var>, [[IntegerDigitsCount]]: <var>int</var>, [[RoundingMagnitude]]: <var>e</var>–<var>p</var>+1 }.</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>p</var> be <var>maxPrecision</var>.</li><li>If <var>x</var> = 0, then<ol><li>Let <var>m</var> be the String consisting of <var>p</var> occurrences of the code unit 0x0030 (DIGIT ZERO).</li><li>Let <var>e</var> be 0.</li><li>Let <var>xFinal</var> be 0.</li></ol></li><li>Else,<ol><li>Let <var>n1</var> and <var>e1</var> each be an integer and <var>r1</var> a mathematical value, with <emu-eqn class="inline"><var>r1</var> = <emu-xref aoid="ToRawPrecisionFn" id="_ref_61"><a href="#eqn-ToRawPrecisionFn">ToRawPrecisionFn</a></emu-xref>(<var>n1</var>, <var>e1</var>, <var>p</var>)</emu-eqn>, such that <emu-eqn class="inline"><var>r1</var> ≤ <var>x</var></emu-eqn> and <var>r1</var> is maximized.</li><li>Let <var>n2</var> and <var>e2</var> each be an integer and <var>r2</var> a mathematical value, with <emu-eqn class="inline"><var>r2</var> = <emu-xref aoid="ToRawPrecisionFn" id="_ref_62"><a href="#eqn-ToRawPrecisionFn">ToRawPrecisionFn</a></emu-xref>(<var>n2</var>, <var>e2</var>, <var>p</var>)</emu-eqn>, such that <emu-eqn class="inline"><var>r2</var> ≥ <var>x</var></emu-eqn> and <var>r2</var> is minimized.</li><li>Let <var>r</var> be <emu-xref aoid="ApplyUnsignedRoundingMode" id="_ref_63"><a href="#sec-applyunsignedroundingmode">ApplyUnsignedRoundingMode</a></emu-xref>(<var>x</var>, <var>r1</var>, <var>r2</var>, <var>unsignedRoundingMode</var>).</li><li>If <var>r</var> is <var>r1</var>, then<ol><li>Let <var>n</var> be <var>n1</var>.</li><li>Let <var>e</var> be <var>e1</var>.</li><li>Let <var>xFinal</var> be <var>r1</var>.</li></ol></li><li>Else,<ol><li>Let <var>n</var> be <var>n2</var>.</li><li>Let <var>e</var> be <var>e2</var>.</li><li>Let <var>xFinal</var> be <var>r2</var>.</li></ol></li><li>Let <var>m</var> be the String consisting of the digits of the decimal representation of <var>n</var> (in order, with no leading zeroes).</li></ol></li><li>If <var>e</var> ≥ (<var>p</var> - 1), then<ol><li>Set <var>m</var> to the string-concatenation of <var>m</var> and <var>e</var> - <var>p</var> + 1 occurrences of the code unit 0x0030 (DIGIT ZERO).</li><li>Let <var>int</var> be <var>e</var> + 1.</li></ol></li><li>Else if <var>e</var> ≥ 0, then<ol><li>Set <var>m</var> to the string-concatenation of the first <var>e</var> + 1 code units of <var>m</var>, the code unit 0x002E (FULL STOP), and the remaining <var>p</var> - (<var>e</var> + 1) code units of <var>m</var>.</li><li>Let <var>int</var> be <var>e</var> + 1.</li></ol></li><li>Else,<ol><li>Assert: <var>e</var> &lt; 0.</li><li>Set <var>m</var> to the string-concatenation of <emu-val>"0."</emu-val>, -(<var>e</var> + 1) occurrences of the code unit 0x0030 (DIGIT ZERO), and <var>m</var>.</li><li>Let <var>int</var> be 1.</li></ol></li><li>If <var>m</var> contains the code unit 0x002E (FULL STOP) and <var>maxPrecision</var> &gt; <var>minPrecision</var>, then<ol><li>Let <var>cut</var> be <var>maxPrecision</var> - <var>minPrecision</var>.</li><li>Repeat, while <var>cut</var> &gt; 0 and the last code unit of <var>m</var> is 0x0030 (DIGIT ZERO),<ol><li>Remove the last code unit from <var>m</var>.</li><li>Decrease <var>cut</var> by 1.</li></ol></li><li>If the last code unit of <var>m</var> is 0x002E (FULL STOP), then<ol><li>Remove the last code unit from <var>m</var>.</li></ol></li></ol></li><li>Return the Record { [[FormattedString]]: <var>m</var>, [[RoundedNumber]]: <var>xFinal</var>, [[IntegerDigitsCount]]: <var>int</var>, [[RoundingMagnitude]]: <var>e</var>–<var>p</var>+1 }.</li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-torawfixed" aoid="ToRawFixed">
       <h1><span class="secnum">1.5.9</span> ToRawFixed ( <var>x</var>, <var>minFraction</var>, <var>maxFraction</var>, <var>roundingIncrement</var>, <var>unsignedRoundingMode</var> )</h1>
 
       <p>
-        ToRawFixed is an abstract operation that involves solving the following equation, which returns a valid <emu-xref href="#mathematical-value"><a href="https://tc39.es/ecma262/#mathematical-value">mathematical value</a></emu-xref> given <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref> inputs:
+        ToRawFixed is an abstract operation that involves solving the following equation, which returns a valid mathematical value given integer inputs:
       </p>
 
       <emu-eqn id="eqn-ToRawFixedFn" aoid="ToRawFixedFn"><div>        ToRawFixedFn(<var>n</var>, <var>f</var>) = <var>n</var> × 10<sup>–<var>f</var></sup></div></emu-eqn>
 
       <p>
-        When the ToRawFixed abstract operation is called with arguments <var>x</var> (which must be a finite non-negative <emu-xref href="#mathematical-value"><a href="https://tc39.es/ecma262/#mathematical-value">mathematical value</a></emu-xref>), <var>minFraction</var>, <var>maxFraction</var> (which must be integers between 0 and 20), <var>roundingIncrement</var> (an <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref>), and <var>unsignedRoundingMode</var> (a specification type from the <emu-val>Unsigned Rounding Mode</emu-val> column of <emu-xref href="#table-intl-unsigned-rounding-modes" id="_ref_8"><a href="#table-intl-unsigned-rounding-modes">Table 4</a></emu-xref> or <emu-val>undefined</emu-val>), the following steps are taken:
+        When the ToRawFixed abstract operation is called with arguments <var>x</var> (which must be a finite non-negative mathematical value), <var>minFraction</var>, <var>maxFraction</var> (which must be integers between 0 and 20), <var>roundingIncrement</var> (an integer), and <var>unsignedRoundingMode</var> (a specification type from the <emu-val>Unsigned Rounding Mode</emu-val> column of <emu-xref href="#table-intl-unsigned-rounding-modes" id="_ref_8"><a href="#table-intl-unsigned-rounding-modes">Table 4</a></emu-xref> or <emu-val>undefined</emu-val>), the following steps are taken:
       </p>
 
-      <emu-alg><ol><li>Let <var>f</var> be <var>maxFraction</var>.</li><li>Let <var>n1</var> be an <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref> and <var>r1</var> a <emu-xref href="#mathematical-value"><a href="https://tc39.es/ecma262/#mathematical-value">mathematical value</a></emu-xref>, with <emu-eqn class="inline"><var>r1</var> = <emu-xref aoid="ToRawFixedFn" id="_ref_84"><a href="#eqn-ToRawFixedFn">ToRawFixedFn</a></emu-xref>(<var>n1</var>, <var>f</var>)</emu-eqn>, such that <emu-eqn class="inline"><var>n1</var> <emu-xref aoid="modulo"><a href="https://tc39.es/ecma262/#eqn-modulo">modulo</a></emu-xref> <var>roundingIncrement</var> = 0</emu-eqn>, <emu-eqn class="inline"><var>r1</var> ≤ <var>x</var></emu-eqn>, and <var>r1</var> is maximized.</li><li>Let <var>n2</var> be an <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref> and <var>r2</var> a <emu-xref href="#mathematical-value"><a href="https://tc39.es/ecma262/#mathematical-value">mathematical value</a></emu-xref>, with <emu-eqn class="inline"><var>r2</var> = <emu-xref aoid="ToRawFixedFn" id="_ref_85"><a href="#eqn-ToRawFixedFn">ToRawFixedFn</a></emu-xref>(<var>n2</var>, <var>f</var>)</emu-eqn>, such that <emu-eqn class="inline"><var>n2</var> <emu-xref aoid="modulo"><a href="https://tc39.es/ecma262/#eqn-modulo">modulo</a></emu-xref> <var>roundingIncrement</var> = 0</emu-eqn>, <emu-eqn class="inline"><var>r2</var> ≥ <var>x</var></emu-eqn>, and <var>r2</var> is minimized.</li><li>Let <var>r</var> be <emu-xref aoid="ApplyUnsignedRoundingMode" id="_ref_86"><a href="#sec-applyunsignedroundingmode">ApplyUnsignedRoundingMode</a></emu-xref>(<var>x</var>, <var>r1</var>, <var>r2</var>, <var>unsignedRoundingMode</var>).</li><li>If <var>r</var> is <var>r1</var>, then<ol><li>Let <var>n</var> be <var>n1</var>.</li><li>Let <var>xFinal</var> be <var>r1</var>.</li></ol></li><li>Else,<ol><li>Let <var>n</var> be <var>n2</var>.</li><li>Let <var>xFinal</var> be <var>r2</var>.</li></ol></li><li>If <var>n</var> = 0, let <var>m</var> be <emu-val>"0"</emu-val>. Otherwise, let <var>m</var> be the String consisting of the digits of the decimal representation of <var>n</var> (in order, with no leading zeroes).</li><li>If <var>f</var> ≠ 0, then<ol><li>Let <var>k</var> be the length of <var>m</var>.</li><li>If <var>k</var> ≤ <var>f</var>, then<ol><li>Let <var>z</var> be the String value consisting of <var>f</var> + 1 - <var>k</var> occurrences of the code unit 0x0030 (DIGIT ZERO).</li><li>Set <var>m</var> to the <emu-xref href="#sec-ecmascript-language-types-string-type"><a href="https://tc39.es/ecma262/#sec-ecmascript-language-types-string-type">string-concatenation</a></emu-xref> of <var>z</var> and <var>m</var>.</li><li>Set <var>k</var> to <var>f</var> + 1.</li></ol></li><li>Let <var>a</var> be the first <var>k</var> - <var>f</var> code units of <var>m</var>, and let <var>b</var> be the remaining <var>f</var> code units of <var>m</var>.</li><li>Set <var>m</var> to the <emu-xref href="#sec-ecmascript-language-types-string-type"><a href="https://tc39.es/ecma262/#sec-ecmascript-language-types-string-type">string-concatenation</a></emu-xref> of <var>a</var>, <emu-val>"."</emu-val>, and <var>b</var>.</li><li>Let <var>int</var> be the length of <var>a</var>.</li></ol></li><li>Else, let <var>int</var> be the length of <var>m</var>.</li><li>Let <var>cut</var> be <var>maxFraction</var> - <var>minFraction</var>.</li><li>Repeat, while <var>cut</var> &gt; 0 and the last code unit of <var>m</var> is 0x0030 (DIGIT ZERO),<ol><li>Remove the last code unit from <var>m</var>.</li><li>Decrease <var>cut</var> by 1.</li></ol></li><li>If the last code unit of <var>m</var> is 0x002E (FULL STOP), then<ol><li>Remove the last code unit from <var>m</var>.</li></ol></li><li>Return the <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[FormattedString]]: <var>m</var>, [[RoundedNumber]]: <var>xFinal</var>, [[IntegerDigitsCount]]: <var>int</var>, [[RoundingMagnitude]]: –<var>f</var> }.</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>f</var> be <var>maxFraction</var>.</li><li>Let <var>n1</var> be an integer and <var>r1</var> a mathematical value, with <emu-eqn class="inline"><var>r1</var> = <emu-xref aoid="ToRawFixedFn" id="_ref_64"><a href="#eqn-ToRawFixedFn">ToRawFixedFn</a></emu-xref>(<var>n1</var>, <var>f</var>)</emu-eqn>, such that <emu-eqn class="inline"><var>n1</var> modulo <var>roundingIncrement</var> = 0</emu-eqn>, <emu-eqn class="inline"><var>r1</var> ≤ <var>x</var></emu-eqn>, and <var>r1</var> is maximized.</li><li>Let <var>n2</var> be an integer and <var>r2</var> a mathematical value, with <emu-eqn class="inline"><var>r2</var> = <emu-xref aoid="ToRawFixedFn" id="_ref_65"><a href="#eqn-ToRawFixedFn">ToRawFixedFn</a></emu-xref>(<var>n2</var>, <var>f</var>)</emu-eqn>, such that <emu-eqn class="inline"><var>n2</var> modulo <var>roundingIncrement</var> = 0</emu-eqn>, <emu-eqn class="inline"><var>r2</var> ≥ <var>x</var></emu-eqn>, and <var>r2</var> is minimized.</li><li>Let <var>r</var> be <emu-xref aoid="ApplyUnsignedRoundingMode" id="_ref_66"><a href="#sec-applyunsignedroundingmode">ApplyUnsignedRoundingMode</a></emu-xref>(<var>x</var>, <var>r1</var>, <var>r2</var>, <var>unsignedRoundingMode</var>).</li><li>If <var>r</var> is <var>r1</var>, then<ol><li>Let <var>n</var> be <var>n1</var>.</li><li>Let <var>xFinal</var> be <var>r1</var>.</li></ol></li><li>Else,<ol><li>Let <var>n</var> be <var>n2</var>.</li><li>Let <var>xFinal</var> be <var>r2</var>.</li></ol></li><li>If <var>n</var> = 0, let <var>m</var> be <emu-val>"0"</emu-val>. Otherwise, let <var>m</var> be the String consisting of the digits of the decimal representation of <var>n</var> (in order, with no leading zeroes).</li><li>If <var>f</var> ≠ 0, then<ol><li>Let <var>k</var> be the length of <var>m</var>.</li><li>If <var>k</var> ≤ <var>f</var>, then<ol><li>Let <var>z</var> be the String value consisting of <var>f</var> + 1 - <var>k</var> occurrences of the code unit 0x0030 (DIGIT ZERO).</li><li>Set <var>m</var> to the string-concatenation of <var>z</var> and <var>m</var>.</li><li>Set <var>k</var> to <var>f</var> + 1.</li></ol></li><li>Let <var>a</var> be the first <var>k</var> - <var>f</var> code units of <var>m</var>, and let <var>b</var> be the remaining <var>f</var> code units of <var>m</var>.</li><li>Set <var>m</var> to the string-concatenation of <var>a</var>, <emu-val>"."</emu-val>, and <var>b</var>.</li><li>Let <var>int</var> be the length of <var>a</var>.</li></ol></li><li>Else, let <var>int</var> be the length of <var>m</var>.</li><li>Let <var>cut</var> be <var>maxFraction</var> - <var>minFraction</var>.</li><li>Repeat, while <var>cut</var> &gt; 0 and the last code unit of <var>m</var> is 0x0030 (DIGIT ZERO),<ol><li>Remove the last code unit from <var>m</var>.</li><li>Decrease <var>cut</var> by 1.</li></ol></li><li>If the last code unit of <var>m</var> is 0x002E (FULL STOP), then<ol><li>Remove the last code unit from <var>m</var>.</li></ol></li><li>Return the Record { [[FormattedString]]: <var>m</var>, [[RoundedNumber]]: <var>xFinal</var>, [[IntegerDigitsCount]]: <var>int</var>, [[RoundingMagnitude]]: –<var>f</var> }.</li></ol></emu-alg>
     </emu-clause>
 
     <emu-normative-optional>
@@ -2712,19 +3469,19 @@ li.menu-search-result-term:before {
       <p>
         The UnwrapNumberFormat abstract operation returns the NumberFormat instance
         of its input object, which is either the value itself or a value associated
-        with it by <emu-xref href="#sec-intl-numberformat-constructor" id="_ref_87"><a href="#sec-intl-numberformat-constructor">%NumberFormat%</a></emu-xref> according to the normative optional
-        <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> mode of <emu-xref href="#legacy-constructor"></emu-xref>.
+        with it by <emu-xref href="#sec-intl-numberformat-constructor" id="_ref_67"><a href="#sec-intl-numberformat-constructor">%NumberFormat%</a></emu-xref> according to the normative optional
+        constructor mode of <emu-xref href="#legacy-constructor"></emu-xref>.
       </p>
-      <emu-alg><ol><li>If <emu-xref aoid="Type" id="_ref_88"><a href="https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>nf</var>) is not Object, throw a <emu-val>TypeError</emu-val> exception.</li><li>If <var>nf</var> does not have an [[InitializedNumberFormat]] internal slot and ?&nbsp;<emu-xref aoid="OrdinaryHasInstance" id="_ref_89"><a href="https://tc39.es/ecma262/#sec-ordinaryhasinstance">OrdinaryHasInstance</a></emu-xref>(<emu-xref href="#sec-intl-numberformat-constructor" id="_ref_90"><a href="#sec-intl-numberformat-constructor">%NumberFormat%</a></emu-xref>, <var>nf</var>) is <emu-val>true</emu-val>, then<ol><li>Return ?&nbsp;<emu-xref aoid="Get" id="_ref_91"><a href="https://tc39.es/ecma262/#sec-get-o-p">Get</a></emu-xref>(<var>nf</var>, %Intl%.[[FallbackSymbol]]).</li></ol></li><li>Return <var>nf</var>.</li></ol></emu-alg>
+      <emu-alg><ol><li>If Type(<var>nf</var>) is not Object, throw a <emu-val>TypeError</emu-val> exception.</li><li>If <var>nf</var> does not have an [[InitializedNumberFormat]] internal slot and ?&nbsp;OrdinaryHasInstance(<emu-xref href="#sec-intl-numberformat-constructor" id="_ref_68"><a href="#sec-intl-numberformat-constructor">%NumberFormat%</a></emu-xref>, <var>nf</var>) is <emu-val>true</emu-val>, then<ol><li>Return ?&nbsp;Get(<var>nf</var>, %Intl%.[[FallbackSymbol]]).</li></ol></li><li>Return <var>nf</var>.</li></ol></emu-alg>
     </emu-clause>
     </emu-normative-optional>
 
     <emu-clause id="sec-getnumberformatpattern" aoid="GetNumberFormatPattern">
       <h1><span class="secnum">1.5.11</span> GetNumberFormatPattern ( <var>numberFormat</var>, <var>x</var> )</h1>
       <p>
-        The abstract operation GetNumberFormatPattern considers the resolved unit-related options in the number format object along with the final scaled and rounded number being formatted and returns a pattern, a String value as described in <emu-xref href="#sec-intl.numberformat-internal-slots" id="_ref_9"><a href="#sec-intl.numberformat-internal-slots">1.2.3</a></emu-xref>.
+        The abstract operation GetNumberFormatPattern considers the resolved unit-related options in the number format object along with the final scaled and rounded number being formatted (an <emu-xref href="#intl-mathematical-value" id="_ref_69"><a href="#intl-mathematical-value">Intl mathematical value</a></emu-xref>) and returns a pattern, a String value as described in <emu-xref href="#sec-intl.numberformat-internal-slots" id="_ref_9"><a href="#sec-intl.numberformat-internal-slots">1.2.3</a></emu-xref>.
       </p>
-      <emu-alg><ol><li>Let <var>localeData</var> be <emu-xref href="#sec-intl-numberformat-constructor" id="_ref_92"><a href="#sec-intl-numberformat-constructor">%NumberFormat%</a></emu-xref>.[[LocaleData]].</li><li>Let <var>dataLocale</var> be <var>numberFormat</var>.[[DataLocale]].</li><li>Let <var>dataLocaleData</var> be <var>localeData</var>.[[&lt;<var>dataLocale</var>&gt;]].</li><li>Let <var>patterns</var> be <var>dataLocaleData</var>.[[patterns]].</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>patterns</var> is a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> (see <emu-xref href="#sec-intl.numberformat-internal-slots" id="_ref_10"><a href="#sec-intl.numberformat-internal-slots">1.2.3</a></emu-xref>).</li><li>Let <var>style</var> be <var>numberFormat</var>.[[Style]].</li><li>If <var>style</var> is <emu-val>"percent"</emu-val>, then<ol><li>Let <var>patterns</var> be <var>patterns</var>.[[percent]].</li></ol></li><li>Else if <var>style</var> is <emu-val>"unit"</emu-val>, then<ol><li>Let <var>unit</var> be <var>numberFormat</var>.[[Unit]].</li><li>Let <var>unitDisplay</var> be <var>numberFormat</var>.[[UnitDisplay]].</li><li>Let <var>patterns</var> be <var>patterns</var>.[[unit]].</li><li>If <var>patterns</var> doesn't have a field [[&lt;<var>unit</var>&gt;]], then<ol><li>Let <var>unit</var> be <emu-val>"fallback"</emu-val>.</li></ol></li><li>Let <var>patterns</var> be <var>patterns</var>.[[&lt;<var>unit</var>&gt;]].</li><li>Let <var>patterns</var> be <var>patterns</var>.[[&lt;<var>unitDisplay</var>&gt;]].</li></ol></li><li>Else if <var>style</var> is <emu-val>"currency"</emu-val>, then<ol><li>Let <var>currency</var> be <var>numberFormat</var>.[[Currency]].</li><li>Let <var>currencyDisplay</var> be <var>numberFormat</var>.[[CurrencyDisplay]].</li><li>Let <var>currencySign</var> be <var>numberFormat</var>.[[CurrencySign]].</li><li>Let <var>patterns</var> be <var>patterns</var>.[[currency]].</li><li>If <var>patterns</var> doesn't have a field [[&lt;<var>currency</var>&gt;]], then<ol><li>Let <var>currency</var> be <emu-val>"fallback"</emu-val>.</li></ol></li><li>Let <var>patterns</var> be <var>patterns</var>.[[&lt;<var>currency</var>&gt;]].</li><li>Let <var>patterns</var> be <var>patterns</var>.[[&lt;<var>currencyDisplay</var>&gt;]].</li><li>Let <var>patterns</var> be <var>patterns</var>.[[&lt;<var>currencySign</var>&gt;]].</li></ol></li><li>Else,<ol><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>style</var> is <emu-val>"decimal"</emu-val>.</li><li>Let <var>patterns</var> be <var>patterns</var>.[[decimal]].</li></ol></li><li>Let <var>signDisplay</var> be <var>numberFormat</var>.[[SignDisplay]].</li><li>If <var>signDisplay</var> is <emu-val>"never"</emu-val>, then<ol><li>Let <var>pattern</var> be <var>patterns</var>.[[zeroPattern]].</li></ol></li><li>Else if <var>signDisplay</var> is <emu-val>"auto"</emu-val>, then<ol><li>If <var>x</var> is 0 or <var>x</var> &gt; 0 or <var>x</var> is <emu-val>NaN</emu-val>, then<ol><li>Let <var>pattern</var> be <var>patterns</var>.[[zeroPattern]].</li></ol></li><li>Else,<ol><li>Let <var>pattern</var> be <var>patterns</var>.[[negativePattern]].</li></ol></li></ol></li><li>Else if <var>signDisplay</var> is <emu-val>"always"</emu-val>, then<ol><li>If <var>x</var> is 0 or <var>x</var> &gt; 0 or <var>x</var> is <emu-val>NaN</emu-val>, then<ol><li>Let <var>pattern</var> be <var>patterns</var>.[[positivePattern]].</li></ol></li><li>Else,<ol><li>Let <var>pattern</var> be <var>patterns</var>.[[negativePattern]].</li></ol></li></ol></li><li>Else if <var>signDisplay</var> is <emu-val>"exceptZero"</emu-val>, then<ol><li>If <var>x</var> is <emu-val>NaN</emu-val>, or if <var>x</var> is finite and <emu-xref href="#ℝ"><a href="https://tc39.es/ecma262/#ℝ">ℝ</a></emu-xref>(<var>x</var>) is 0, then<ol><li>Let <var>pattern</var> be <var>patterns</var>.[[zeroPattern]].</li></ol></li><li>Else if <emu-xref href="#ℝ"><a href="https://tc39.es/ecma262/#ℝ">ℝ</a></emu-xref>(<var>x</var>) &gt; 0, then<ol><li>Let <var>pattern</var> be <var>patterns</var>.[[positivePattern]].</li></ol></li><li>Else,<ol><li>Let <var>pattern</var> be <var>patterns</var>.[[negativePattern]].</li></ol></li></ol></li><li>Else,<ol><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>signDisplay</var> is <emu-val>"negative"</emu-val>.</li><li>If <var>x</var> is <emu-val>NaN</emu-val>, or if <var>x</var> is finite and <emu-xref href="#ℝ"><a href="https://tc39.es/ecma262/#ℝ">ℝ</a></emu-xref>(<var>x</var>) ≥ 0, then<ol><li>Let <var>pattern</var> be <var>patterns</var>.[[zeroPattern]].</li></ol></li><li>Else,<ol><li>Let <var>pattern</var> be <var>patterns</var>.[[negativePattern]].</li></ol></li></ol></li><li>Return <var>pattern</var>.</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>localeData</var> be <emu-xref href="#sec-intl-numberformat-constructor" id="_ref_70"><a href="#sec-intl-numberformat-constructor">%NumberFormat%</a></emu-xref>.[[LocaleData]].</li><li>Let <var>dataLocale</var> be <var>numberFormat</var>.[[DataLocale]].</li><li>Let <var>dataLocaleData</var> be <var>localeData</var>.[[&lt;<var>dataLocale</var>&gt;]].</li><li>Let <var>patterns</var> be <var>dataLocaleData</var>.[[patterns]].</li><li>Assert: <var>patterns</var> is a Record (see <emu-xref href="#sec-intl.numberformat-internal-slots" id="_ref_10"><a href="#sec-intl.numberformat-internal-slots">1.2.3</a></emu-xref>).</li><li>Let <var>style</var> be <var>numberFormat</var>.[[Style]].</li><li>If <var>style</var> is <emu-val>"percent"</emu-val>, then<ol><li>Let <var>patterns</var> be <var>patterns</var>.[[percent]].</li></ol></li><li>Else if <var>style</var> is <emu-val>"unit"</emu-val>, then<ol><li>Let <var>unit</var> be <var>numberFormat</var>.[[Unit]].</li><li>Let <var>unitDisplay</var> be <var>numberFormat</var>.[[UnitDisplay]].</li><li>Let <var>patterns</var> be <var>patterns</var>.[[unit]].</li><li>If <var>patterns</var> doesn't have a field [[&lt;<var>unit</var>&gt;]], then<ol><li>Let <var>unit</var> be <emu-val>"fallback"</emu-val>.</li></ol></li><li>Let <var>patterns</var> be <var>patterns</var>.[[&lt;<var>unit</var>&gt;]].</li><li>Let <var>patterns</var> be <var>patterns</var>.[[&lt;<var>unitDisplay</var>&gt;]].</li></ol></li><li>Else if <var>style</var> is <emu-val>"currency"</emu-val>, then<ol><li>Let <var>currency</var> be <var>numberFormat</var>.[[Currency]].</li><li>Let <var>currencyDisplay</var> be <var>numberFormat</var>.[[CurrencyDisplay]].</li><li>Let <var>currencySign</var> be <var>numberFormat</var>.[[CurrencySign]].</li><li>Let <var>patterns</var> be <var>patterns</var>.[[currency]].</li><li>If <var>patterns</var> doesn't have a field [[&lt;<var>currency</var>&gt;]], then<ol><li>Let <var>currency</var> be <emu-val>"fallback"</emu-val>.</li></ol></li><li>Let <var>patterns</var> be <var>patterns</var>.[[&lt;<var>currency</var>&gt;]].</li><li>Let <var>patterns</var> be <var>patterns</var>.[[&lt;<var>currencyDisplay</var>&gt;]].</li><li>Let <var>patterns</var> be <var>patterns</var>.[[&lt;<var>currencySign</var>&gt;]].</li></ol></li><li>Else,<ol><li>Assert: <var>style</var> is <emu-val>"decimal"</emu-val>.</li><li>Let <var>patterns</var> be <var>patterns</var>.[[decimal]].</li></ol></li><li>If <var>x</var> is <emu-const>negative-infinity</emu-const>, then<ol><li>Let <var>category</var> be <emu-const>negative-nonzero</emu-const>.</li></ol></li><li>Else if <var>x</var> is <emu-const>negative-zero</emu-const>, then<ol><li>Let <var>category</var> be <emu-const>negative-zero</emu-const>.</li></ol></li><li>Else if <var>x</var> is <emu-const>not-a-number</emu-const>, then<ol><li>Let <var>category</var> be <emu-const>positive-zero</emu-const>.</li></ol></li><li>Else if <var>x</var> is <emu-const>positive-infinity</emu-const>, then<ol><li>Let <var>category</var> be <emu-const>positive-nonzero</emu-const>.</li></ol></li><li>Else,<ol><li>Assert: <var>x</var> is a mathematical value.</li><li>If <var>x</var> &lt; 0, then<ol><li>Let <var>category</var> be <emu-const>negative-nonzero</emu-const>.</li></ol></li><li>Else if <var>x</var> &gt; 0, then<ol><li>Let <var>category</var> be <emu-const>positive-nonzero</emu-const>.</li></ol></li><li>Else,<ol><li>Let <var>category</var> be <emu-const>positive-zero</emu-const>.</li></ol></li></ol></li><li>Let <var>signDisplay</var> be <var>numberFormat</var>.[[SignDisplay]].</li><li>If <var>signDisplay</var> is <emu-val>"never"</emu-val>, then<ol><li>Let <var>pattern</var> be <var>patterns</var>.[[zeroPattern]].</li></ol></li><li>Else if <var>signDisplay</var> is <emu-val>"auto"</emu-val>, then<ol><li>If <var>category</var> is <emu-const>positive-nonzero</emu-const> or <emu-const>positive-zero</emu-const>, then<ol><li>Let <var>pattern</var> be <var>patterns</var>.[[zeroPattern]].</li></ol></li><li>Else,<ol><li>Let <var>pattern</var> be <var>patterns</var>.[[negativePattern]].</li></ol></li></ol></li><li>Else if <var>signDisplay</var> is <emu-val>"always"</emu-val>, then<ol><li>If <var>category</var> is <emu-const>positive-nonzero</emu-const> or <emu-const>positive-zero</emu-const>, then<ol><li>Let <var>pattern</var> be <var>patterns</var>.[[positivePattern]].</li></ol></li><li>Else,<ol><li>Let <var>pattern</var> be <var>patterns</var>.[[negativePattern]].</li></ol></li></ol></li><li>Else if <var>signDisplay</var> is <emu-val>"exceptZero"</emu-val>, then<ol><li>If <var>category</var> is <emu-const>positive-zero</emu-const> or <emu-const>negative-zero</emu-const>, then<ol><li>Let <var>pattern</var> be <var>patterns</var>.[[zeroPattern]].</li></ol></li><li>Else if <var>category</var> is <emu-const>positive-nonzero</emu-const>, then<ol><li>Let <var>pattern</var> be <var>patterns</var>.[[positivePattern]].</li></ol></li><li>Else,<ol><li>Let <var>pattern</var> be <var>patterns</var>.[[negativePattern]].</li></ol></li></ol></li><li>Else,<ol><li>Assert: <var>signDisplay</var> is <emu-val>"negative"</emu-val>.</li><li>If <var>category</var> is <emu-const>negative-nonzero</emu-const>, then<ol><li>Let <var>pattern</var> be <var>patterns</var>.[[negativePattern]].</li></ol></li><li>Else,<ol><li>Let <var>pattern</var> be <var>patterns</var>.[[zeroPattern]].</li></ol></li></ol></li><li>Return <var>pattern</var>.</li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-getnotationsubpattern" aoid="GetNotationSubPattern">
@@ -2732,7 +3489,7 @@ li.menu-search-result-term:before {
       <p>
         The abstract operation GetNotationSubPattern considers the resolved notation and <var>exponent</var>, and returns a String value for the notation sub pattern as described in <emu-xref href="#sec-intl.numberformat-internal-slots" id="_ref_11"><a href="#sec-intl.numberformat-internal-slots">1.2.3</a></emu-xref>.
       </p>
-      <emu-alg><ol><li>Let <var>localeData</var> be <emu-xref href="#sec-intl-numberformat-constructor" id="_ref_93"><a href="#sec-intl-numberformat-constructor">%NumberFormat%</a></emu-xref>.[[LocaleData]].</li><li>Let <var>dataLocale</var> be <var>numberFormat</var>.[[DataLocale]].</li><li>Let <var>dataLocaleData</var> be <var>localeData</var>.[[&lt;<var>dataLocale</var>&gt;]].</li><li>Let <var>notationSubPatterns</var> be <var>dataLocaleData</var>.[[notationSubPatterns]].</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>notationSubPatterns</var> is a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> (see <emu-xref href="#sec-intl.numberformat-internal-slots" id="_ref_12"><a href="#sec-intl.numberformat-internal-slots">1.2.3</a></emu-xref>).</li><li>Let <var>notation</var> be <var>numberFormat</var>.[[Notation]].</li><li>If <var>notation</var> is <emu-val>"scientific"</emu-val> or <var>notation</var> is <emu-val>"engineering"</emu-val>, then<ol><li>Return <var>notationSubPatterns</var>.[[scientific]].</li></ol></li><li>Else if <var>exponent</var> is not 0, then<ol><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>notation</var> is <emu-val>"compact"</emu-val>.</li><li>Let <var>compactDisplay</var> be <var>numberFormat</var>.[[CompactDisplay]].</li><li>Let <var>compactPatterns</var> be <var>notationSubPatterns</var>.[[compact]].[[&lt;<var>compactDisplay</var>&gt;]].</li><li>Return <var>compactPatterns</var>.[[&lt;<var>exponent</var>&gt;]].</li></ol></li><li>Else,<ol><li>Return <emu-val>"{number}"</emu-val>.</li></ol></li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>localeData</var> be <emu-xref href="#sec-intl-numberformat-constructor" id="_ref_71"><a href="#sec-intl-numberformat-constructor">%NumberFormat%</a></emu-xref>.[[LocaleData]].</li><li>Let <var>dataLocale</var> be <var>numberFormat</var>.[[DataLocale]].</li><li>Let <var>dataLocaleData</var> be <var>localeData</var>.[[&lt;<var>dataLocale</var>&gt;]].</li><li>Let <var>notationSubPatterns</var> be <var>dataLocaleData</var>.[[notationSubPatterns]].</li><li>Assert: <var>notationSubPatterns</var> is a Record (see <emu-xref href="#sec-intl.numberformat-internal-slots" id="_ref_12"><a href="#sec-intl.numberformat-internal-slots">1.2.3</a></emu-xref>).</li><li>Let <var>notation</var> be <var>numberFormat</var>.[[Notation]].</li><li>If <var>notation</var> is <emu-val>"scientific"</emu-val> or <var>notation</var> is <emu-val>"engineering"</emu-val>, then<ol><li>Return <var>notationSubPatterns</var>.[[scientific]].</li></ol></li><li>Else if <var>exponent</var> is not 0, then<ol><li>Assert: <var>notation</var> is <emu-val>"compact"</emu-val>.</li><li>Let <var>compactDisplay</var> be <var>numberFormat</var>.[[CompactDisplay]].</li><li>Let <var>compactPatterns</var> be <var>notationSubPatterns</var>.[[compact]].[[&lt;<var>compactDisplay</var>&gt;]].</li><li>Return <var>compactPatterns</var>.[[&lt;<var>exponent</var>&gt;]].</li></ol></li><li>Else,<ol><li>Return <emu-val>"{number}"</emu-val>.</li></ol></li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-computeexponent" aoid="ComputeExponent">
@@ -2741,7 +3498,7 @@ li.menu-search-result-term:before {
         The abstract operation ComputeExponent computes an exponent (power of ten) by which to scale <var>x</var> according to the number formatting settings.
         It handles cases such as 999 rounding up to 1000, requiring a different exponent.
       </p>
-      <emu-alg><ol><li>If <var>x</var> = 0, then<ol><li>Return 0.</li></ol></li><li>If <var>x</var> &lt; 0, then<ol><li>Let <var>x</var> = -<var>x</var>.</li></ol></li><li>Let <var>magnitude</var> be the base 10 logarithm of <var>x</var> rounded down to the nearest <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref>.</li><li>Let <var>exponent</var> be <emu-xref aoid="ComputeExponentForMagnitude" id="_ref_94"><a href="#sec-computeexponentformagnitude">ComputeExponentForMagnitude</a></emu-xref>(<var>numberFormat</var>, <var>magnitude</var>).</li><li>Let <var>x</var> be <var>x</var> × 10<sup>-<var>exponent</var></sup>.</li><li>Let <var>formatNumberResult</var> be <emu-xref aoid="FormatNumericToString" id="_ref_95"><a href="#sec-formatnumberstring">FormatNumericToString</a></emu-xref>(<var>numberFormat</var>, <var>x</var>).</li><li>If <var>formatNumberResult</var>.[[RoundedNumber]] = 0, then<ol><li>Return <var>exponent</var>.</li></ol></li><li>Let <var>newMagnitude</var> be the base 10 logarithm of <var>formatNumberResult</var>.[[RoundedNumber]] rounded down to the nearest <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref>.</li><li>If <var>newMagnitude</var> is <var>magnitude</var> - <var>exponent</var>, then<ol><li>Return <var>exponent</var>.</li></ol></li><li>Return <emu-xref aoid="ComputeExponentForMagnitude" id="_ref_96"><a href="#sec-computeexponentformagnitude">ComputeExponentForMagnitude</a></emu-xref>(<var>numberFormat</var>, <var>magnitude</var> + 1).</li></ol></emu-alg>
+      <emu-alg><ol><li>If <var>x</var> = 0, then<ol><li>Return 0.</li></ol></li><li>If <var>x</var> &lt; 0, then<ol><li>Let <var>x</var> = -<var>x</var>.</li></ol></li><li>Let <var>magnitude</var> be the base 10 logarithm of <var>x</var> rounded down to the nearest integer.</li><li>Let <var>exponent</var> be <emu-xref aoid="ComputeExponentForMagnitude" id="_ref_72"><a href="#sec-computeexponentformagnitude">ComputeExponentForMagnitude</a></emu-xref>(<var>numberFormat</var>, <var>magnitude</var>).</li><li>Let <var>x</var> be <var>x</var> × 10<sup>-<var>exponent</var></sup>.</li><li>Let <var>formatNumberResult</var> be <emu-xref aoid="FormatNumericToString" id="_ref_73"><a href="#sec-formatnumberstring">FormatNumericToString</a></emu-xref>(<var>numberFormat</var>, <var>x</var>).</li><li>If <var>formatNumberResult</var>.[[RoundedNumber]] = 0, then<ol><li>Return <var>exponent</var>.</li></ol></li><li>Let <var>newMagnitude</var> be the base 10 logarithm of <var>formatNumberResult</var>.[[RoundedNumber]] rounded down to the nearest integer.</li><li>If <var>newMagnitude</var> is <var>magnitude</var> - <var>exponent</var>, then<ol><li>Return <var>exponent</var>.</li></ol></li><li>Return <emu-xref aoid="ComputeExponentForMagnitude" id="_ref_74"><a href="#sec-computeexponentformagnitude">ComputeExponentForMagnitude</a></emu-xref>(<var>numberFormat</var>, <var>magnitude</var> + 1).</li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-computeexponentformagnitude" aoid="ComputeExponentForMagnitude">
@@ -2749,57 +3506,84 @@ li.menu-search-result-term:before {
       <p>
         The abstract operation ComputeExponentForMagnitude computes an exponent by which to scale a number of the given magnitude (power of ten of the most significant digit) according to the locale and the desired notation (scientific, engineering, or compact).
       </p>
-      <emu-alg><ol><li>Let <var>notation</var> be <var>numberFormat</var>.[[Notation]].</li><li>If <var>notation</var> is <emu-val>"standard"</emu-val>, then<ol><li>Return 0.</li></ol></li><li>Else if <var>notation</var> is <emu-val>"scientific"</emu-val>, then<ol><li>Return <var>magnitude</var>.</li></ol></li><li>Else if <var>notation</var> is <emu-val>"engineering"</emu-val>, then<ol><li>Let <var>thousands</var> be the greatest <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref> that is not greater than <var>magnitude</var> / 3.</li><li>Return <var>thousands</var> × 3.</li></ol></li><li>Else,<ol><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>notation</var> is <emu-val>"compact"</emu-val>.</li><li>Let <var>exponent</var> be an implementation- and locale-dependent (ILD) <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref> by which to scale a number of the given magnitude in compact notation for the current locale.</li><li>Return <var>exponent</var>.</li></ol></li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>notation</var> be <var>numberFormat</var>.[[Notation]].</li><li>If <var>notation</var> is <emu-val>"standard"</emu-val>, then<ol><li>Return 0.</li></ol></li><li>Else if <var>notation</var> is <emu-val>"scientific"</emu-val>, then<ol><li>Return <var>magnitude</var>.</li></ol></li><li>Else if <var>notation</var> is <emu-val>"engineering"</emu-val>, then<ol><li>Let <var>thousands</var> be the greatest integer that is not greater than <var>magnitude</var> / 3.</li><li>Return <var>thousands</var> × 3.</li></ol></li><li>Else,<ol><li>Assert: <var>notation</var> is <emu-val>"compact"</emu-val>.</li><li>Let <var>exponent</var> be an implementation- and locale-dependent (ILD) integer by which to scale a number of the given magnitude in compact notation for the current locale.</li><li>Return <var>exponent</var>.</li></ol></li></ol></emu-alg>
     </emu-clause>
 
 
-    <emu-clause id="sec-runtime-semantics-stringintlmv" type="sdo">
+    <emu-clause id="sec-runtime-semantics-stringintlmv" type="sdo" aoid="StringIntlMV">
       <h1><span class="secnum">1.5.15</span> Runtime Semantics: StringIntlMV</h1>
-      <dl class="header">
-      </dl>
+      <p>The syntax-directed operation StringIntlMV takes no arguments.</p>
       <emu-note><span class="note">Note</span><div class="note-contents">
-        <p>The conversion of a <emu-nt id="_ref_123"><a href="#prod-StringNumericLiteral">StringNumericLiteral</a></emu-nt> to a <emu-xref href="#number-value"><a href="https://tc39.es/ecma262/#number-value">Number value</a></emu-xref> is similar overall to the determination of the NumericValue of a <emu-nt><a href="https://tc39.es/ecma262/#prod-annexB-NumericLiteral">NumericLiteral</a></emu-nt> (see <emu-xref href="#sec-literals-numeric-literals"><a href="https://tc39.es/ecma262/#sec-literals-numeric-literals">11.8.3</a></emu-xref>), but some of the details are different.</p>
+        <p>The conversion of a <emu-nt>StringNumericLiteral</emu-nt> to a Number value is similar overall to the determination of the NumericValue of a <emu-nt>NumericLiteral</emu-nt> (see <emu-xref href="#sec-literals-numeric-literals"></emu-xref>), but some of the details are different.</p>
       </div></emu-note>
-      <emu-grammar><emu-production name="StringNumericLiteral" type="regexp" collapsed="" id="prod-StringNumericLiteral">
-    <emu-nt><a href="#prod-StringNumericLiteral">StringNumericLiteral</a></emu-nt><emu-geq>:::</emu-geq><emu-rhs a="9a4be900"><emu-nt optional=""><a href="https://tc39.es/ecma262/#prod-StrWhiteSpace">StrWhiteSpace</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt></emu-rhs>
-</emu-production></emu-grammar>
+      <p>It is defined piecewise over the following productions:</p>
+      <emu-grammar><emu-production name="StringNumericLiteral" type="regexp" collapsed="">
+    <emu-nt>StringNumericLiteral</emu-nt> <emu-geq>:::</emu-geq> <emu-rhs a="mkvpahdu"><emu-nt optional="">StrWhiteSpace<emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt></emu-rhs>
+</emu-production>
+</emu-grammar>
       <emu-alg><ol><li>Return 0.</li></ol></emu-alg>
       <emu-grammar><emu-production name="StringNumericLiteral" type="regexp" collapsed="">
-    <emu-nt><a href="#prod-StringNumericLiteral">StringNumericLiteral</a></emu-nt><emu-geq>:::</emu-geq><emu-rhs a="fe58c396"><emu-nt optional=""><a href="https://tc39.es/ecma262/#prod-StrWhiteSpace">StrWhiteSpace</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt><emu-nt id="_ref_124"><a href="#prod-StrNumericLiteral">StrNumericLiteral</a></emu-nt><emu-nt optional=""><a href="https://tc39.es/ecma262/#prod-StrWhiteSpace">StrWhiteSpace</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt></emu-rhs>
-</emu-production></emu-grammar>
-      <emu-alg><ol><li>Return StringIntlMV of <emu-nt id="_ref_125"><a href="#prod-StrNumericLiteral">StrNumericLiteral</a></emu-nt>.</li></ol></emu-alg>
-      <emu-grammar><emu-production name="StrNumericLiteral" type="regexp" collapsed="" id="prod-StrNumericLiteral">
-    <emu-nt><a href="#prod-StrNumericLiteral">StrNumericLiteral</a></emu-nt><emu-geq>:::</emu-geq><emu-rhs a="e867b70b"><emu-nt><a href="https://tc39.es/ecma262/#prod-NonDecimalIntegerLiteral">NonDecimalIntegerLiteral</a></emu-nt></emu-rhs>
-</emu-production></emu-grammar>
-      <emu-alg><ol><li>Return MV of <emu-nt><a href="https://tc39.es/ecma262/#prod-NonDecimalIntegerLiteral">NonDecimalIntegerLiteral</a></emu-nt>.</li></ol></emu-alg>
-      <emu-grammar><emu-production name="StrDecimalLiteral" type="regexp" collapsed="" id="prod-StrDecimalLiteral">
-    <emu-nt><a href="#prod-StrDecimalLiteral">StrDecimalLiteral</a></emu-nt><emu-geq>:::</emu-geq><emu-rhs a="d60f01a5"><emu-t>-</emu-t><emu-nt id="_ref_126"><a href="#prod-StrUnsignedDecimalLiteral">StrUnsignedDecimalLiteral</a></emu-nt></emu-rhs>
-</emu-production></emu-grammar>
-      <emu-alg><ol><li>Let <var>a</var> be StringIntlMV of <emu-nt id="_ref_127"><a href="#prod-StrUnsignedDecimalLiteral">StrUnsignedDecimalLiteral</a></emu-nt>.</li><li>If <var>a</var> is 0, return <emu-const>negative-zero</emu-const>.</li><li>If <var>a</var> is <emu-const>positive-infinity</emu-const>, return <emu-const>negative-infinity</emu-const>.</li><li>Return -<var>a</var>.</li></ol></emu-alg>
-      <emu-grammar><emu-production name="StrUnsignedDecimalLiteral" type="regexp" collapsed="" id="prod-StrUnsignedDecimalLiteral">
-    <emu-nt><a href="#prod-StrUnsignedDecimalLiteral">StrUnsignedDecimalLiteral</a></emu-nt><emu-geq>:::</emu-geq><emu-rhs a="4afe8df8"><emu-t>Infinity</emu-t></emu-rhs>
-</emu-production></emu-grammar>
+    <emu-nt>StringNumericLiteral</emu-nt> <emu-geq>:::</emu-geq> <emu-rhs a="_ljdljxm">
+        <emu-nt optional="">StrWhiteSpace<emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt>StrNumericLiteral</emu-nt>
+        <emu-nt optional="">StrWhiteSpace<emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+    </emu-rhs>
+</emu-production>
+</emu-grammar>
+      <emu-alg><ol><li>Return <emu-xref aoid="StringIntlMV" id="_ref_75"><a href="#sec-runtime-semantics-stringintlmv">StringIntlMV</a></emu-xref> of <emu-nt>StrNumericLiteral</emu-nt>.</li></ol></emu-alg>
+      <emu-grammar><emu-production name="StrNumericLiteral" type="regexp" collapsed="">
+    <emu-nt>StrNumericLiteral</emu-nt> <emu-geq>:::</emu-geq> <emu-rhs a="6ge3c7dq"><emu-nt>NonDecimalIntegerLiteral</emu-nt></emu-rhs>
+</emu-production>
+</emu-grammar>
+      <emu-alg><ol><li>Return MV of <emu-nt>NonDecimalIntegerLiteral</emu-nt>.</li></ol></emu-alg>
+      <emu-grammar><emu-production name="StrDecimalLiteral" type="regexp" collapsed="">
+    <emu-nt>StrDecimalLiteral</emu-nt> <emu-geq>:::</emu-geq> <emu-rhs a="1g8bpsll">
+        <emu-t>-</emu-t>
+        <emu-nt>StrUnsignedDecimalLiteral</emu-nt>
+    </emu-rhs>
+</emu-production>
+</emu-grammar>
+      <emu-alg><ol><li>Let <var>a</var> be <emu-xref aoid="StringIntlMV" id="_ref_76"><a href="#sec-runtime-semantics-stringintlmv">StringIntlMV</a></emu-xref> of <emu-nt>StrUnsignedDecimalLiteral</emu-nt>.</li><li>If <var>a</var> is 0, return <emu-const>negative-zero</emu-const>.</li><li>If <var>a</var> is <emu-const>positive-infinity</emu-const>, return <emu-const>negative-infinity</emu-const>.</li><li>Return -<var>a</var>.</li></ol></emu-alg>
+      <emu-grammar><emu-production name="StrUnsignedDecimalLiteral" type="regexp" collapsed="">
+    <emu-nt>StrUnsignedDecimalLiteral</emu-nt> <emu-geq>:::</emu-geq> <emu-rhs a="sv6n-gkb"><emu-t>Infinity</emu-t></emu-rhs>
+</emu-production>
+</emu-grammar>
       <emu-alg><ol><li>Return <emu-const>positive-infinity</emu-const>.</li></ol></emu-alg>
       <emu-grammar><emu-production name="StrUnsignedDecimalLiteral" type="regexp" collapsed="">
-    <emu-nt><a href="#prod-StrUnsignedDecimalLiteral">StrUnsignedDecimalLiteral</a></emu-nt><emu-geq>:::</emu-geq><emu-rhs a="8a89062c"><emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-DecimalDigits">DecimalDigits</a></emu-nt><emu-t>.</emu-t><emu-nt optional=""><a href="https://tc39.es/ecma262/#prod-grammar-notation-DecimalDigits">DecimalDigits</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt><emu-nt optional=""><a href="https://tc39.es/ecma262/#prod-ExponentPart">ExponentPart</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt></emu-rhs>
-</emu-production></emu-grammar>
-      <emu-alg><ol><li>Let <var>a</var> be MV of the first <emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-DecimalDigits">DecimalDigits</a></emu-nt>.</li><li>If the second <emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-DecimalDigits">DecimalDigits</a></emu-nt> is present, then<ol><li>Let <var>b</var> be MV of the second <emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-DecimalDigits">DecimalDigits</a></emu-nt>.</li><li>Let <var>n</var> be the number of code points in the second <emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-DecimalDigits">DecimalDigits</a></emu-nt>.</li></ol></li><li>Else,<ol><li>Let <var>b</var> be 0.</li><li>Let <var>n</var> be 0.</li></ol></li><li>If <emu-nt><a href="https://tc39.es/ecma262/#prod-ExponentPart">ExponentPart</a></emu-nt> is present, let <var>e</var> be MV of <emu-nt><a href="https://tc39.es/ecma262/#prod-ExponentPart">ExponentPart</a></emu-nt>. Otherwise, let <var>e</var> be 0.</li><li>Return (<var>a</var> + (<var>b</var> × 10<sup>-<var>n</var></sup>)) × 10<sup><var>e</var></sup>.</li></ol></emu-alg>
+    <emu-nt>StrUnsignedDecimalLiteral</emu-nt> <emu-geq>:::</emu-geq> <emu-rhs a="iokglhcc">
+        <emu-nt>DecimalDigits</emu-nt>
+        <emu-t>.</emu-t>
+        <emu-nt optional="">DecimalDigits<emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt optional="">ExponentPart<emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+    </emu-rhs>
+</emu-production>
+</emu-grammar>
+      <emu-alg><ol><li>Let <var>a</var> be MV of the first <emu-nt>DecimalDigits</emu-nt>.</li><li>If the second <emu-nt>DecimalDigits</emu-nt> is present, then<ol><li>Let <var>b</var> be MV of the second <emu-nt>DecimalDigits</emu-nt>.</li><li>Let <var>n</var> be the number of code points in the second <emu-nt>DecimalDigits</emu-nt>.</li></ol></li><li>Else,<ol><li>Let <var>b</var> be 0.</li><li>Let <var>n</var> be 0.</li></ol></li><li>If <emu-nt>ExponentPart</emu-nt> is present, let <var>e</var> be MV of <emu-nt>ExponentPart</emu-nt>. Otherwise, let <var>e</var> be 0.</li><li>Return (<var>a</var> + (<var>b</var> × 10<sup>-<var>n</var></sup>)) × 10<sup><var>e</var></sup>.</li></ol></emu-alg>
       <emu-grammar><emu-production name="StrUnsignedDecimalLiteral" type="regexp" collapsed="">
-    <emu-nt><a href="#prod-StrUnsignedDecimalLiteral">StrUnsignedDecimalLiteral</a></emu-nt><emu-geq>:::</emu-geq><emu-rhs a="5cf3aa35"><emu-t>.</emu-t><emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-DecimalDigits">DecimalDigits</a></emu-nt><emu-nt optional=""><a href="https://tc39.es/ecma262/#prod-ExponentPart">ExponentPart</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt></emu-rhs>
-</emu-production></emu-grammar>
-      <emu-alg><ol><li>Let <var>b</var> be MV of <emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-DecimalDigits">DecimalDigits</a></emu-nt>.</li><li>If <emu-nt><a href="https://tc39.es/ecma262/#prod-ExponentPart">ExponentPart</a></emu-nt> is present, let <var>e</var> be MV of <emu-nt><a href="https://tc39.es/ecma262/#prod-ExponentPart">ExponentPart</a></emu-nt>. Otherwise, let <var>e</var> be 0.</li><li>Let <var>n</var> be the number of code points in <emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-DecimalDigits">DecimalDigits</a></emu-nt>.</li><li>Return <var>b</var> × 10<sup><var>e</var> - <var>n</var></sup>.</li></ol></emu-alg>
+    <emu-nt>StrUnsignedDecimalLiteral</emu-nt> <emu-geq>:::</emu-geq> <emu-rhs a="xpoqnclz">
+        <emu-t>.</emu-t>
+        <emu-nt>DecimalDigits</emu-nt>
+        <emu-nt optional="">ExponentPart<emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+    </emu-rhs>
+</emu-production>
+</emu-grammar>
+      <emu-alg><ol><li>Let <var>b</var> be MV of <emu-nt>DecimalDigits</emu-nt>.</li><li>If <emu-nt>ExponentPart</emu-nt> is present, let <var>e</var> be MV of <emu-nt>ExponentPart</emu-nt>. Otherwise, let <var>e</var> be 0.</li><li>Let <var>n</var> be the number of code points in <emu-nt>DecimalDigits</emu-nt>.</li><li>Return <var>b</var> × 10<sup><var>e</var> - <var>n</var></sup>.</li></ol></emu-alg>
       <emu-grammar><emu-production name="StrUnsignedDecimalLiteral" type="regexp" collapsed="">
-    <emu-nt><a href="#prod-StrUnsignedDecimalLiteral">StrUnsignedDecimalLiteral</a></emu-nt><emu-geq>:::</emu-geq><emu-rhs a="24e27af7"><emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-DecimalDigits">DecimalDigits</a></emu-nt><emu-nt optional=""><a href="https://tc39.es/ecma262/#prod-ExponentPart">ExponentPart</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt></emu-rhs>
-</emu-production></emu-grammar>
-      <emu-alg><ol><li>Let <var>a</var> be MV of <emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-DecimalDigits">DecimalDigits</a></emu-nt>.</li><li>If <emu-nt><a href="https://tc39.es/ecma262/#prod-ExponentPart">ExponentPart</a></emu-nt> is present, let <var>e</var> be MV of <emu-nt><a href="https://tc39.es/ecma262/#prod-ExponentPart">ExponentPart</a></emu-nt>. Otherwise, let <var>e</var> be 0.</li><li>Return <var>a</var> × 10<sup><var>e</var></sup>.</li></ol></emu-alg>
+    <emu-nt>StrUnsignedDecimalLiteral</emu-nt> <emu-geq>:::</emu-geq> <emu-rhs a="joj696lw">
+        <emu-nt>DecimalDigits</emu-nt>
+        <emu-nt optional="">ExponentPart<emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+    </emu-rhs>
+</emu-production>
+</emu-grammar>
+      <emu-alg><ol><li>Let <var>a</var> be MV of <emu-nt>DecimalDigits</emu-nt>.</li><li>If <emu-nt>ExponentPart</emu-nt> is present, let <var>e</var> be MV of <emu-nt>ExponentPart</emu-nt>. Otherwise, let <var>e</var> be 0.</li><li>Return <var>a</var> × 10<sup><var>e</var></sup>.</li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-tointlmathematicalvalue" aoid="ToIntlMathematicalValue">
       <h1><span class="secnum">1.5.16</span> ToIntlMathematicalValue ( <var>value</var> )</h1>
       <p>
-        The abstract operation ToIntlMathematicalValue takes argument <var>value</var>. It returns <var>value</var> converted to an <dfn id="intl-mathematical-value">Intl mathematical value</dfn>, which is a <emu-xref href="#mathematical-value"><a href="https://tc39.es/ecma262/#mathematical-value">mathematical value</a></emu-xref> together with <emu-const>positive-infinity</emu-const>, <emu-const>negative-infinity</emu-const>, <emu-const>not-a-number</emu-const>, and <emu-const>negative-zero</emu-const>. This abstract operation is similar to <emu-xref href="#sec-tonumeric"><a href="https://tc39.es/ecma262/#sec-tonumeric">7.1.3</a></emu-xref>, but a <emu-xref href="#mathematical-value"><a href="https://tc39.es/ecma262/#mathematical-value">mathematical value</a></emu-xref> can be returned instead of a Number or BigInt, so that exact decimal values can be represented. The following steps are taken:
+        The abstract operation ToIntlMathematicalValue takes argument <var>value</var>. It returns <var>value</var> converted to an <dfn id="intl-mathematical-value">Intl mathematical value</dfn>, which is a mathematical value together with <emu-const>positive-infinity</emu-const>, <emu-const>negative-infinity</emu-const>, <emu-const>not-a-number</emu-const>, and <emu-const>negative-zero</emu-const>. This abstract operation is similar to <emu-xref href="#sec-tonumeric"></emu-xref>, but a mathematical value can be returned instead of a Number or BigInt, so that exact decimal values can be represented. The following steps are taken:
       </p>
-      <emu-alg><ol><li>Let <var>primValue</var> be ?&nbsp;<emu-xref aoid="ToPrimitive" id="_ref_97"><a href="https://tc39.es/ecma262/#sec-toprimitive">ToPrimitive</a></emu-xref>(<var>value</var>, <emu-const>number</emu-const>).</li><li>If <emu-xref aoid="Type" id="_ref_98"><a href="https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>primValue</var>) is BigInt, return <emu-xref href="#ℝ"><a href="https://tc39.es/ecma262/#ℝ">ℝ</a></emu-xref>(<var>primValue</var>).</li><li>If <emu-xref aoid="Type" id="_ref_99"><a href="https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>primValue</var>) is String,<ol><li>Let <var>str</var> be <var>primValue</var>.</li></ol></li><li>Else,<ol><li>Let <var>x</var> be ?&nbsp;<emu-xref aoid="ToNumber" id="_ref_100"><a href="https://tc39.es/ecma262/#sec-tonumber">ToNumber</a></emu-xref>(<var>primValue</var>).</li><li>If <var>x</var> is <emu-val>-0</emu-val><sub>𝔽</sub>, return <emu-const>negative-zero</emu-const>.</li><li>Let <var>str</var> be ! <emu-xref aoid="Number::toString" id="_ref_101"><a href="https://tc39.es/ecma262/#sec-numeric-types-number-tostring">Number::toString</a></emu-xref>(<var>x</var>).</li></ol></li><li>Let <var>text</var> be !&nbsp;StringToCodePoints(<var>str</var>).</li><li>Let <var>literal</var> be ParseText(<var>text</var>, <emu-nt id="_ref_128"><a href="#prod-StringNumericLiteral">StringNumericLiteral</a></emu-nt>).</li><li>If <var>literal</var> is a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> of errors, return <emu-const>not-a-number</emu-const>.</li><li>Return the StringIntlMV of <var>literal</var>.</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>primValue</var> be ?&nbsp;ToPrimitive(<var>value</var>, <emu-const>number</emu-const>).</li><li>If Type(<var>primValue</var>) is BigInt, return ℝ(<var>primValue</var>).</li><li>If Type(<var>primValue</var>) is String,<ol><li>Let <var>str</var> be <var>primValue</var>.</li></ol></li><li>Else,<ol><li>Let <var>x</var> be ?&nbsp;ToNumber(<var>primValue</var>).</li><li>If <var>x</var> is <emu-val>-0</emu-val><sub>𝔽</sub>, return <emu-const>negative-zero</emu-const>.</li><li>Let <var>str</var> be !&nbsp;Number::toString(<var>x</var>).</li></ol></li><li>Let <var>text</var> be !&nbsp;StringToCodePoints(<var>str</var>).</li><li>Let <var>literal</var> be ParseText(<var>text</var>, <emu-nt>StringNumericLiteral</emu-nt>).</li><li>If <var>literal</var> is a List of errors, return <emu-const>not-a-number</emu-const>.</li><li>Let <var>intlMV</var> be the <emu-xref aoid="StringIntlMV" id="_ref_77"><a href="#sec-runtime-semantics-stringintlmv">StringIntlMV</a></emu-xref> of <var>literal</var>.</li><li>If <var>intlMV</var> is a mathematical value, then<ol><li>Let <var>rounded</var> be RoundMVResult(abs(<var>intlMV</var>)).</li><li>If <var>rounded</var> is <emu-val>+∞</emu-val><sub>𝔽</sub> and <var>intlMV</var> &lt; 0, return <emu-const>negative-infinity</emu-const>.</li><li>If <var>rounded</var> is <emu-val>+∞</emu-val><sub>𝔽</sub>, return <emu-const>positive-infinity</emu-const>.</li><li>If <var>rounded</var> is <emu-val>+0</emu-val><sub>𝔽</sub> and <var>intlMV</var> &lt; 0, return <emu-const>negative-zero</emu-const>.</li><li>If <var>rounded</var> is <emu-val>+0</emu-val><sub>𝔽</sub>, return 0.</li></ol></li><li>Return <var>intlMV</var>.</li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-getunsignedroundingmode" aoid="GetUnsignedRoundingMode">
@@ -2906,34 +3690,37 @@ li.menu-search-result-term:before {
     <emu-clause id="sec-applyunsignedroundingmode" aoid="ApplyUnsignedRoundingMode">
       <h1><span class="secnum">1.5.18</span> ApplyUnsignedRoundingMode ( <var>x</var>, <var>r1</var>, <var>r2</var>, <var>unsignedRoundingMode</var> )</h1>
       <p>
-        The abstract operation ApplyUnsignedRoundingMode considers <var>x</var> (a <emu-xref href="#mathematical-value"><a href="https://tc39.es/ecma262/#mathematical-value">mathematical value</a></emu-xref>), bracketed below by <var>r1</var> (a <emu-xref href="#mathematical-value"><a href="https://tc39.es/ecma262/#mathematical-value">mathematical value</a></emu-xref>) and above by <var>r2</var> (a <emu-xref href="#mathematical-value"><a href="https://tc39.es/ecma262/#mathematical-value">mathematical value</a></emu-xref>), and returns either <var>r1</var> or <var>r2</var> according to <var>unsignedRoundingMode</var> (a specification type from the <emu-val>Unsigned Rounding Mode</emu-val> column of <emu-xref href="#table-intl-unsigned-rounding-modes" id="_ref_16"><a href="#table-intl-unsigned-rounding-modes">Table 4</a></emu-xref> or <emu-val>undefined</emu-val>). The following steps are taken:
+        The abstract operation ApplyUnsignedRoundingMode considers <var>x</var> (a mathematical value), bracketed below by <var>r1</var> (a mathematical value) and above by <var>r2</var> (a mathematical value), and returns either <var>r1</var> or <var>r2</var> according to <var>unsignedRoundingMode</var> (a specification type from the <emu-val>Unsigned Rounding Mode</emu-val> column of <emu-xref href="#table-intl-unsigned-rounding-modes" id="_ref_16"><a href="#table-intl-unsigned-rounding-modes">Table 4</a></emu-xref> or <emu-val>undefined</emu-val>). The following steps are taken:
       </p>
-      <emu-alg><ol><li>If <var>x</var> is equal to <var>r1</var>, return <var>r1</var>.</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>r1</var> &lt; <var>x</var> &lt; <var>r2</var>.</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>unsignedRoundingMode</var> is not <emu-val>undefined</emu-val>.</li><li>If <var>unsignedRoundingMode</var> is <emu-const>zero</emu-const>, return <var>r1</var>.</li><li>If <var>unsignedRoundingMode</var> is <emu-const>infinity</emu-const>, return <var>r2</var>.</li><li>Let <var>d1</var> be <emu-eqn class="inline"><var>x</var> – <var>r1</var></emu-eqn>.</li><li>Let <var>d2</var> be <emu-eqn class="inline"><var>r2</var> – <var>x</var></emu-eqn>.</li><li>If <var>d1</var> &lt; <var>d2</var>, return <var>r1</var>.</li><li>If <var>d2</var> &lt; <var>d1</var>, return <var>r2</var>.</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>d1</var> is equal to <var>d2</var>.</li><li>If <var>unsignedRoundingMode</var> is <emu-const>half-zero</emu-const>, return <var>r1</var>.</li><li>If <var>unsignedRoundingMode</var> is <emu-const>half-infinity</emu-const>, return <var>r2</var>.</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>unsignedRoundingMode</var> is <emu-const>half-even</emu-const>.</li><li>Let <var>cardinality</var> be <emu-eqn class="inline">(<var>r1</var> / (<var>r2</var> – <var>r1</var>)) <emu-xref aoid="modulo"><a href="https://tc39.es/ecma262/#eqn-modulo">modulo</a></emu-xref> 2</emu-eqn>.</li><li>If <var>cardinality</var> is 0, return <var>r1</var>.</li><li>Return <var>r2</var>.</li></ol></emu-alg>
+      <emu-alg><ol><li>If <var>x</var> is equal to <var>r1</var>, return <var>r1</var>.</li><li>Assert: <var>r1</var> &lt; <var>x</var> &lt; <var>r2</var>.</li><li>Assert: <var>unsignedRoundingMode</var> is not <emu-val>undefined</emu-val>.</li><li>If <var>unsignedRoundingMode</var> is <emu-const>zero</emu-const>, return <var>r1</var>.</li><li>If <var>unsignedRoundingMode</var> is <emu-const>infinity</emu-const>, return <var>r2</var>.</li><li>Let <var>d1</var> be <emu-eqn class="inline"><var>x</var> – <var>r1</var></emu-eqn>.</li><li>Let <var>d2</var> be <emu-eqn class="inline"><var>r2</var> – <var>x</var></emu-eqn>.</li><li>If <var>d1</var> &lt; <var>d2</var>, return <var>r1</var>.</li><li>If <var>d2</var> &lt; <var>d1</var>, return <var>r2</var>.</li><li>Assert: <var>d1</var> is equal to <var>d2</var>.</li><li>If <var>unsignedRoundingMode</var> is <emu-const>half-zero</emu-const>, return <var>r1</var>.</li><li>If <var>unsignedRoundingMode</var> is <emu-const>half-infinity</emu-const>, return <var>r2</var>.</li><li>Assert: <var>unsignedRoundingMode</var> is <emu-const>half-even</emu-const>.</li><li>Let <var>cardinality</var> be <emu-eqn class="inline">(<var>r1</var> / (<var>r2</var> – <var>r1</var>)) modulo 2</emu-eqn>.</li><li>If <var>cardinality</var> is 0, return <var>r1</var>.</li><li>Return <var>r2</var>.</li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-partitionnumberrangepattern" aoid="PartitionNumberRangePattern">
       <h1><span class="secnum">1.5.19</span> PartitionNumberRangePattern ( <var>numberFormat</var>, <var>x</var>, <var>y</var> )</h1>
       <p>
-        The abstract operation PartitionNumberRangePattern creates the parts for a localized number range according to <var>x</var> (which must be an <emu-xref href="#intl-mathematical-value" id="_ref_102"><a href="#intl-mathematical-value">Intl mathematical value</a></emu-xref>), <var>y</var> (which must be an <emu-xref href="#intl-mathematical-value" id="_ref_103"><a href="#intl-mathematical-value">Intl mathematical value</a></emu-xref>), and the formatting options of <var>numberFormat</var> (which must be an object initialized as NumberFormat). The following steps are taken:
+        The abstract operation PartitionNumberRangePattern creates the parts for a localized number range according to <var>x</var> (which must be an <emu-xref href="#intl-mathematical-value" id="_ref_78"><a href="#intl-mathematical-value">Intl mathematical value</a></emu-xref>), <var>y</var> (which must be an <emu-xref href="#intl-mathematical-value" id="_ref_79"><a href="#intl-mathematical-value">Intl mathematical value</a></emu-xref>), and the formatting options of <var>numberFormat</var> (which must be an object initialized as NumberFormat). The following steps are taken:
       </p>
-      <emu-alg><ol><li>If <var>x</var> is <emu-const>not-a-number</emu-const> or <var>y</var> is <emu-const>not-a-number</emu-const>, throw a <emu-val>RangeError</emu-val> exception.</li><li>Let <var>result</var> be a new empty <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref>.</li><li>Let <var>xResult</var> be ?&nbsp;<emu-xref aoid="PartitionNumberPattern" id="_ref_104"><a href="#sec-partitionnumberpattern">PartitionNumberPattern</a></emu-xref>(<var>numberFormat</var>, <var>x</var>).</li><li>Let <var>yResult</var> be ?&nbsp;<emu-xref aoid="PartitionNumberPattern" id="_ref_105"><a href="#sec-partitionnumberpattern">PartitionNumberPattern</a></emu-xref>(<var>numberFormat</var>, <var>y</var>).</li><li>If <var>xResult</var> is equal to <var>yResult</var>, then<ol><li>Let <var>appxResult</var> be ?&nbsp;<emu-xref aoid="FormatApproximately" id="_ref_106"><a href="#sec-formatapproximately">FormatApproximately</a></emu-xref>(<var>numberFormat</var>, <var>xResult</var>).</li><li>For each <var>r</var> in <var>appxResult</var>, do<ol><li>Set <var>r</var>.[[Source]] to <emu-val>"shared"</emu-val>.</li></ol></li><li>Return <var>appxResult</var>.</li></ol></li><li>For each <var>r</var> in <var>xResult</var>, do<ol><li>Set <var>r</var>.[[Source]] to <emu-val>"startRange"</emu-val>.</li></ol></li><li>Add all elements in <var>xResult</var> to <var>result</var> in order.</li><li>Let <var>rangeSeparator</var> be an ILND String value used to separate two numbers.</li><li>Append a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]]: <emu-val>"literal"</emu-val>, [[Value]]: <var>rangeSeparator</var>, [[Source]]: <emu-val>"shared"</emu-val> } element to <var>result</var>.</li><li>For each <var>r</var> in <var>yResult</var>, do<ol><li>Set <var>r</var>.[[Source]] to <emu-val>"endRange"</emu-val>.</li></ol></li><li>Add all elements in <var>yResult</var> to <var>result</var> in order.</li><li>Return !&nbsp;<emu-xref aoid="CollapseNumberRange" id="_ref_107"><a href="#sec-collapsenumberrange">CollapseNumberRange</a></emu-xref>(<var>result</var>).</li></ol></emu-alg>
+      <emu-alg><ol><li>If <var>x</var> is <emu-const>not-a-number</emu-const> or <var>y</var> is <emu-const>not-a-number</emu-const>, throw a <emu-val>RangeError</emu-val> exception.</li><li>Let <var>result</var> be a new empty List.</li><li>Let <var>xResult</var> be ?&nbsp;<emu-xref aoid="PartitionNumberPattern" id="_ref_80"><a href="#sec-partitionnumberpattern">PartitionNumberPattern</a></emu-xref>(<var>numberFormat</var>, <var>x</var>).</li><li>Let <var>yResult</var> be ?&nbsp;<emu-xref aoid="PartitionNumberPattern" id="_ref_81"><a href="#sec-partitionnumberpattern">PartitionNumberPattern</a></emu-xref>(<var>numberFormat</var>, <var>y</var>).</li><li>If <var>xResult</var> is equal to <var>yResult</var>, then<ol><li>Let <var>appxResult</var> be ?&nbsp;<emu-xref aoid="FormatApproximately" id="_ref_82"><a href="#sec-formatapproximately">FormatApproximately</a></emu-xref>(<var>numberFormat</var>, <var>xResult</var>).</li><li>For each <var>r</var> in <var>appxResult</var>, do<ol><li>Set <var>r</var>.[[Source]] to <emu-val>"shared"</emu-val>.</li></ol></li><li>Return <var>appxResult</var>.</li></ol></li><li>For each <var>r</var> in <var>xResult</var>, do<ol><li>Set <var>r</var>.[[Source]] to <emu-val>"startRange"</emu-val>.</li></ol></li><li>Add all elements in <var>xResult</var> to <var>result</var> in order.</li><li>Let <var>rangeSeparator</var> be an ILND String value used to separate two numbers.</li><li>Append a new Record { [[Type]]: <emu-val>"literal"</emu-val>, [[Value]]: <var>rangeSeparator</var>, [[Source]]: <emu-val>"shared"</emu-val> } element to <var>result</var>.</li><li>For each <var>r</var> in <var>yResult</var>, do<ol><li>Set <var>r</var>.[[Source]] to <emu-val>"endRange"</emu-val>.</li></ol></li><li>Add all elements in <var>yResult</var> to <var>result</var> in order.</li><li>Return !&nbsp;<emu-xref aoid="CollapseNumberRange" id="_ref_83"><a href="#sec-collapsenumberrange">CollapseNumberRange</a></emu-xref>(<var>result</var>).</li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-formatapproximately" aoid="FormatApproximately">
       <h1><span class="secnum">1.5.20</span> FormatApproximately ( <var>numberFormat</var>, <var>result</var> )</h1>
       <p>
-        The FormatApproximately abstract operation modifies <var>result</var>, which must be a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> of <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> values as described in <emu-xref aoid="PartitionNumberPattern" id="_ref_108"><a href="#sec-partitionnumberpattern">PartitionNumberPattern</a></emu-xref>, by adding a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> for the approximately sign, which may depend on <var>numberFormat</var> (which must be an object initialized as NumberFormat). The following steps are taken:
+        The FormatApproximately abstract operation modifies <var>result</var>, which must be a List of Record values as described in <emu-xref aoid="PartitionNumberPattern" id="_ref_84"><a href="#sec-partitionnumberpattern">PartitionNumberPattern</a></emu-xref>, by adding a new Record for the approximately sign, which may depend on <var>numberFormat</var> (which must be an object initialized as NumberFormat). The following steps are taken:
       </p>
-      <emu-alg><ol><li>Let <var>i</var> be an index into <var>result</var>, determined by an implementation-defined algorithm based on <var>numberFormat</var> and <var>result</var>.</li><li>Let <var>approximatelySign</var> be an ILND String value used to signify that a number is approximate.</li><li>Insert a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Type]]: <emu-val>"approximatelySign"</emu-val>, [[Value]]: <var>approximatelySign</var> } at index <var>i</var> in <var>result</var>.</li><li>Return <var>result</var>.</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>i</var> be an index into <var>result</var>, determined by an implementation-defined algorithm based on <var>numberFormat</var> and <var>result</var>.</li><li>Let <var>approximatelySign</var> be an ILND String value used to signify that a number is approximate.</li><li>If <var>approximatelySign</var> is not empty, insert a new Record { [[Type]]: <emu-val>"approximatelySign"</emu-val>, [[Value]]: <var>approximatelySign</var> } at index <var>i</var> in <var>result</var>.</li><li>Return <var>result</var>.</li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-collapsenumberrange" aoid="CollapseNumberRange">
       <h1><span class="secnum">1.5.21</span> CollapseNumberRange ( <var>result</var> )</h1>
       <p>
-        The CollapseNumberRange abstract operation modifies <var>result</var>, which must be a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> of <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> values as described in <emu-xref aoid="PartitionNumberRangePattern" id="_ref_109"><a href="#sec-partitionnumberrangepattern">PartitionNumberRangePattern</a></emu-xref>, by removing redundant information, and returns the resulting <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref>. The algorithm is implementation dependent, but it must not introduce ambiguity: the resulting list after modification should be unique for all pairs <var>x</var> and <var>y</var>.
+        The CollapseNumberRange abstract operation modifies <var>result</var>, which must be a List of Record values as described in <emu-xref aoid="PartitionNumberRangePattern" id="_ref_85"><a href="#sec-partitionnumberrangepattern">PartitionNumberRangePattern</a></emu-xref>, by removing redundant information, and returns the resulting List. The algorithm is implementation dependent, but it must not introduce ambiguity: the resulting list after modification should be unique for all pairs <var>x</var> and <var>y</var>.
       </p>
       <p>
         For example, an implementation may choose to remove the currency symbol following the range separator, to produce "$3–5" instead of "$3–$5".
+      </p>
+      <p>
+        The implementation may choose to modify symbols for grammatical correctness; for example, "0.5 miles–1 mile" may become "0.5–1 miles".
       </p>
       <p>
         Returning <var>result</var> unmodified is guaranteed to be a correct implementation of CollapseNumberRange.
@@ -2944,20 +3731,20 @@ li.menu-search-result-term:before {
       <h1><span class="secnum">1.5.22</span> FormatNumericRange( <var>numberFormat</var>, <var>x</var>, <var>y</var> )</h1>
 
       <p>
-        The FormatNumericRange abstract operation is called with arguments <var>numberFormat</var> (which must be an object initialized as a NumberFormat), <var>x</var> (which must be an <emu-xref href="#intl-mathematical-value" id="_ref_110"><a href="#intl-mathematical-value">Intl mathematical value</a></emu-xref>), and <var>y</var> (which must be an <emu-xref href="#intl-mathematical-value" id="_ref_111"><a href="#intl-mathematical-value">Intl mathematical value</a></emu-xref> greater than or equal to <var>x</var>), and performs the following steps:
+        The FormatNumericRange abstract operation is called with arguments <var>numberFormat</var> (which must be an object initialized as a NumberFormat), <var>x</var> (which must be an <emu-xref href="#intl-mathematical-value" id="_ref_86"><a href="#intl-mathematical-value">Intl mathematical value</a></emu-xref>), and <var>y</var> (which must be an <emu-xref href="#intl-mathematical-value" id="_ref_87"><a href="#intl-mathematical-value">Intl mathematical value</a></emu-xref> greater than or equal to <var>x</var>), and performs the following steps:
       </p>
 
-      <emu-alg><ol><li>Let <var>parts</var> be ?&nbsp;<emu-xref aoid="PartitionNumberRangePattern" id="_ref_112"><a href="#sec-partitionnumberrangepattern">PartitionNumberRangePattern</a></emu-xref>(<var>numberFormat</var>, <var>x</var>, <var>y</var>).</li><li>Let <var>result</var> be the empty String.</li><li>For each <var>part</var> in <var>parts</var>, do<ol><li>Set <var>result</var> to the <emu-xref href="#sec-ecmascript-language-types-string-type"><a href="https://tc39.es/ecma262/#sec-ecmascript-language-types-string-type">string-concatenation</a></emu-xref> of <var>result</var> and <var>part</var>.[[Value]].</li></ol></li><li>Return <var>result</var>.</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>parts</var> be ?&nbsp;<emu-xref aoid="PartitionNumberRangePattern" id="_ref_88"><a href="#sec-partitionnumberrangepattern">PartitionNumberRangePattern</a></emu-xref>(<var>numberFormat</var>, <var>x</var>, <var>y</var>).</li><li>Let <var>result</var> be the empty String.</li><li>For each <var>part</var> in <var>parts</var>, do<ol><li>Set <var>result</var> to the string-concatenation of <var>result</var> and <var>part</var>.[[Value]].</li></ol></li><li>Return <var>result</var>.</li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-formatnumericrangetoparts" aoid="FormatNumericRangeToParts">
       <h1><span class="secnum">1.5.23</span> FormatNumericRangeToParts( <var>numberFormat</var>, <var>x</var>, <var>y</var> )</h1>
 
       <p>
-        The FormatNumericRangeToParts abstract operation is called with arguments <var>numberFormat</var> (which must be an object initialized as a NumberFormat), <var>x</var> (which must be an <emu-xref href="#intl-mathematical-value" id="_ref_113"><a href="#intl-mathematical-value">Intl mathematical value</a></emu-xref>), and <var>y</var> (which must be an <emu-xref href="#intl-mathematical-value" id="_ref_114"><a href="#intl-mathematical-value">Intl mathematical value</a></emu-xref> greater than or equal to <var>x</var>), and performs the following steps:
+        The FormatNumericRangeToParts abstract operation is called with arguments <var>numberFormat</var> (which must be an object initialized as a NumberFormat), <var>x</var> (which must be an <emu-xref href="#intl-mathematical-value" id="_ref_89"><a href="#intl-mathematical-value">Intl mathematical value</a></emu-xref>), and <var>y</var> (which must be an <emu-xref href="#intl-mathematical-value" id="_ref_90"><a href="#intl-mathematical-value">Intl mathematical value</a></emu-xref> greater than or equal to <var>x</var>), and performs the following steps:
       </p>
 
-      <emu-alg><ol><li>Let <var>parts</var> be ?&nbsp;<emu-xref aoid="PartitionNumberRangePattern" id="_ref_115"><a href="#sec-partitionnumberrangepattern">PartitionNumberRangePattern</a></emu-xref>(<var>numberFormat</var>, <var>x</var>, <var>y</var>).</li><li>Let <var>result</var> be <emu-xref aoid="ArrayCreate" id="_ref_116"><a href="https://tc39.es/ecma262/#sec-arraycreate">ArrayCreate</a></emu-xref>(0).</li><li>Let <var>n</var> be 0.</li><li>For each <var>part</var> in <var>parts</var>, do<ol><li>Let <var>O</var> be <emu-xref aoid="ObjectCreate" id="_ref_117"><a href="https://tc39.es/ecma262/#sec-objectcreate">ObjectCreate</a></emu-xref>(<emu-xref href="#sec-properties-of-the-object-prototype-object"><a href="https://tc39.es/ecma262/#sec-properties-of-the-object-prototype-object">%ObjectPrototype%</a></emu-xref>).</li><li>Perform !&nbsp;<emu-xref aoid="CreateDataPropertyOrThrow" id="_ref_118"><a href="https://tc39.es/ecma262/#sec-createdatapropertyorthrow">CreateDataPropertyOrThrow</a></emu-xref>(<var>O</var>, <emu-val>"type"</emu-val>, <var>part</var>.[[Type]]).</li><li>Perform !&nbsp;<emu-xref aoid="CreateDataPropertyOrThrow" id="_ref_119"><a href="https://tc39.es/ecma262/#sec-createdatapropertyorthrow">CreateDataPropertyOrThrow</a></emu-xref>(<var>O</var>, <emu-val>"value"</emu-val>, <var>part</var>.[[Value]]).</li><li>Perform !&nbsp;<emu-xref aoid="CreateDataPropertyOrThrow" id="_ref_120"><a href="https://tc39.es/ecma262/#sec-createdatapropertyorthrow">CreateDataPropertyOrThrow</a></emu-xref>(<var>O</var>, <emu-val>"source"</emu-val>, <var>part</var>.[[Source]]).</li><li>Perform !&nbsp;<emu-xref aoid="CreateDataPropertyOrThrow" id="_ref_121"><a href="https://tc39.es/ecma262/#sec-createdatapropertyorthrow">CreateDataPropertyOrThrow</a></emu-xref>(<var>result</var>, !&nbsp;<emu-xref aoid="ToString" id="_ref_122"><a href="https://tc39.es/ecma262/#sec-tostring">ToString</a></emu-xref>(<var>n</var>), <var>O</var>).</li><li>Increment <var>n</var> by 1.</li></ol></li><li>Return <var>result</var>.</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>parts</var> be ?&nbsp;<emu-xref aoid="PartitionNumberRangePattern" id="_ref_91"><a href="#sec-partitionnumberrangepattern">PartitionNumberRangePattern</a></emu-xref>(<var>numberFormat</var>, <var>x</var>, <var>y</var>).</li><li>Let <var>result</var> be ArrayCreate(0).</li><li>Let <var>n</var> be 0.</li><li>For each <var>part</var> in <var>parts</var>, do<ol><li>Let <var>O</var> be ObjectCreate(%ObjectPrototype%).</li><li>Perform !&nbsp;CreateDataPropertyOrThrow(<var>O</var>, <emu-val>"type"</emu-val>, <var>part</var>.[[Type]]).</li><li>Perform !&nbsp;CreateDataPropertyOrThrow(<var>O</var>, <emu-val>"value"</emu-val>, <var>part</var>.[[Value]]).</li><li>Perform !&nbsp;CreateDataPropertyOrThrow(<var>O</var>, <emu-val>"source"</emu-val>, <var>part</var>.[[Source]]).</li><li>Perform !&nbsp;CreateDataPropertyOrThrow(<var>result</var>, !&nbsp;ToString(<var>n</var>), <var>O</var>).</li><li>Increment <var>n</var> by 1.</li></ol></li><li>Return <var>result</var>.</li></ol></emu-alg>
     </emu-clause>
   </emu-clause>
 </emu-clause>

--- a/out/pluralrules/diff.html
+++ b/out/pluralrules/diff.html
@@ -1,6 +1,88 @@
 <!doctype html>
-<head><meta charset="utf-8"><script type="application/json" id="menu-search-biblio">[{"type":"term","term":"%PluralRules%","refId":"sec-intl-pluralrules-constructor","referencingIds":[],"namespace":"<no location>","location":"","key":"%PluralRules%"},{"type":"clause","id":"sec-intl.pluralrules","aoid":null,"title":"Intl.PluralRules ( [ locales [ , options ] ] )","titleHTML":"Intl.PluralRules ( [ <var>locales</var> [ , <var>options</var> ] ] )","number":"1.1.1","namespace":"<no location>","location":"","referencingIds":[],"key":"Intl.PluralRules ( [ locales [ , options ] ] )"},{"type":"op","aoid":"InitializePluralRules","refId":"sec-initializepluralrules","location":"","referencingIds":[],"key":"InitializePluralRules"},{"type":"clause","id":"sec-initializepluralrules","aoid":"InitializePluralRules","title":"InitializePluralRules ( pluralRules, locales, options )","titleHTML":"InitializePluralRules ( <var>pluralRules</var>, <var>locales</var>, <var>options</var> )","number":"1.1.2","namespace":"<no location>","location":"","referencingIds":["_ref_3"],"key":"InitializePluralRules ( pluralRules, locales, options )"},{"type":"clause","id":"sec-intl-pluralrules-constructor","aoid":null,"title":"The Intl.PluralRules Constructor","titleHTML":"The Intl.PluralRules Constructor","number":"1.1","namespace":"<no location>","location":"","referencingIds":["_ref_4","_ref_5","_ref_6","_ref_8","_ref_9"],"key":"The Intl.PluralRules Constructor"},{"type":"clause","id":"sec-intl.pluralrules.prototype","aoid":null,"title":"Intl.PluralRules.prototype","titleHTML":"Intl.PluralRules.prototype","number":"1.2.1","namespace":"<no location>","location":"","referencingIds":[],"key":"Intl.PluralRules.prototype"},{"type":"clause","id":"sec-intl.pluralrules.supportedlocalesof","aoid":null,"title":"Intl.PluralRules.supportedLocalesOf ( locales [ , options ] )","titleHTML":"Intl.PluralRules.supportedLocalesOf ( <var>locales</var> [ , <var>options</var> ] )","number":"1.2.2","namespace":"<no location>","location":"","referencingIds":[],"key":"Intl.PluralRules.supportedLocalesOf ( locales [ , options ] )"},{"type":"clause","id":"sec-intl.pluralrules-internal-slots","aoid":null,"title":"Internal slots","titleHTML":"Internal slots","number":"1.2.3","namespace":"<no location>","location":"","referencingIds":[],"key":"Internal slots"},{"type":"clause","id":"sec-properties-of-intl-pluralrules-constructor","aoid":null,"title":"Properties of the Intl.PluralRules Constructor","titleHTML":"Properties of the Intl.PluralRules Constructor","number":"1.2","namespace":"<no location>","location":"","referencingIds":[],"key":"Properties of the Intl.PluralRules Constructor"},{"type":"term","term":"%PluralRules.prototype%","refId":"sec-properties-of-intl-pluralrules-prototype-object","referencingIds":[],"namespace":"<no location>","location":"","key":"%PluralRules.prototype%"},{"type":"clause","id":"sec-intl.pluralrules.prototype.constructor","aoid":null,"title":"Intl.PluralRules.prototype.constructor","titleHTML":"Intl.PluralRules.prototype.constructor","number":"1.3.1","namespace":"<no location>","location":"","referencingIds":[],"key":"Intl.PluralRules.prototype.constructor"},{"type":"clause","id":"sec-intl.pluralrules.prototype-tostringtag","aoid":null,"title":"Intl.PluralRules.prototype [ @@toStringTag ]","titleHTML":"Intl.PluralRules.prototype [ @@toStringTag ]","number":"1.3.2","namespace":"<no location>","location":"","referencingIds":[],"key":"Intl.PluralRules.prototype [ @@toStringTag ]"},{"type":"clause","id":"sec-intl.pluralrules.prototype.select","aoid":null,"title":"Intl.PluralRules.prototype.select ( value )","titleHTML":"Intl.PluralRules.prototype.select ( <var>value</var> )","number":"1.3.3","namespace":"<no location>","location":"","referencingIds":[],"key":"Intl.PluralRules.prototype.select ( value )"},{"type":"clause","id":"sec-intl.pluralrules.prototype.selectrange","aoid":null,"title":"Intl.PluralRules.prototype.selectRange ( start, end )","titleHTML":"Intl.PluralRules.prototype.selectRange ( <var>start</var>, <var>end</var> )","number":"1.3.4","namespace":"<no location>","location":"","referencingIds":[],"key":"Intl.PluralRules.prototype.selectRange ( start, end )"},{"type":"table","id":"table-pluralrules-resolvedoptions-properties","number":1,"caption":"Table 1: Resolved Options of PluralRules Instances","referencingIds":["_ref_0"],"namespace":"<no location>","location":"","key":"Table 1: Resolved Options of PluralRules Instances"},{"type":"clause","id":"sec-intl.pluralrules.prototype.resolvedoptions","aoid":null,"title":"Intl.PluralRules.prototype.resolvedOptions ( )","titleHTML":"Intl.PluralRules.prototype.resolvedOptions ( )","number":"1.3.5","namespace":"<no location>","location":"","referencingIds":[],"key":"Intl.PluralRules.prototype.resolvedOptions ( )"},{"type":"clause","id":"sec-properties-of-intl-pluralrules-prototype-object","aoid":null,"title":"Properties of the Intl.PluralRules Prototype Object","titleHTML":"Properties of the Intl.PluralRules Prototype Object","number":"1.3","namespace":"<no location>","location":"","referencingIds":["_ref_7","_ref_24"],"key":"Properties of the Intl.PluralRules Prototype Object"},{"type":"clause","id":"sec-properties-of-intl-pluralrules-instances","aoid":null,"title":"Properties of Intl.PluralRules Instances","titleHTML":"Properties of Intl.PluralRules Instances","number":"1.4","namespace":"<no location>","location":"","referencingIds":[],"key":"Properties of Intl.PluralRules Instances"},{"type":"table","id":"table-plural-operands","number":2,"caption":"Table 2: Plural Rules Operands Record Fields","referencingIds":[],"namespace":"<no location>","location":"","key":"Table 2: Plural Rules Operands Record Fields"},{"type":"clause","id":"sec-getoperands","aoid":null,"title":"\n         GetOperands (\n           s: a decimal String,\n         )\n       ","titleHTML":"\n         GetOperands (\n           <var>s</var>: a decimal String,\n         )\n       ","number":"1.5.1","namespace":"<no location>","location":"","referencingIds":[],"key":"\n         GetOperands (\n           s: a decimal String,\n         )\n       "},{"type":"clause","id":"sec-pluralruleselect","aoid":null,"title":"\n        PluralRuleSelect (\n          locale: a String,\n          type: a String,\n          n: a finite Number,\n          operands: a Plural Rules Operands Record derived from formatting n,\n        )\n      ","titleHTML":"\n        PluralRuleSelect (\n          <var>locale</var>: a String,\n          <var>type</var>: a String,\n          <var>n</var>: a finite Number,\n          <var>operands</var>: a Plural Rules Operands Record derived from formatting <var>n</var>,\n        )\n      ","number":"1.5.2","namespace":"<no location>","location":"","referencingIds":["_ref_1"],"key":"\n        PluralRuleSelect (\n          locale: a String,\n          type: a String,\n          n: a finite Number,\n          operands: a Plural Rules Operands Record derived from formatting n,\n        )\n      "},{"type":"op","aoid":"ResolvePlural","refId":"sec-resolveplural","location":"","referencingIds":[],"key":"ResolvePlural"},{"type":"clause","id":"sec-resolveplural","aoid":"ResolvePlural","title":"ResolvePlural ( pluralRules, n )","titleHTML":"ResolvePlural ( <var>pluralRules</var>, <var>n</var> )","number":"1.5.3","namespace":"<no location>","location":"","referencingIds":["_ref_12","_ref_34","_ref_35"],"key":"ResolvePlural ( pluralRules, n )"},{"type":"op","aoid":"PluralRuleSelectRange","refId":"sec-pluralruleselectrange","location":"","referencingIds":[],"key":"PluralRuleSelectRange"},{"type":"clause","id":"sec-pluralruleselectrange","aoid":"PluralRuleSelectRange","title":"PluralRuleSelectRange ( locale, type, xp, yp )","titleHTML":"PluralRuleSelectRange ( <var>locale</var>, <var>type</var>, <var>xp</var>, <var>yp</var> )","number":"1.5.4","namespace":"<no location>","location":"","referencingIds":["_ref_36"],"key":"PluralRuleSelectRange ( locale, type, xp, yp )"},{"type":"op","aoid":"ResolvePluralRange","refId":"sec-resolvepluralrange","location":"","referencingIds":[],"key":"ResolvePluralRange"},{"type":"clause","id":"sec-resolvepluralrange","aoid":"ResolvePluralRange","title":"ResolvePluralRange ( pluralRules, x, y )","titleHTML":"ResolvePluralRange ( <var>pluralRules</var>, <var>x</var>, <var>y</var> )","number":"1.5.5","namespace":"<no location>","location":"","referencingIds":["_ref_16"],"key":"ResolvePluralRange ( pluralRules, x, y )"},{"type":"clause","id":"sec-intl-pluralrules-abstracts","aoid":null,"title":"Abstract Operations for PluralRules Objects","titleHTML":"Abstract Operations for PluralRules Objects","number":"1.5","namespace":"<no location>","location":"","referencingIds":[],"key":"Abstract Operations for PluralRules Objects"},{"type":"clause","id":"pluralrules-objects","aoid":null,"title":"PluralRules Objects","titleHTML":"PluralRules Objects","number":"1","namespace":"<no location>","location":"","referencingIds":[],"key":"PluralRules Objects"}]</script><script>"use strict";
+<head><meta charset="utf-8"><script>'use strict';
+let sdoBox = {
+  init() {
+    this.$alternativeId = null;
+    this.$outer = document.createElement('div');
+    this.$outer.classList.add('toolbox-container');
+    this.$container = document.createElement('div');
+    this.$container.classList.add('toolbox');
+    this.$displayLink = document.createElement('a');
+    this.$displayLink.setAttribute('href', '#');
+    this.$displayLink.textContent = 'Syntax-Directed Operations';
+    this.$displayLink.addEventListener('click', e => {
+      e.preventDefault();
+      e.stopPropagation();
+      referencePane.showSDOs(sdoMap[this.$alternativeId] || {}, this.$alternativeId);
+    });
+    this.$container.appendChild(this.$displayLink);
+    this.$outer.appendChild(this.$container);
+    document.body.appendChild(this.$outer);
+  },
 
+  activate(el) {
+    clearTimeout(this.deactiveTimeout);
+    Toolbox.deactivate();
+    this.$alternativeId = el.id;
+    let numSdos = Object.keys(sdoMap[this.$alternativeId] || {}).length;
+    this.$displayLink.textContent = 'Syntax-Directed Operations (' + numSdos + ')';
+    this.$outer.classList.add('active');
+    let top = el.offsetTop - this.$outer.offsetHeight;
+    let left = el.offsetLeft + 50 - 10; // 50px = padding-left(=75px) + text-indent(=-25px)
+    this.$outer.setAttribute('style', 'left: ' + left + 'px; top: ' + top + 'px');
+    if (top < document.body.scrollTop) {
+      this.$container.scrollIntoView();
+    }
+  },
+
+  deactivate() {
+    clearTimeout(this.deactiveTimeout);
+    this.$outer.classList.remove('active');
+  },
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+  if (typeof sdoMap == 'undefined') {
+    console.error('could not find sdo map');
+    return;
+  }
+  sdoBox.init();
+
+  let insideTooltip = false;
+  sdoBox.$outer.addEventListener('pointerenter', () => {
+    insideTooltip = true;
+  });
+  sdoBox.$outer.addEventListener('pointerleave', () => {
+    insideTooltip = false;
+    sdoBox.deactivate();
+  });
+
+  sdoBox.deactiveTimeout = null;
+  [].forEach.call(document.querySelectorAll('emu-grammar[type=definition] emu-rhs'), node => {
+    node.addEventListener('pointerenter', function () {
+      sdoBox.activate(this);
+    });
+
+    node.addEventListener('pointerleave', () => {
+      sdoBox.deactiveTimeout = setTimeout(() => {
+        if (!insideTooltip) {
+          sdoBox.deactivate();
+        }
+      }, 500);
+    });
+  });
+
+  document.addEventListener(
+    'keydown',
+    debounce(e => {
+      if (e.code === 'Escape') {
+        sdoBox.deactivate();
+      }
+    })
+  );
+});
+
+'use strict';
 function Search(menu) {
   this.menu = menu;
   this.$search = document.getElementById('menu-search');
@@ -11,8 +93,14 @@ function Search(menu) {
 
   document.addEventListener('keydown', this.documentKeydown.bind(this));
 
-  this.$searchBox.addEventListener('keydown', debounce(this.searchBoxKeydown.bind(this), { stopPropagation: true }));
-  this.$searchBox.addEventListener('keyup', debounce(this.searchBoxKeyup.bind(this), { stopPropagation: true }));
+  this.$searchBox.addEventListener(
+    'keydown',
+    debounce(this.searchBoxKeydown.bind(this), { stopPropagation: true })
+  );
+  this.$searchBox.addEventListener(
+    'keyup',
+    debounce(this.searchBoxKeyup.bind(this), { stopPropagation: true })
+  );
 
   // Perform an initial search if the box is not empty.
   if (this.$searchBox.value) {
@@ -21,26 +109,34 @@ function Search(menu) {
 }
 
 Search.prototype.loadBiblio = function () {
-  var $biblio = document.getElementById('menu-search-biblio');
-  if (!$biblio) {
-    this.biblio = [];
+  if (typeof biblio === 'undefined') {
+    console.error('could not find biblio');
+    this.biblio = { refToClause: {}, entries: [] };
   } else {
-    this.biblio = JSON.parse($biblio.textContent);
-    this.biblio.clauses = this.biblio.filter(function (e) { return e.type === 'clause' });
-    this.biblio.byId = this.biblio.reduce(function (map, entry) {
+    this.biblio = biblio;
+    this.biblio.clauses = this.biblio.entries.filter(e => e.type === 'clause');
+    this.biblio.byId = this.biblio.entries.reduce((map, entry) => {
       map[entry.id] = entry;
       return map;
     }, {});
+    let refParentClause = Object.create(null);
+    this.biblio.refParentClause = refParentClause;
+    let refsByClause = this.biblio.refsByClause;
+    Object.keys(refsByClause).forEach(clause => {
+      refsByClause[clause].forEach(ref => {
+        refParentClause[ref] = clause;
+      });
+    });
   }
-}
+};
 
 Search.prototype.documentKeydown = function (e) {
-  if (e.keyCode === 191) {
+  if (e.key === '/') {
     e.preventDefault();
     e.stopPropagation();
     this.triggerSearch();
   }
-}
+};
 
 Search.prototype.searchBoxKeydown = function (e) {
   e.stopPropagation();
@@ -51,7 +147,7 @@ Search.prototype.searchBoxKeydown = function (e) {
     e.preventDefault();
     this.selectResult();
   }
-}
+};
 
 Search.prototype.searchBoxKeyup = function (e) {
   if (e.keyCode === 13 || e.keyCode === 9) {
@@ -59,10 +155,9 @@ Search.prototype.searchBoxKeyup = function (e) {
   }
 
   this.search(e.target.value);
-}
+};
 
-
-Search.prototype.triggerSearch = function (e) {
+Search.prototype.triggerSearch = function () {
   if (this.menu.isVisible()) {
     this._closeAfterSearch = false;
   } else {
@@ -72,14 +167,14 @@ Search.prototype.triggerSearch = function (e) {
 
   this.$searchBox.focus();
   this.$searchBox.select();
-}
+};
 // bit 12 - Set if the result starts with searchString
 // bits 8-11: 8 - number of chunks multiplied by 2 if cases match, otherwise 1.
 // bits 1-7: 127 - length of the entry
 // General scheme: prefer case sensitive matches with fewer chunks, and otherwise
 // prefer shorter matches.
-function relevance(result, searchString) {
-  var relevance = 0;
+function relevance(result) {
+  let relevance = 0;
 
   relevance = Math.max(0, 8 - result.match.chunks) << 7;
 
@@ -88,10 +183,10 @@ function relevance(result, searchString) {
   }
 
   if (result.match.prefix) {
-    relevance += 2048
+    relevance += 2048;
   }
 
-  relevance += Math.max(0, 255 - result.entry.key.length);
+  relevance += Math.max(0, 255 - result.key.length);
 
   return relevance;
 }
@@ -110,36 +205,34 @@ Search.prototype.search = function (searchString) {
     return;
   }
 
-  var results;
+  let results;
 
-  if (/^[\d\.]*$/.test(searchString)) {
-    results = this.biblio.clauses.filter(function (clause) {
-      return clause.number.substring(0, searchString.length) === searchString;
-    }).map(function (clause) {
-      return { entry: clause };
-    });
+  if (/^[\d.]*$/.test(searchString)) {
+    results = this.biblio.clauses
+      .filter(clause => clause.number.substring(0, searchString.length) === searchString)
+      .map(clause => ({ key: getKey(clause), entry: clause }));
   } else {
     results = [];
 
-    for (var i = 0; i < this.biblio.length; i++) {
-      var entry = this.biblio[i];
-      if (!entry.key) {
+    for (let i = 0; i < this.biblio.entries.length; i++) {
+      let entry = this.biblio.entries[i];
+      let key = getKey(entry);
+      if (!key) {
         // biblio entries without a key aren't searchable
         continue;
       }
 
-      var match = fuzzysearch(searchString, entry.key);
+      let match = fuzzysearch(searchString, key);
       if (match) {
-        results.push({ entry: entry, match: match });
+        results.push({ key, entry, match });
       }
     }
 
-    results.forEach(function (result) {
+    results.forEach(result => {
       result.relevance = relevance(result, searchString);
     });
 
-    results = results.sort(function (a, b) { return b.relevance - a.relevance });
-
+    results = results.sort((a, b) => b.relevance - a.relevance);
   }
 
   if (results.length > 50) {
@@ -147,17 +240,17 @@ Search.prototype.search = function (searchString) {
   }
 
   this.displayResults(results);
-}
+};
 Search.prototype.hideSearch = function () {
   this.$search.classList.remove('active');
-}
+};
 
 Search.prototype.showSearch = function () {
   this.$search.classList.add('active');
-}
+};
 
 Search.prototype.selectResult = function () {
-  var $first = this.$searchResults.querySelector('li:first-child a');
+  let $first = this.$searchResults.querySelector('li:first-child a');
 
   if ($first) {
     document.location = $first.getAttribute('href');
@@ -171,53 +264,79 @@ Search.prototype.selectResult = function () {
   if (this._closeAfterSearch) {
     this.menu.hide();
   }
-}
+};
 
 Search.prototype.displayResults = function (results) {
   if (results.length > 0) {
     this.$searchResults.classList.remove('no-results');
 
-    var html = '<ul>';
+    let html = '<ul>';
 
-    results.forEach(function (result) {
-      var entry = result.entry;
-      var id = entry.id;
-      var cssClass = '';
-      var text = '';
+    results.forEach(result => {
+      let key = result.key;
+      let entry = result.entry;
+      let id = entry.id;
+      let cssClass = '';
+      let text = '';
 
       if (entry.type === 'clause') {
-        var number = entry.number ? entry.number + ' ' : '';
-        text = number + entry.key;
+        let number = entry.number ? entry.number + ' ' : '';
+        text = number + key;
         cssClass = 'clause';
         id = entry.id;
       } else if (entry.type === 'production') {
-        text = entry.key;
+        text = key;
         cssClass = 'prod';
         id = entry.id;
       } else if (entry.type === 'op') {
-        text = entry.key;
+        text = key;
         cssClass = 'op';
         id = entry.id || entry.refId;
       } else if (entry.type === 'term') {
-        text = entry.key;
+        text = key;
         cssClass = 'term';
         id = entry.id || entry.refId;
       }
 
       if (text) {
-        html += '<li class=menu-search-result-' + cssClass + '><a href="#' + id + '">' + text + '</a></li>';
+        // prettier-ignore
+        html += `<li class=menu-search-result-${cssClass}><a href="${makeLinkToId(id)}">${text}</a></li>`;
       }
     });
 
-    html += '</ul>'
+    html += '</ul>';
 
     this.$searchResults.innerHTML = html;
   } else {
     this.$searchResults.innerHTML = '';
     this.$searchResults.classList.add('no-results');
   }
-}
+};
 
+function getKey(item) {
+  if (item.key) {
+    return item.key;
+  }
+  switch (item.type) {
+    case 'clause':
+      return item.title || item.titleHTML;
+    case 'production':
+      return item.name;
+    case 'op':
+      return item.aoid;
+    case 'term':
+      return item.term;
+    case 'table':
+    case 'figure':
+    case 'example':
+    case 'note':
+      return item.caption;
+    case 'step':
+      return item.id;
+    default:
+      throw new Error("Can't get key for " + item.type);
+  }
+}
 
 function Menu() {
   this.$toggle = document.getElementById('menu-toggle');
@@ -229,7 +348,7 @@ function Menu() {
   this.$specContainer = document.getElementById('spec-container');
   this.search = new Search(this);
 
-  this._pinnedIds = {}; 
+  this._pinnedIds = {};
   this.loadPinEntries();
 
   // toggle menu
@@ -239,23 +358,23 @@ function Menu() {
   document.addEventListener('keydown', this.documentKeydown.bind(this));
 
   // toc expansion
-  var tocItems = this.$menu.querySelectorAll('#menu-toc li');
-  for (var i = 0; i < tocItems.length; i++) {
-    var $item = tocItems[i];
-    $item.addEventListener('click', function($item, event) {
+  let tocItems = this.$menu.querySelectorAll('#menu-toc li');
+  for (let i = 0; i < tocItems.length; i++) {
+    let $item = tocItems[i];
+    $item.addEventListener('click', event => {
       $item.classList.toggle('active');
       event.stopPropagation();
-    }.bind(null, $item));
+    });
   }
 
   // close toc on toc item selection
-  var tocLinks = this.$menu.querySelectorAll('#menu-toc li > a');
-  for (var i = 0; i < tocLinks.length; i++) {
-    var $link = tocLinks[i];
-    $link.addEventListener('click', function(event) {
+  let tocLinks = this.$menu.querySelectorAll('#menu-toc li > a');
+  for (let i = 0; i < tocLinks.length; i++) {
+    let $link = tocLinks[i];
+    $link.addEventListener('click', event => {
       this.toggle();
       event.stopPropagation();
-    }.bind(this));
+    });
   }
 
   // update active clause on scroll
@@ -263,14 +382,13 @@ function Menu() {
   this.updateActiveClause();
 
   // prevent menu scrolling from scrolling the body
-  this.$toc.addEventListener('wheel', function (e) {
-    var target = e.currentTarget;
-    var offTop = e.deltaY < 0 && target.scrollTop === 0;
+  this.$toc.addEventListener('wheel', e => {
+    let target = e.currentTarget;
+    let offTop = e.deltaY < 0 && target.scrollTop === 0;
     if (offTop) {
       e.preventDefault();
     }
-    var offBottom = e.deltaY > 0
-                    && target.offsetHeight + target.scrollTop >= target.scrollHeight;
+    let offBottom = e.deltaY > 0 && target.offsetHeight + target.scrollTop >= target.scrollHeight;
 
     if (offBottom) {
       e.preventDefault();
@@ -285,62 +403,66 @@ Menu.prototype.documentKeydown = function (e) {
   } else if (e.keyCode > 48 && e.keyCode < 58) {
     this.selectPin(e.keyCode - 49);
   }
-}
+};
 
 Menu.prototype.updateActiveClause = function () {
-  this.setActiveClause(findActiveClause(this.$specContainer))
-}
+  this.setActiveClause(findActiveClause(this.$specContainer));
+};
 
 Menu.prototype.setActiveClause = function (clause) {
   this.$activeClause = clause;
   this.revealInToc(this.$activeClause);
-}
+};
 
 Menu.prototype.revealInToc = function (path) {
-  var current = this.$toc.querySelectorAll('li.revealed');
-  for (var i = 0; i < current.length; i++) {
+  let current = this.$toc.querySelectorAll('li.revealed');
+  for (let i = 0; i < current.length; i++) {
     current[i].classList.remove('revealed');
     current[i].classList.remove('revealed-leaf');
   }
 
-  var current = this.$toc;
-  var index = 0;
-  while (index < path.length) {
-    var children = current.children;
-    for (var i = 0; i < children.length; i++) {
-      if ('#' + path[index].id === children[i].children[1].getAttribute('href') ) {
+  current = this.$toc;
+  let index = 0;
+  outer: while (index < path.length) {
+    let children = current.children;
+    for (let i = 0; i < children.length; i++) {
+      if ('#' + path[index].id === children[i].children[1].hash) {
         children[i].classList.add('revealed');
         if (index === path.length - 1) {
           children[i].classList.add('revealed-leaf');
-          var rect = children[i].getBoundingClientRect();
+          let rect = children[i].getBoundingClientRect();
           // this.$toc.getBoundingClientRect().top;
-          var tocRect = this.$toc.getBoundingClientRect();
+          let tocRect = this.$toc.getBoundingClientRect();
           if (rect.top + 10 > tocRect.bottom) {
-            this.$toc.scrollTop = this.$toc.scrollTop + (rect.top - tocRect.bottom) + (rect.bottom - rect.top);
+            this.$toc.scrollTop =
+              this.$toc.scrollTop + (rect.top - tocRect.bottom) + (rect.bottom - rect.top);
           } else if (rect.top < tocRect.top) {
             this.$toc.scrollTop = this.$toc.scrollTop - (tocRect.top - rect.top);
           }
         }
         current = children[i].querySelector('ol');
         index++;
-        break;
+        continue outer;
       }
     }
-
+    console.log('could not find location in table of contents', path);
+    break;
   }
-}
+};
 
 function findActiveClause(root, path) {
-  var clauses = new ClauseWalker(root);
-  var $clause;
-  var path = path || [];
+  let clauses = getChildClauses(root);
+  path = path || [];
 
-  while ($clause = clauses.nextNode()) {
-    var rect = $clause.getBoundingClientRect();
-    var $header = $clause.querySelector("h1");
-    var marginTop = parseInt(getComputedStyle($header)["margin-top"]);
+  for (let $clause of clauses) {
+    let rect = $clause.getBoundingClientRect();
+    let $header = $clause.querySelector('h1');
+    let marginTop = Math.max(
+      parseInt(getComputedStyle($clause)['margin-top']),
+      parseInt(getComputedStyle($header)['margin-top'])
+    );
 
-    if ((rect.top - marginTop) <= 0 && rect.bottom > 0) {
+    if (rect.top - marginTop <= 1 && rect.bottom > 0) {
       return findActiveClause($clause, path.concat($clause)) || path;
     }
   }
@@ -348,57 +470,49 @@ function findActiveClause(root, path) {
   return path;
 }
 
-function ClauseWalker(root) {
-  var previous;
-  var treeWalker = document.createTreeWalker(
-    root,
-    NodeFilter.SHOW_ELEMENT,
-    {
-      acceptNode: function (node) {
-        if (previous === node.parentNode) {
-          return NodeFilter.FILTER_REJECT;
-        } else {
-          previous = node;
-        }
-        if (node.nodeName === 'EMU-CLAUSE' || node.nodeName === 'EMU-INTRO' || node.nodeName === 'EMU-ANNEX') {
-          return NodeFilter.FILTER_ACCEPT;
-        } else {
-          return NodeFilter.FILTER_SKIP;
-        }
-      }
-    },
-    false
-    );
+function* getChildClauses(root) {
+  for (let el of root.children) {
+    switch (el.nodeName) {
+      // descend into <emu-import>
+      case 'EMU-IMPORT':
+        yield* getChildClauses(el);
+        break;
 
-  return treeWalker;
+      // accept <emu-clause>, <emu-intro>, and <emu-annex>
+      case 'EMU-CLAUSE':
+      case 'EMU-INTRO':
+      case 'EMU-ANNEX':
+        yield el;
+    }
+  }
 }
 
 Menu.prototype.toggle = function () {
   this.$menu.classList.toggle('active');
-}
+};
 
 Menu.prototype.show = function () {
   this.$menu.classList.add('active');
-}
+};
 
 Menu.prototype.hide = function () {
   this.$menu.classList.remove('active');
-}
+};
 
-Menu.prototype.isVisible = function() {
+Menu.prototype.isVisible = function () {
   return this.$menu.classList.contains('active');
-}
+};
 
 Menu.prototype.showPins = function () {
   this.$pins.classList.add('active');
-}
+};
 
 Menu.prototype.hidePins = function () {
   this.$pins.classList.remove('active');
-}
+};
 
 Menu.prototype.addPinEntry = function (id) {
-  var entry = this.search.biblio.byId[id];
+  let entry = this.search.biblio.byId[id];
   if (!entry) {
     // id was deleted after pin (or something) so remove it
     delete this._pinnedIds[id];
@@ -407,15 +521,16 @@ Menu.prototype.addPinEntry = function (id) {
   }
 
   if (entry.type === 'clause') {
-    var prefix;
+    let prefix;
     if (entry.number) {
       prefix = entry.number + ' ';
     } else {
       prefix = '';
     }
-    this.$pinList.innerHTML += '<li><a href="#' + entry.id + '">' + prefix + entry.titleHTML + '</a></li>';
+    // prettier-ignore
+    this.$pinList.innerHTML += `<li><a href="${makeLinkToId(entry.id)}">${prefix}${entry.titleHTML}</a></li>`;
   } else {
-    this.$pinList.innerHTML += '<li><a href="#' + entry.id + '">' + entry.key + '</a></li>';
+    this.$pinList.innerHTML += `<li><a href="${makeLinkToId(entry.id)}">${getKey(entry)}</a></li>`;
   }
 
   if (Object.keys(this._pinnedIds).length === 0) {
@@ -423,10 +538,10 @@ Menu.prototype.addPinEntry = function (id) {
   }
   this._pinnedIds[id] = true;
   this.persistPinEntries();
-}
+};
 
 Menu.prototype.removePinEntry = function (id) {
-  var item = this.$pinList.querySelector('a[href="#' + id + '"]').parentNode;
+  let item = this.$pinList.querySelector(`a[href="${makeLinkToId(id)}"]`).parentNode;
   this.$pinList.removeChild(item);
   delete this._pinnedIds[id];
   if (Object.keys(this._pinnedIds).length === 0) {
@@ -434,7 +549,7 @@ Menu.prototype.removePinEntry = function (id) {
   }
 
   this.persistPinEntries();
-}
+};
 
 Menu.prototype.persistPinEntries = function () {
   try {
@@ -444,7 +559,7 @@ Menu.prototype.persistPinEntries = function () {
   }
 
   localStorage.pinEntries = JSON.stringify(Object.keys(this._pinnedIds));
-}
+};
 
 Menu.prototype.loadPinEntries = function () {
   try {
@@ -453,13 +568,13 @@ Menu.prototype.loadPinEntries = function () {
     return;
   }
 
-  var pinsString = window.localStorage.pinEntries;
+  let pinsString = window.localStorage.pinEntries;
   if (!pinsString) return;
-  var pins = JSON.parse(pinsString);
-  for(var i = 0; i < pins.length; i++) {
+  let pins = JSON.parse(pinsString);
+  for (let i = 0; i < pins.length; i++) {
     this.addPinEntry(pins[i]);
   }
-}
+};
 
 Menu.prototype.togglePinEntry = function (id) {
   if (!id) {
@@ -471,62 +586,49 @@ Menu.prototype.togglePinEntry = function (id) {
   } else {
     this.addPinEntry(id);
   }
-}
+};
 
 Menu.prototype.selectPin = function (num) {
   document.location = this.$pinList.children[num].children[0].href;
-}
+};
 
-var menu;
-function init() {
-  menu = new Menu();
-  var $container = document.getElementById('spec-container');
-  $container.addEventListener('mouseover', debounce(function (e) {
-    Toolbox.activateIfMouseOver(e);
-  }));
-  document.addEventListener('keydown', debounce(function (e) {
-    if (e.code === "Escape" && Toolbox.active) {
-      Toolbox.deactivate();
-    }
-  }));
-}
+let menu;
 
 document.addEventListener('DOMContentLoaded', init);
 
 function debounce(fn, opts) {
   opts = opts || {};
-  var timeout;
-  return function(e) {
+  let timeout;
+  return function (e) {
     if (opts.stopPropagation) {
       e.stopPropagation();
     }
-    var args = arguments;
+    let args = arguments;
     if (timeout) {
       clearTimeout(timeout);
     }
-    timeout = setTimeout(function() {
+    timeout = setTimeout(() => {
       timeout = null;
       fn.apply(this, args);
-    }.bind(this), 150);
-  }
+    }, 150);
+  };
 }
 
-var CLAUSE_NODES = ['EMU-CLAUSE', 'EMU-INTRO', 'EMU-ANNEX'];
-function findLocalReferences ($elem) {
-  var name = $elem.innerHTML;
-  var references = [];
-
-  var parentClause = $elem.parentNode;
+let CLAUSE_NODES = ['EMU-CLAUSE', 'EMU-INTRO', 'EMU-ANNEX'];
+function findContainer($elem) {
+  let parentClause = $elem.parentNode;
   while (parentClause && CLAUSE_NODES.indexOf(parentClause.nodeName) === -1) {
     parentClause = parentClause.parentNode;
   }
+  return parentClause;
+}
 
-  if(!parentClause) return;
+function findLocalReferences(parentClause, name) {
+  let vars = parentClause.querySelectorAll('var');
+  let references = [];
 
-  var vars = parentClause.querySelectorAll('var');
-
-  for (var i = 0; i < vars.length; i++) {
-    var $var = vars[i];
+  for (let i = 0; i < vars.length; i++) {
+    let $var = vars[i];
 
     if ($var.innerHTML === name) {
       references.push($var);
@@ -536,21 +638,38 @@ function findLocalReferences ($elem) {
   return references;
 }
 
+let REFERENCED_CLASSES = Array.from({ length: 7 }, (x, i) => `referenced${i}`);
+function chooseHighlightIndex(parentClause) {
+  let counts = REFERENCED_CLASSES.map($class => parentClause.getElementsByClassName($class).length);
+  // Find the earliest index with the lowest count.
+  let minCount = Infinity;
+  let index = null;
+  for (let i = 0; i < counts.length; i++) {
+    if (counts[i] < minCount) {
+      minCount = counts[i];
+      index = i;
+    }
+  }
+  return index;
+}
+
 function toggleFindLocalReferences($elem) {
-  var references = findLocalReferences($elem);
+  let parentClause = findContainer($elem);
+  let references = findLocalReferences(parentClause, $elem.innerHTML);
   if ($elem.classList.contains('referenced')) {
-    references.forEach(function ($reference) {
-      $reference.classList.remove('referenced');
+    references.forEach($reference => {
+      $reference.classList.remove('referenced', ...REFERENCED_CLASSES);
     });
   } else {
-    references.forEach(function ($reference) {
-      $reference.classList.add('referenced');
+    let index = chooseHighlightIndex(parentClause);
+    references.forEach($reference => {
+      $reference.classList.add('referenced', `referenced${index}`);
     });
   }
 }
 
-function installFindLocalReferences () {
-  document.addEventListener('click', function (e) {
+function installFindLocalReferences() {
+  document.addEventListener('click', e => {
     if (e.target.nodeName === 'VAR') {
       toggleFindLocalReferences(e.target);
     }
@@ -558,9 +677,6 @@ function installFindLocalReferences () {
 }
 
 document.addEventListener('DOMContentLoaded', installFindLocalReferences);
-
-
-
 
 // The following license applies to the fuzzysearch function
 // The MIT License (MIT)
@@ -582,11 +698,11 @@ document.addEventListener('DOMContentLoaded', installFindLocalReferences);
 // COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-function fuzzysearch (searchString, haystack, caseInsensitive) {
-  var tlen = haystack.length;
-  var qlen = searchString.length;
-  var chunks = 1;
-  var finding = false;
+function fuzzysearch(searchString, haystack, caseInsensitive) {
+  let tlen = haystack.length;
+  let qlen = searchString.length;
+  let chunks = 1;
+  let finding = false;
 
   if (qlen > tlen) {
     return false;
@@ -602,10 +718,11 @@ function fuzzysearch (searchString, haystack, caseInsensitive) {
     }
   }
 
-  outer: for (var i = 0, j = 0; i < qlen; i++) {
-    var nch = searchString[i];
+  let j = 0;
+  outer: for (let i = 0; i < qlen; i++) {
+    let nch = searchString[i];
     while (j < tlen) {
-      var targetChar = haystack[j++];
+      let targetChar = haystack[j++];
       if (targetChar === nch) {
         finding = true;
         continue outer;
@@ -616,113 +733,24 @@ function fuzzysearch (searchString, haystack, caseInsensitive) {
       }
     }
 
-    if (caseInsensitive) { return false; }
+    if (caseInsensitive) {
+      return false;
+    }
 
     return fuzzysearch(searchString.toLowerCase(), haystack.toLowerCase(), true);
   }
 
-  return { caseMatch: !caseInsensitive, chunks: chunks, prefix: j <= qlen };
+  return { caseMatch: !caseInsensitive, chunks, prefix: j <= qlen };
 }
 
-var Toolbox = {
-  init: function () {
-    this.$container = document.createElement('div');
-    this.$container.classList.add('toolbox');
-    this.$permalink = document.createElement('a');
-    this.$permalink.textContent = 'Permalink';
-    this.$pinLink = document.createElement('a');
-    this.$pinLink.textContent = 'Pin';
-    this.$pinLink.setAttribute('href', '#');
-    this.$pinLink.addEventListener('click', function (e) {
-      e.preventDefault();
-      e.stopPropagation();
-      menu.togglePinEntry(this.entry.id);
-    }.bind(this));
-
-    this.$refsLink = document.createElement('a');
-    this.$refsLink.setAttribute('href', '#');
-    this.$refsLink.addEventListener('click', function (e) {
-      e.preventDefault();
-      e.stopPropagation();
-      referencePane.showReferencesFor(this.entry);
-    }.bind(this));
-    this.$container.appendChild(this.$permalink);
-    this.$container.appendChild(this.$pinLink);
-    this.$container.appendChild(this.$refsLink);
-    document.body.appendChild(this.$container);
-  },
-
-  activate: function (el, entry, target) {
-    if (el === this._activeEl) return;
-    this.active = true;
-    this.entry = entry;
-    this.$container.classList.add('active');
-    this.top = el.offsetTop - this.$container.offsetHeight - 10;
-    this.left = el.offsetLeft;
-    this.$container.setAttribute('style', 'left: ' + this.left + 'px; top: ' + this.top + 'px');
-    this.updatePermalink();
-    this.updateReferences();
-    this._activeEl = el;
-    if (this.top < document.body.scrollTop && el === target) {
-      // don't scroll unless it's a small thing (< 200px)
-      this.$container.scrollIntoView();
-    }
-  },
-
-  updatePermalink: function () {
-    this.$permalink.setAttribute('href', '#' + this.entry.id);
-  },
-
-  updateReferences: function () {
-    this.$refsLink.textContent = 'References (' + this.entry.referencingIds.length + ')';
-  },
-
-  activateIfMouseOver: function (e) {
-    var ref = this.findReferenceUnder(e.target);
-    if (ref && (!this.active || e.pageY > this._activeEl.offsetTop)) {
-      var entry = menu.search.biblio.byId[ref.id];
-      this.activate(ref.element, entry, e.target);
-    } else if (this.active && ((e.pageY < this.top) || e.pageY > (this._activeEl.offsetTop + this._activeEl.offsetHeight))) {
-      this.deactivate();
-    }
-  },
-
-  findReferenceUnder: function (el) {
-    while (el) {
-      var parent = el.parentNode;
-      if (el.nodeName === 'H1' && parent.nodeName.match(/EMU-CLAUSE|EMU-ANNEX|EMU-INTRO/) && parent.id) {
-        return { element: el, id: parent.id };
-      } else if (el.nodeName.match(/EMU-(?!CLAUSE|XREF|ANNEX|INTRO)|DFN/) &&
-                el.id && el.id[0] !== '_') {
-        if (el.nodeName === 'EMU-FIGURE' || el.nodeName === 'EMU-TABLE' || el.nodeName === 'EMU-EXAMPLE') {
-          // return the figcaption element
-          return { element: el.children[0].children[0], id: el.id };
-        } else if (el.nodeName === 'EMU-PRODUCTION') {
-          // return the LHS non-terminal element
-          return { element: el.children[0], id: el.id };
-        } else {
-          return { element: el, id: el.id };
-        }
-      }
-      el = parent;
-    }
-  },
-
-  deactivate: function () {
-    this.$container.classList.remove('active');
-    this._activeEl = null;
-    this.activeElBounds = null;
-    this.active = false;
-  }
-}
-
-var referencePane = {
-  init: function() {
+let referencePane = {
+  init() {
     this.$container = document.createElement('div');
     this.$container.setAttribute('id', 'references-pane-container');
 
-    var $spacer = document.createElement('div');
+    let $spacer = document.createElement('div');
     $spacer.setAttribute('id', 'references-pane-spacer');
+    $spacer.classList.add('menu-spacer');
 
     this.$pane = document.createElement('div');
     this.$pane.setAttribute('id', 'references-pane');
@@ -732,18 +760,19 @@ var referencePane = {
 
     this.$header = document.createElement('div');
     this.$header.classList.add('menu-pane-header');
-    this.$header.textContent = 'References to ';
+    this.$headerText = document.createElement('span');
+    this.$header.appendChild(this.$headerText);
     this.$headerRefId = document.createElement('a');
     this.$header.appendChild(this.$headerRefId);
     this.$closeButton = document.createElement('span');
     this.$closeButton.setAttribute('id', 'references-pane-close');
-    this.$closeButton.addEventListener('click', function (e) {
+    this.$closeButton.addEventListener('click', () => {
       this.deactivate();
-    }.bind(this));
+    });
     this.$header.appendChild(this.$closeButton);
 
     this.$pane.appendChild(this.$header);
-    var tableContainer = document.createElement('div');
+    let tableContainer = document.createElement('div');
     tableContainer.setAttribute('id', 'references-pane-table-container');
 
     this.$table = document.createElement('table');
@@ -757,70 +786,238 @@ var referencePane = {
     menu.$specContainer.appendChild(this.$container);
   },
 
-  activate: function () {
+  activate() {
     this.$container.classList.add('active');
   },
 
-  deactivate: function () {
+  deactivate() {
     this.$container.classList.remove('active');
+    this.state = null;
   },
 
   showReferencesFor(entry) {
     this.activate();
-    var newBody = document.createElement('tbody');
-    var previousId;
-    var previousCell;
-    var dupCount = 0;
+    this.state = { type: 'ref', id: entry.id };
+    this.$headerText.textContent = 'References to ';
+    let newBody = document.createElement('tbody');
+    let previousId;
+    let previousCell;
+    let dupCount = 0;
     this.$headerRefId.textContent = '#' + entry.id;
-    this.$headerRefId.setAttribute('href', '#' + entry.id);
-    entry.referencingIds.map(function (id) {
-      var target = document.getElementById(id);
-      var cid = findParentClauseId(target);
-      var clause = menu.search.biblio.byId[cid];
-      return { id: id, clause: clause }
-    }).sort(function (a, b) {
-      return sortByClauseNumber(a.clause, b.clause);
-    }).forEach(function (record, i) {
-      if (previousId === record.clause.id) {
-        previousCell.innerHTML += ' (<a href="#' + record.id + '">' + (dupCount + 2) + '</a>)';
-        dupCount++;
-      } else {
-        var row = newBody.insertRow();
-        var cell = row.insertCell();
-        cell.innerHTML = record.clause.number;
-        cell = row.insertCell();
-        cell.innerHTML = '<a href="#' + record.id + '">' + record.clause.titleHTML + '</a>';
-        previousCell = cell;
-        previousId = record.clause.id;
-        dupCount = 0;
-      }
-    }, this);
+    this.$headerRefId.setAttribute('href', makeLinkToId(entry.id));
+    this.$headerRefId.style.display = 'inline';
+    (entry.referencingIds || [])
+      .map(id => {
+        let cid = menu.search.biblio.refParentClause[id];
+        let clause = menu.search.biblio.byId[cid];
+        if (clause == null) {
+          throw new Error('could not find clause for id ' + cid);
+        }
+        return { id, clause };
+      })
+      .sort((a, b) => sortByClauseNumber(a.clause, b.clause))
+      .forEach(record => {
+        if (previousId === record.clause.id) {
+          previousCell.innerHTML += ` (<a href="${makeLinkToId(record.id)}">${dupCount + 2}</a>)`;
+          dupCount++;
+        } else {
+          let row = newBody.insertRow();
+          let cell = row.insertCell();
+          cell.innerHTML = record.clause.number;
+          cell = row.insertCell();
+          cell.innerHTML = `<a href="${makeLinkToId(record.id)}">${record.clause.titleHTML}</a>`;
+          previousCell = cell;
+          previousId = record.clause.id;
+          dupCount = 0;
+        }
+      }, this);
     this.$table.removeChild(this.$tableBody);
     this.$tableBody = newBody;
     this.$table.appendChild(this.$tableBody);
-  }
-}
-function findParentClauseId(node) {
-  while (node && node.nodeName !== 'EMU-CLAUSE' && node.nodeName !== 'EMU-INTRO' && node.nodeName !== 'EMU-ANNEX') {
-    node = node.parentNode;
-  }
-  if (!node) return null;
-  return node.getAttribute('id');
-}
+  },
 
-function sortByClauseNumber(c1, c2) {
-  var c1c = c1.number.split('.');
-  var c2c = c2.number.split('.');
+  showSDOs(sdos, alternativeId) {
+    let rhs = document.getElementById(alternativeId);
+    let parentName = rhs.parentNode.getAttribute('name');
+    let colons = rhs.parentNode.querySelector('emu-geq');
+    rhs = rhs.cloneNode(true);
+    rhs.querySelectorAll('emu-params,emu-constraints').forEach(e => {
+      e.remove();
+    });
+    rhs.querySelectorAll('[id]').forEach(e => {
+      e.removeAttribute('id');
+    });
+    rhs.querySelectorAll('a').forEach(e => {
+      e.parentNode.replaceChild(document.createTextNode(e.textContent), e);
+    });
 
-  for (var i = 0; i < c1c.length; i++) {
+    // prettier-ignore
+    this.$headerText.innerHTML = `Syntax-Directed Operations for<br><a href="${makeLinkToId(alternativeId)}" class="menu-pane-header-production"><emu-nt>${parentName}</emu-nt> ${colons.outerHTML} </a>`;
+    this.$headerText.querySelector('a').append(rhs);
+    this.showSDOsBody(sdos, alternativeId);
+  },
+
+  showSDOsBody(sdos, alternativeId) {
+    this.activate();
+    this.state = { type: 'sdo', id: alternativeId, html: this.$headerText.innerHTML };
+    this.$headerRefId.style.display = 'none';
+    let newBody = document.createElement('tbody');
+    Object.keys(sdos).forEach(sdoName => {
+      let pair = sdos[sdoName];
+      let clause = pair.clause;
+      let ids = pair.ids;
+      let first = ids[0];
+      let row = newBody.insertRow();
+      let cell = row.insertCell();
+      cell.innerHTML = clause;
+      cell = row.insertCell();
+      let html = '<a href="' + makeLinkToId(first) + '">' + sdoName + '</a>';
+      for (let i = 1; i < ids.length; ++i) {
+        html += ' (<a href="' + makeLinkToId(ids[i]) + '">' + (i + 1) + '</a>)';
+      }
+      cell.innerHTML = html;
+    });
+    this.$table.removeChild(this.$tableBody);
+    this.$tableBody = newBody;
+    this.$table.appendChild(this.$tableBody);
+  },
+};
+
+let Toolbox = {
+  init() {
+    this.$outer = document.createElement('div');
+    this.$outer.classList.add('toolbox-container');
+    this.$container = document.createElement('div');
+    this.$container.classList.add('toolbox');
+    this.$outer.appendChild(this.$container);
+    this.$permalink = document.createElement('a');
+    this.$permalink.textContent = 'Permalink';
+    this.$pinLink = document.createElement('a');
+    this.$pinLink.textContent = 'Pin';
+    this.$pinLink.setAttribute('href', '#');
+    this.$pinLink.addEventListener('click', e => {
+      e.preventDefault();
+      e.stopPropagation();
+      menu.togglePinEntry(this.entry.id);
+      this.$pinLink.textContent = menu._pinnedIds[this.entry.id] ? 'Unpin' : 'Pin';
+    });
+
+    this.$refsLink = document.createElement('a');
+    this.$refsLink.setAttribute('href', '#');
+    this.$refsLink.addEventListener('click', e => {
+      e.preventDefault();
+      e.stopPropagation();
+      referencePane.showReferencesFor(this.entry);
+    });
+    this.$container.appendChild(this.$permalink);
+    this.$container.appendChild(this.$pinLink);
+    this.$container.appendChild(this.$refsLink);
+    document.body.appendChild(this.$outer);
+  },
+
+  activate(el, entry, target) {
+    if (el === this._activeEl) return;
+    sdoBox.deactivate();
+    this.active = true;
+    this.entry = entry;
+    this.$pinLink.textContent = menu._pinnedIds[entry.id] ? 'Unpin' : 'Pin';
+    this.$outer.classList.add('active');
+    this.top = el.offsetTop - this.$outer.offsetHeight;
+    this.left = el.offsetLeft - 10;
+    this.$outer.setAttribute('style', 'left: ' + this.left + 'px; top: ' + this.top + 'px');
+    this.updatePermalink();
+    this.updateReferences();
+    this._activeEl = el;
+    if (this.top < document.body.scrollTop && el === target) {
+      // don't scroll unless it's a small thing (< 200px)
+      this.$outer.scrollIntoView();
+    }
+  },
+
+  updatePermalink() {
+    this.$permalink.setAttribute('href', makeLinkToId(this.entry.id));
+  },
+
+  updateReferences() {
+    this.$refsLink.textContent = `References (${(this.entry.referencingIds || []).length})`;
+  },
+
+  activateIfMouseOver(e) {
+    let ref = this.findReferenceUnder(e.target);
+    if (ref && (!this.active || e.pageY > this._activeEl.offsetTop)) {
+      let entry = menu.search.biblio.byId[ref.id];
+      this.activate(ref.element, entry, e.target);
+    } else if (
+      this.active &&
+      (e.pageY < this.top || e.pageY > this._activeEl.offsetTop + this._activeEl.offsetHeight)
+    ) {
+      this.deactivate();
+    }
+  },
+
+  findReferenceUnder(el) {
+    while (el) {
+      let parent = el.parentNode;
+      if (el.nodeName === 'EMU-RHS' || el.nodeName === 'EMU-PRODUCTION') {
+        return null;
+      }
+      if (
+        el.nodeName === 'H1' &&
+        parent.nodeName.match(/EMU-CLAUSE|EMU-ANNEX|EMU-INTRO/) &&
+        parent.id
+      ) {
+        return { element: el, id: parent.id };
+      } else if (el.nodeName === 'EMU-NT') {
+        if (
+          parent.nodeName === 'EMU-PRODUCTION' &&
+          parent.id &&
+          parent.id[0] !== '_' &&
+          parent.firstElementChild === el
+        ) {
+          // return the LHS non-terminal element
+          return { element: el, id: parent.id };
+        }
+        return null;
+      } else if (
+        el.nodeName.match(/EMU-(?!CLAUSE|XREF|ANNEX|INTRO)|DFN/) &&
+        el.id &&
+        el.id[0] !== '_'
+      ) {
+        if (
+          el.nodeName === 'EMU-FIGURE' ||
+          el.nodeName === 'EMU-TABLE' ||
+          el.nodeName === 'EMU-EXAMPLE'
+        ) {
+          // return the figcaption element
+          return { element: el.children[0].children[0], id: el.id };
+        } else {
+          return { element: el, id: el.id };
+        }
+      }
+      el = parent;
+    }
+  },
+
+  deactivate() {
+    this.$outer.classList.remove('active');
+    this._activeEl = null;
+    this.active = false;
+  },
+};
+
+function sortByClauseNumber(clause1, clause2) {
+  let c1c = clause1.number.split('.');
+  let c2c = clause2.number.split('.');
+
+  for (let i = 0; i < c1c.length; i++) {
     if (i >= c2c.length) {
       return 1;
     }
 
-    var c1 = c1c[i];
-    var c2 = c2c[i];
-    var c1cn = Number(c1);
-    var c2cn = Number(c2);
+    let c1 = c1c[i];
+    let c2 = c2c[i];
+    let c1cn = Number(c1);
+    let c2cn = Number(c2);
 
     if (Number.isNaN(c1cn) && Number.isNaN(c2cn)) {
       if (c1 > c2) {
@@ -832,7 +1029,7 @@ function sortByClauseNumber(c1, c2) {
       return -1;
     } else if (Number.isNaN(c1cn) && !Number.isNaN(c2cn)) {
       return 1;
-    } else if(c1cn > c2cn) {
+    } else if (c1cn > c2cn) {
       return 1;
     } else if (c1cn < c2cn) {
       return -1;
@@ -845,59 +1042,314 @@ function sortByClauseNumber(c1, c2) {
   return -1;
 }
 
-document.addEventListener('DOMContentLoaded', function () {
+function makeLinkToId(id) {
+  let hash = '#' + id;
+  if (typeof idToSection === 'undefined' || !idToSection[id]) {
+    return hash;
+  }
+  let targetSec = idToSection[id];
+  return (targetSec === 'index' ? './' : targetSec + '.html') + hash;
+}
+
+function doShortcut(e) {
+  if (!(e.target instanceof HTMLElement)) {
+    return;
+  }
+  let target = e.target;
+  let name = target.nodeName.toLowerCase();
+  if (name === 'textarea' || name === 'input' || name === 'select' || target.isContentEditable) {
+    return;
+  }
+  if (e.altKey || e.ctrlKey || e.metaKey) {
+    return;
+  }
+  if (e.key === 'm' && usesMultipage) {
+    let pathParts = location.pathname.split('/');
+    let hash = location.hash;
+    if (pathParts[pathParts.length - 2] === 'multipage') {
+      if (hash === '') {
+        let sectionName = pathParts[pathParts.length - 1];
+        if (sectionName.endsWith('.html')) {
+          sectionName = sectionName.slice(0, -5);
+        }
+        if (idToSection['sec-' + sectionName] !== undefined) {
+          hash = '#sec-' + sectionName;
+        }
+      }
+      location = pathParts.slice(0, -2).join('/') + '/' + hash;
+    } else {
+      location = 'multipage/' + hash;
+    }
+  } else if (e.key === 'u') {
+    document.documentElement.classList.toggle('show-ao-annotations');
+  } else if (e.key === '?') {
+    document.getElementById('shortcuts-help').classList.toggle('active');
+  }
+}
+
+function init() {
+  menu = new Menu();
+  let $container = document.getElementById('spec-container');
+  $container.addEventListener(
+    'mouseover',
+    debounce(e => {
+      Toolbox.activateIfMouseOver(e);
+    })
+  );
+  document.addEventListener(
+    'keydown',
+    debounce(e => {
+      if (e.code === 'Escape') {
+        if (Toolbox.active) {
+          Toolbox.deactivate();
+        }
+        document.getElementById('shortcuts-help').classList.remove('active');
+      }
+    })
+  );
+}
+
+document.addEventListener('keypress', doShortcut);
+
+document.addEventListener('DOMContentLoaded', () => {
   Toolbox.init();
   referencePane.init();
-})
-var CLAUSE_NODES = ['EMU-CLAUSE', 'EMU-INTRO', 'EMU-ANNEX'];
-function findLocalReferences ($elem) {
-  var name = $elem.innerHTML;
-  var references = [];
+});
 
-  var parentClause = $elem.parentNode;
-  while (parentClause && CLAUSE_NODES.indexOf(parentClause.nodeName) === -1) {
-    parentClause = parentClause.parentNode;
+// preserve state during navigation
+
+function getTocPath(li) {
+  let path = [];
+  let pointer = li;
+  while (true) {
+    let parent = pointer.parentElement;
+    if (parent == null) {
+      return null;
+    }
+    let index = [].indexOf.call(parent.children, pointer);
+    if (index == -1) {
+      return null;
+    }
+    path.unshift(index);
+    pointer = parent.parentElement;
+    if (pointer == null) {
+      return null;
+    }
+    if (pointer.id === 'menu-toc') {
+      break;
+    }
+    if (pointer.tagName !== 'LI') {
+      return null;
+    }
   }
+  return path;
+}
 
-  if(!parentClause) return;
+function activateTocPath(path) {
+  try {
+    let pointer = document.getElementById('menu-toc');
+    for (let index of path) {
+      pointer = pointer.querySelector('ol').children[index];
+    }
+    pointer.classList.add('active');
+  } catch (e) {
+    // pass
+  }
+}
 
-  var vars = parentClause.querySelectorAll('var');
+function getActiveTocPaths() {
+  return [...menu.$menu.querySelectorAll('.active')].map(getTocPath).filter(p => p != null);
+}
 
-  for (var i = 0; i < vars.length; i++) {
-    var $var = vars[i];
-
-    if ($var.innerHTML === name) {
-      references.push($var);
+function loadStateFromSessionStorage() {
+  if (!window.sessionStorage || typeof menu === 'undefined' || window.navigating) {
+    return;
+  }
+  if (sessionStorage.referencePaneState != null) {
+    let state = JSON.parse(sessionStorage.referencePaneState);
+    if (state != null) {
+      if (state.type === 'ref') {
+        let entry = menu.search.biblio.byId[state.id];
+        if (entry != null) {
+          referencePane.showReferencesFor(entry);
+        }
+      } else if (state.type === 'sdo') {
+        let sdos = sdoMap[state.id];
+        if (sdos != null) {
+          referencePane.$headerText.innerHTML = state.html;
+          referencePane.showSDOsBody(sdos, state.id);
+        }
+      }
+      delete sessionStorage.referencePaneState;
     }
   }
 
-  return references;
-}
+  if (sessionStorage.activeTocPaths != null) {
+    document
+      .getElementById('menu-toc')
+      .querySelectorAll('.active')
+      .forEach(e => {
+        e.classList.remove('active');
+      });
+    let active = JSON.parse(sessionStorage.activeTocPaths);
+    active.forEach(activateTocPath);
+    delete sessionStorage.activeTocPaths;
+  }
 
-function toggleFindLocalReferences($elem) {
-  var references = findLocalReferences($elem);
-  if ($elem.classList.contains('referenced')) {
-    references.forEach(function ($reference) {
-      $reference.classList.remove('referenced');
-    });
-  } else {
-    references.forEach(function ($reference) {
-      $reference.classList.add('referenced');
-    });
+  if (sessionStorage.searchValue != null) {
+    let value = JSON.parse(sessionStorage.searchValue);
+    menu.search.$searchBox.value = value;
+    menu.search.search(value);
+    delete sessionStorage.searchValue;
+  }
+
+  if (sessionStorage.tocScroll != null) {
+    let tocScroll = JSON.parse(sessionStorage.tocScroll);
+    menu.$toc.scrollTop = tocScroll;
+    delete sessionStorage.tocScroll;
   }
 }
 
-function installFindLocalReferences () {
-  document.addEventListener('click', function (e) {
-    if (e.target.nodeName === 'VAR') {
-      toggleFindLocalReferences(e.target);
+document.addEventListener('DOMContentLoaded', loadStateFromSessionStorage);
+
+window.addEventListener('pageshow', loadStateFromSessionStorage);
+
+window.addEventListener('beforeunload', () => {
+  if (!window.sessionStorage || typeof menu === 'undefined') {
+    return;
+  }
+  sessionStorage.referencePaneState = JSON.stringify(referencePane.state || null);
+  sessionStorage.activeTocPaths = JSON.stringify(getActiveTocPaths());
+  sessionStorage.searchValue = JSON.stringify(menu.search.$searchBox.value);
+  sessionStorage.tocScroll = JSON.stringify(menu.$toc.scrollTop);
+});
+
+'use strict';
+
+// Manually prefix algorithm step list items with hidden counter representations
+// corresponding with their markers so they get selected and copied with content.
+// We read list-style-type to avoid divergence with the style sheet, but
+// for efficiency assume that all lists at the same nesting depth use the same
+// style (except for those associated with replacement steps).
+// We also precompute some initial items for each supported style type.
+// https://w3c.github.io/csswg-drafts/css-counter-styles/
+
+const lowerLetters = Array.from({ length: 26 }, (_, i) =>
+  String.fromCharCode('a'.charCodeAt(0) + i)
+);
+// Implement the lower-alpha 'alphabetic' algorithm,
+// adjusting for indexing from 0 rather than 1.
+// https://w3c.github.io/csswg-drafts/css-counter-styles/#simple-alphabetic
+// https://w3c.github.io/csswg-drafts/css-counter-styles/#alphabetic-system
+const lowerAlphaTextForIndex = i => {
+  let S = '';
+  for (const N = lowerLetters.length; i >= 0; i--) {
+    S = lowerLetters[i % N] + S;
+    i = Math.floor(i / N);
+  }
+  return S;
+};
+
+const weightedLowerRomanSymbols = Object.entries({
+  m: 1000,
+  cm: 900,
+  d: 500,
+  cd: 400,
+  c: 100,
+  xc: 90,
+  l: 50,
+  xl: 40,
+  x: 10,
+  ix: 9,
+  v: 5,
+  iv: 4,
+  i: 1,
+});
+// Implement the lower-roman 'additive' algorithm,
+// adjusting for indexing from 0 rather than 1.
+// https://w3c.github.io/csswg-drafts/css-counter-styles/#simple-numeric
+// https://w3c.github.io/csswg-drafts/css-counter-styles/#additive-system
+const lowerRomanTextForIndex = i => {
+  let value = i + 1;
+  let S = '';
+  for (const [symbol, weight] of weightedLowerRomanSymbols) {
+    if (!value) break;
+    if (weight > value) continue;
+    const reps = Math.floor(value / weight);
+    S += symbol.repeat(reps);
+    value -= weight * reps;
+  }
+  return S;
+};
+
+// Memoize pure index-to-text functions with an exposed cache for fast retrieval.
+const makeCounter = (pureGetTextForIndex, precomputeCount = 30) => {
+  const cache = Array.from({ length: precomputeCount }, (_, i) => pureGetTextForIndex(i));
+  const getTextForIndex = i => {
+    if (i >= cache.length) cache[i] = pureGetTextForIndex(i);
+    return cache[i];
+  };
+  return { getTextForIndex, cache };
+};
+
+const counterByStyle = {
+  __proto__: null,
+  decimal: makeCounter(i => String(i + 1)),
+  'lower-alpha': makeCounter(lowerAlphaTextForIndex),
+  'upper-alpha': makeCounter(i => lowerAlphaTextForIndex(i).toUpperCase()),
+  'lower-roman': makeCounter(lowerRomanTextForIndex),
+  'upper-roman': makeCounter(i => lowerRomanTextForIndex(i).toUpperCase()),
+};
+const fallbackCounter = makeCounter(() => '?');
+const counterByDepth = [];
+
+function addStepNumberText(
+  ol,
+  depth = 0,
+  special = [...ol.classList].some(c => c.startsWith('nested-'))
+) {
+  let counter = !special && counterByDepth[depth];
+  if (!counter) {
+    const counterStyle = getComputedStyle(ol)['list-style-type'];
+    counter = counterByStyle[counterStyle];
+    if (!counter) {
+      console.warn('unsupported list-style-type', {
+        ol,
+        counterStyle,
+        id: ol.closest('[id]')?.getAttribute('id'),
+      });
+      counterByStyle[counterStyle] = fallbackCounter;
+      counter = fallbackCounter;
     }
+    if (!special) {
+      counterByDepth[depth] = counter;
+    }
+  }
+  const { cache, getTextForIndex } = counter;
+  let i = (Number(ol.getAttribute('start')) || 1) - 1;
+  for (const li of ol.children) {
+    const marker = document.createElement('span');
+    marker.textContent = `${i < cache.length ? cache[i] : getTextForIndex(i)}. `;
+    marker.setAttribute('aria-hidden', 'true');
+    li.prepend(marker);
+    for (const sublist of li.querySelectorAll(':scope > ol')) {
+      addStepNumberText(sublist, depth + 1, special);
+    }
+    i++;
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('emu-alg > ol').forEach(ol => {
+    addStepNumberText(ol);
   });
-}
+});
 
-document.addEventListener('DOMContentLoaded', installFindLocalReferences);
-</script><style>body {
+let sdoMap = JSON.parse(`{}`);
+let biblio = JSON.parse(`{"refsByClause":{"sec-intl.pluralrules.prototype.resolvedoptions":["_ref_0","_ref_1"],"sec-intl.pluralrules":["_ref_2"],"sec-initializepluralrules":["_ref_3","_ref_4","_ref_5"],"sec-intl.pluralrules.prototype":["_ref_6"],"sec-intl.pluralrules.supportedlocalesof":["_ref_7"],"sec-intl.pluralrules.prototype.constructor":["_ref_8"],"sec-intl.pluralrules.prototype.select":["_ref_9"],"sec-intl.pluralrules.prototype.selectrange":["_ref_10"],"sec-properties-of-intl-pluralrules-instances":["_ref_11"],"sec-resolveplural":["_ref_12","_ref_13"],"sec-resolvepluralrange":["_ref_14","_ref_15","_ref_16"]},"entries":[{"type":"term","term":"%PluralRules%","refId":"sec-intl-pluralrules-constructor"},{"type":"clause","id":"sec-intl.pluralrules","title":"Intl.PluralRules ( [ locales [ , options ] ] )","titleHTML":"Intl.PluralRules ( [ <var>locales</var> [ , <var>options</var> ] ] )","number":"1.1.1"},{"type":"op","aoid":"InitializePluralRules","refId":"sec-initializepluralrules"},{"type":"clause","id":"sec-initializepluralrules","title":"InitializePluralRules ( pluralRules, locales, options )","titleHTML":"InitializePluralRules ( <var>pluralRules</var>, <var>locales</var>, <var>options</var> )","number":"1.1.2","referencingIds":["_ref_2"]},{"type":"clause","id":"sec-intl-pluralrules-constructor","titleHTML":"The Intl.PluralRules Constructor","number":"1.1","referencingIds":["_ref_3","_ref_4","_ref_5","_ref_7","_ref_8"]},{"type":"clause","id":"sec-intl.pluralrules.prototype","titleHTML":"Intl.PluralRules.prototype","number":"1.2.1"},{"type":"clause","id":"sec-intl.pluralrules.supportedlocalesof","title":"Intl.PluralRules.supportedLocalesOf ( locales [ , options ] )","titleHTML":"Intl.PluralRules.supportedLocalesOf ( <var>locales</var> [ , <var>options</var> ] )","number":"1.2.2"},{"type":"clause","id":"sec-intl.pluralrules-internal-slots","titleHTML":"Internal slots","number":"1.2.3"},{"type":"clause","id":"sec-properties-of-intl-pluralrules-constructor","titleHTML":"Properties of the Intl.PluralRules Constructor","number":"1.2"},{"type":"term","term":"%PluralRules.prototype%","refId":"sec-properties-of-intl-pluralrules-prototype-object"},{"type":"clause","id":"sec-intl.pluralrules.prototype.constructor","titleHTML":"Intl.PluralRules.prototype.constructor","number":"1.3.1"},{"type":"clause","id":"sec-intl.pluralrules.prototype-tostringtag","titleHTML":"Intl.PluralRules.prototype [ @@toStringTag ]","number":"1.3.2"},{"type":"clause","id":"sec-intl.pluralrules.prototype.select","title":"Intl.PluralRules.prototype.select ( value )","titleHTML":"Intl.PluralRules.prototype.select ( <var>value</var> )","number":"1.3.3"},{"type":"clause","id":"sec-intl.pluralrules.prototype.selectrange","title":"Intl.PluralRules.prototype.selectRange ( start, end )","titleHTML":"Intl.PluralRules.prototype.selectRange ( <var>start</var>, <var>end</var> )","number":"1.3.4"},{"type":"table","id":"table-pluralrules-resolvedoptions-properties","number":1,"caption":"Table 1: Resolved Options of PluralRules Instances","referencingIds":["_ref_0"]},{"type":"clause","id":"sec-intl.pluralrules.prototype.resolvedoptions","titleHTML":"Intl.PluralRules.prototype.resolvedOptions ( )","number":"1.3.5"},{"type":"clause","id":"sec-properties-of-intl-pluralrules-prototype-object","titleHTML":"Properties of the Intl.PluralRules Prototype Object","number":"1.3","referencingIds":["_ref_6","_ref_11"]},{"type":"clause","id":"sec-properties-of-intl-pluralrules-instances","titleHTML":"Properties of Intl.PluralRules Instances","number":"1.4"},{"type":"table","id":"table-plural-operands","number":2,"caption":"Table 2: Plural Rules Operands Record Fields"},{"type":"op","aoid":"GetOperands","refId":"sec-getoperands"},{"type":"clause","id":"sec-getoperands","title":"GetOperands ( s )","titleHTML":"GetOperands ( <var>s</var> )","number":"1.5.1","referencingIds":["_ref_12"]},{"type":"op","aoid":"PluralRuleSelect","refId":"sec-pluralruleselect"},{"type":"clause","id":"sec-pluralruleselect","title":"PluralRuleSelect ( locale, type, n, operands )","titleHTML":"PluralRuleSelect ( <var>locale</var>, <var>type</var>, <var>n</var>, <var>operands</var> )","number":"1.5.2","referencingIds":["_ref_1","_ref_13"]},{"type":"op","aoid":"ResolvePlural","refId":"sec-resolveplural"},{"type":"clause","id":"sec-resolveplural","title":"ResolvePlural ( pluralRules, n )","titleHTML":"ResolvePlural ( <var>pluralRules</var>, <var>n</var> )","number":"1.5.3","referencingIds":["_ref_9","_ref_14","_ref_15"]},{"type":"op","aoid":"PluralRuleSelectRange","refId":"sec-pluralruleselectrange"},{"type":"clause","id":"sec-pluralruleselectrange","title":"PluralRuleSelectRange ( locale, type, xp, yp )","titleHTML":"PluralRuleSelectRange ( <var>locale</var>, <var>type</var>, <var>xp</var>, <var>yp</var> )","number":"1.5.4","referencingIds":["_ref_16"]},{"type":"op","aoid":"ResolvePluralRange","refId":"sec-resolvepluralrange"},{"type":"clause","id":"sec-resolvepluralrange","title":"ResolvePluralRange ( pluralRules, x, y )","titleHTML":"ResolvePluralRange ( <var>pluralRules</var>, <var>x</var>, <var>y</var> )","number":"1.5.5","referencingIds":["_ref_10"]},{"type":"clause","id":"sec-intl-pluralrules-abstracts","titleHTML":"Abstract Operations for PluralRules Objects","number":"1.5"},{"type":"clause","id":"pluralrules-objects","titleHTML":"PluralRules Objects","number":"1"}]}`);
+;let usesMultipage = false</script><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.0.1/styles/base16/solarized-light.min.css"><style>body {
   display: flex;
+  word-wrap: break-word;
   font-size: 18px;
   line-height: 1.5;
   font-family: Cambria, Palatino Linotype, Palatino, Liberation Serif, serif;
@@ -912,6 +1364,7 @@ document.addEventListener('DOMContentLoaded', installFindLocalReferences);
   flex-basis: 66%;
   box-sizing: border-box;
   overflow: hidden;
+  padding-bottom: 1em;
 }
 
 body.oldtoc {
@@ -919,8 +1372,8 @@ body.oldtoc {
 }
 
 a {
-    text-decoration: none;
-    color: #206ca7;
+  text-decoration: none;
+  color: #206ca7;
 }
 
 a:visited {
@@ -928,15 +1381,51 @@ a:visited {
 }
 
 a:hover {
-    text-decoration: underline;
-    color: #239dee;
+  text-decoration: underline;
+  color: #239dee;
 }
 
+a.e-user-code,
+span.e-user-code {
+  white-space: nowrap;
+}
+
+a.e-user-code::before,
+span.e-user-code::before {
+  display: none;
+  color: brown;
+  background-color: white;
+  border: 2pt solid brown;
+  padding: 0.3ex;
+  margin: 0 0.25em 0 0;
+  line-height: 1;
+  vertical-align: text-top;
+  text-transform: uppercase;
+  font-family: 'Comic Code', sans-serif;
+  font-weight: 900;
+  font-size: x-small;
+}
+
+a.e-user-code:hover::before,
+span.e-user-code:hover::before {
+  background-color: brown;
+  color: white;
+}
+
+html.show-ao-annotations a.e-user-code::before,
+html.show-ao-annotations span.e-user-code::before {
+  display: inline-block;
+}
+
+a.e-user-code::before,
+span.e-user-code::before {
+  content: 'UC';
+}
 
 code {
-    font-weight: bold;
-    font-family: Consolas, Monaco, monospace;
-    white-space: pre;
+  font-weight: bold;
+  font-family: Consolas, Monaco, monospace;
+  white-space: pre;
 }
 
 pre code {
@@ -950,13 +1439,13 @@ pre code.hljs {
 }
 
 ol.toc {
-    list-style: none;
-    padding-left: 0;
+  list-style: none;
+  padding-left: 0;
 }
 
 ol.toc ol.toc {
-    padding-left: 2ex;
-    list-style: none;
+  padding-left: 2ex;
+  list-style: none;
 }
 
 var {
@@ -965,8 +1454,40 @@ var {
   cursor: pointer;
 }
 
-var.referenced {
+var.referenced0 {
+  color: inherit;
   background-color: #ffff33;
+  box-shadow: 0 0 0 2px #ffff33;
+}
+var.referenced1 {
+  color: inherit;
+  background-color: #ff87a2;
+  box-shadow: 0 0 0 2px #ff87a2;
+}
+var.referenced2 {
+  color: inherit;
+  background-color: #96e885;
+  box-shadow: 0 0 0 2px #96e885;
+}
+var.referenced3 {
+  color: inherit;
+  background-color: #3eeed2;
+  box-shadow: 0 0 0 2px #3eeed2;
+}
+var.referenced4 {
+  color: inherit;
+  background-color: #eacfb6;
+  box-shadow: 0 0 0 2px #eacfb6;
+}
+var.referenced5 {
+  color: inherit;
+  background-color: #82ddff;
+  box-shadow: 0 0 0 2px #82ddff;
+}
+var.referenced6 {
+  color: inherit;
+  background-color: #ffbcf2;
+  box-shadow: 0 0 0 2px #ffbcf2;
 }
 
 emu-const {
@@ -1015,6 +1536,10 @@ emu-alg ol.nested-lots ol {
   list-style-type: lower-roman;
 }
 
+emu-alg [aria-hidden=true] {
+  font-size: 0;
+}
+
 emu-eqn {
   display: block;
   margin-left: 4em;
@@ -1030,29 +1555,32 @@ emu-eqn div:first-child {
 }
 
 emu-note {
-    margin: 1em 0;
-    color: #666;
-    border-left: 5px solid #ccc;
-    display: flex;
-    flex-direction: row;
+  margin: 1em 0;
+  display: flex;
+  flex-direction: row;
+  color: inherit;
+  border-left: 5px solid #52e052;
+  background: #e9fbe9;
+  padding: 10px 10px 10px 0;
 }
 
 emu-note > span.note {
-    flex-basis: 100px;
-    min-width: 100px;
-    flex-grow: 0;
-    flex-shrink: 1;
-    text-transform: uppercase;
-    padding-left: 5px;
+  flex-basis: 100px;
+  min-width: 100px;
+  flex-grow: 0;
+  flex-shrink: 1;
+  text-transform: uppercase;
+  padding-left: 5px;
 }
 
-emu-note[type=editor] {
+emu-note[type='editor'] {
   border-left-color: #faa;
 }
 
 emu-note > div.note-contents {
   flex-grow: 1;
   flex-shrink: 1;
+  overflow: auto;
 }
 
 emu-note > div.note-contents > p:first-of-type {
@@ -1063,9 +1591,9 @@ emu-note > div.note-contents > p:last-of-type {
   margin-bottom: 0;
 }
 
-emu-table td code {
+emu-table:not(.code) td code {
   white-space: normal;
-} 
+}
 
 emu-figure {
   display: block;
@@ -1090,99 +1618,120 @@ emu-table figure {
 }
 
 emu-production {
-    display: block;
+  display: block;
 }
 
-emu-grammar[type="example"] emu-production,
-emu-grammar[type="definition"] emu-production {
-    margin-top: 1em;
-    margin-bottom: 1em;
-    margin-left: 5ex;
+emu-grammar[type='example'] emu-production,
+emu-grammar[type='definition'] emu-production {
+  margin-top: 1em;
+  margin-bottom: 1em;
+  margin-left: 5ex;
 }
 
-emu-grammar.inline, emu-production.inline,
-emu-grammar.inline emu-production emu-rhs, emu-production.inline emu-rhs,
-emu-grammar[collapsed] emu-production emu-rhs, emu-production[collapsed] emu-rhs {
-    display: inline;
-    padding-left: 1ex;
-    margin-left: 0;
+emu-grammar.inline,
+emu-production.inline,
+emu-grammar.inline emu-production emu-rhs,
+emu-production.inline emu-rhs,
+emu-grammar[collapsed] emu-production emu-rhs {
+  display: inline;
+  padding-left: 1ex;
+  margin-left: 0;
 }
 
-emu-grammar[collapsed] emu-production, emu-production[collapsed] {
-    margin: 0;
+emu-production[collapsed] emu-rhs {
+  display: inline;
+  padding-left: 0.5ex;
+  margin-left: 0;
+}
+
+emu-grammar[collapsed] emu-production,
+emu-production[collapsed] {
+  margin: 0;
 }
 
 emu-constraints {
-    font-size: .75em;
-    margin-right: 1ex;
+  font-size: 0.75em;
+  margin-right: 0.5ex;
 }
 
 emu-gann {
-    margin-right: 1ex;
+  margin-right: 0.5ex;
 }
 
 emu-gann emu-t:last-child,
 emu-gann emu-gprose:last-child,
 emu-gann emu-nt:last-child {
-    margin-right: 0;
+  margin-right: 0;
 }
 
 emu-geq {
-    margin-left: 1ex;
-    font-weight: bold;
+  margin-left: 0.5ex;
+  font-weight: bold;
 }
 
 emu-oneof {
-    font-weight: bold;
-    margin-left: 1ex;
+  font-weight: bold;
+  margin-left: 0.5ex;
 }
 
 emu-nt {
-    display: inline-block;
-    font-style: italic;
-    white-space: nowrap;
-    text-indent: 0;
+  display: inline-block;
+  font-style: italic;
+  white-space: nowrap;
+  text-indent: 0;
 }
 
-emu-nt a, emu-nt a:visited {
+emu-nt a,
+emu-nt a:visited {
   color: #333;
 }
 
 emu-rhs emu-nt {
-    margin-right: 1ex;
+  margin-right: 0.5ex;
 }
 
 emu-t {
-    display: inline-block;
-    font-family: monospace;
-    font-weight: bold;
-    white-space: nowrap;
-    text-indent: 0;
+  display: inline-block;
+  font-family: monospace;
+  font-weight: bold;
+  white-space: nowrap;
+  text-indent: 0;
 }
 
 emu-production emu-t {
-    margin-right: 1ex;
+  margin-right: 0.5ex;
 }
 
 emu-rhs {
-    display: block;
-    padding-left: 75px;
-    text-indent: -25px;
+  display: block;
+  padding-left: 75px;
+  text-indent: -25px;
+}
+
+emu-production:not([collapsed]) emu-rhs {
+  border: 0.2ex dashed transparent;
+}
+
+emu-production:not([collapsed]) emu-rhs:hover {
+  border-color: #888;
+  background-color: #f0f0f0;
 }
 
 emu-mods {
-    font-size: .85em;
-    vertical-align: sub;
-    font-style: normal;
-    font-weight: normal;
+  font-size: 0.85em;
+  vertical-align: sub;
+  font-style: normal;
+  font-weight: normal;
 }
 
-emu-params, emu-opt {
+emu-params,
+emu-opt {
   margin-right: 1ex;
   font-family: monospace;
 }
 
-emu-params, emu-constraints {
+emu-params,
+emu-constraints {
   color: #2aa198;
 }
 
@@ -1191,12 +1740,12 @@ emu-opt {
 }
 
 emu-gprose {
-    font-size: 0.9em;
-    font-family: Helvetica, Arial, sans-serif;
+  font-size: 0.9em;
+  font-family: Helvetica, Arial, sans-serif;
 }
 
 emu-production emu-gprose {
-    margin-right: 1ex;
+  margin-right: 1ex;
 }
 
 h1.shortname {
@@ -1208,20 +1757,19 @@ h1.shortname {
 h1.version {
   color: #f60;
   font-size: 1.5em;
-  margin: 0;
 }
 
 h1.title {
-  margin-top: 0;
   color: #f60;
 }
 
-h1.first {
-  margin-top: 0;
-}
-
-h1, h2, h3, h4, h5, h6 {
-    position: relative;
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  position: relative;
 }
 
 h1 .secnum {
@@ -1233,142 +1781,267 @@ h1 span.title {
   order: 2;
 }
 
+h1 {
+  font-size: 2.67em;
+  margin-bottom: 0;
+  line-height: 1em;
+}
+h2 {
+  font-size: 2em;
+}
+h3 {
+  font-size: 1.56em;
+}
+h4 {
+  font-size: 1.25em;
+}
+h5 {
+  font-size: 1.11em;
+}
+h6 {
+  font-size: 1em;
+}
 
-h1 { font-size: 2.67em; margin-top: 2em; margin-bottom: 0; line-height: 1em;}
-h2 { font-size: 2em; }
-h3 { font-size: 1.56em; }
-h4 { font-size: 1.25em; }
-h5 { font-size: 1.11em; }
-h6 { font-size: 1em; }
+pre code.hljs {
+  background: transparent;
+}
 
-h1:hover span.utils {
+emu-clause[id],
+emu-annex[id],
+emu-intro[id] {
+  scroll-margin-top: 2ex;
+}
+
+emu-intro h1,
+emu-clause h1,
+emu-annex h1 {
+  font-size: 2em;
+}
+emu-intro h2,
+emu-clause h2,
+emu-annex h2 {
+  font-size: 1.56em;
+}
+emu-intro h3,
+emu-clause h3,
+emu-annex h3 {
+  font-size: 1.25em;
+}
+emu-intro h4,
+emu-clause h4,
+emu-annex h4 {
+  font-size: 1.11em;
+}
+emu-intro h5,
+emu-clause h5,
+emu-annex h5 {
+  font-size: 1em;
+}
+emu-intro h6,
+emu-clause h6,
+emu-annex h6 {
+  font-size: 0.9em;
+}
+emu-intro emu-intro h1,
+emu-clause emu-clause h1,
+emu-annex emu-annex h1 {
+  font-size: 1.56em;
+}
+emu-intro emu-intro h2,
+emu-clause emu-clause h2,
+emu-annex emu-annex h2 {
+  font-size: 1.25em;
+}
+emu-intro emu-intro h3,
+emu-clause emu-clause h3,
+emu-annex emu-annex h3 {
+  font-size: 1.11em;
+}
+emu-intro emu-intro h4,
+emu-clause emu-clause h4,
+emu-annex emu-annex h4 {
+  font-size: 1em;
+}
+emu-intro emu-intro h5,
+emu-clause emu-clause h5,
+emu-annex emu-annex h5 {
+  font-size: 0.9em;
+}
+emu-intro emu-intro emu-intro h1,
+emu-clause emu-clause emu-clause h1,
+emu-annex emu-annex emu-annex h1 {
+  font-size: 1.25em;
+}
+emu-intro emu-intro emu-intro h2,
+emu-clause emu-clause emu-clause h2,
+emu-annex emu-annex emu-annex h2 {
+  font-size: 1.11em;
+}
+emu-intro emu-intro emu-intro h3,
+emu-clause emu-clause emu-clause h3,
+emu-annex emu-annex emu-annex h3 {
+  font-size: 1em;
+}
+emu-intro emu-intro emu-intro h4,
+emu-clause emu-clause emu-clause h4,
+emu-annex emu-annex emu-annex h4 {
+  font-size: 0.9em;
+}
+emu-intro emu-intro emu-intro emu-intro h1,
+emu-clause emu-clause emu-clause emu-clause h1,
+emu-annex emu-annex emu-annex emu-annex h1 {
+  font-size: 1.11em;
+}
+emu-intro emu-intro emu-intro emu-intro h2,
+emu-clause emu-clause emu-clause emu-clause h2,
+emu-annex emu-annex emu-annex emu-annex h2 {
+  font-size: 1em;
+}
+emu-intro emu-intro emu-intro emu-intro h3,
+emu-clause emu-clause emu-clause emu-clause h3,
+emu-annex emu-annex emu-annex emu-annex h3 {
+  font-size: 0.9em;
+}
+emu-intro emu-intro emu-intro emu-intro emu-intro h1,
+emu-clause emu-clause emu-clause emu-clause emu-clause h1,
+emu-annex emu-annex emu-annex emu-annex emu-annex h1 {
+  font-size: 1em;
+}
+emu-intro emu-intro emu-intro emu-intro emu-intro h2,
+emu-clause emu-clause emu-clause emu-clause emu-clause h2,
+emu-annex emu-annex emu-annex emu-annex emu-annex h2 {
+  font-size: 0.9em;
+}
+emu-intro emu-intro emu-intro emu-intro emu-intro emu-intro h1,
+emu-clause emu-clause emu-clause emu-clause emu-clause emu-clause h1,
+emu-annex emu-annex emu-annex emu-annex emu-annex emu-annex h1 {
+  font-size: 0.9em;
+}
+
+emu-clause,
+emu-intro,
+emu-annex {
   display: block;
 }
 
-span.utils {
-  font-size: 18px;
-  line-height: 18px;
-  display: none;
-  position: absolute;
-  top: 100%;
-  left: 0;
-  right: 0;
-  font-weight: normal;
+/* these values are twice the font-size for the <h1> titles for clauses */
+emu-intro,
+emu-clause,
+emu-annex {
+  margin-top: 4em;
+}
+emu-intro emu-intro,
+emu-clause emu-clause,
+emu-annex emu-annex {
+  margin-top: 3.12em;
+}
+emu-intro emu-intro emu-intro,
+emu-clause emu-clause emu-clause,
+emu-annex emu-annex emu-annex {
+  margin-top: 2.5em;
+}
+emu-intro emu-intro emu-intro emu-intro,
+emu-clause emu-clause emu-clause emu-clause,
+emu-annex emu-annex emu-annex emu-annex {
+  margin-top: 2.22em;
+}
+emu-intro emu-intro emu-intro emu-intro emu-intro,
+emu-clause emu-clause emu-clause emu-clause emu-clause,
+emu-annex emu-annex emu-annex emu-annex emu-annex {
+  margin-top: 2em;
+}
+emu-intro emu-intro emu-intro emu-intro emu-intro emu-intro,
+emu-clause emu-clause emu-clause emu-clause emu-clause emu-clause,
+emu-annex emu-annex emu-annex emu-annex emu-annex emu-annex {
+  margin-top: 1.8em;
 }
 
-span.utils:before {
-    content: "⤷";
-    display: inline-block;
-    padding: 0 5px;
-}
-
-span.utils > * {
-  display: inline-block;
-  margin-right: 20px;
-}
-
-h1 span.utils span.anchor a,
-h2 span.utils span.anchor a,
-h3 span.utils span.anchor a,
-h4 span.utils span.anchor a,
-h5 span.utils span.anchor a,
-h6 span.utils span.anchor a {
-  text-decoration: none;
-  font-variant: small-caps;
-}
-
-h1 span.utils span.anchor a:hover,
-h2 span.utils span.anchor a:hover,
-h3 span.utils span.anchor a:hover,
-h4 span.utils span.anchor a:hover,
-h5 span.utils span.anchor a:hover,
-h6 span.utils span.anchor a:hover {
-  color: #333;
-}
-
-emu-intro h1, emu-clause h1, emu-annex h1 { font-size: 2em; }
-emu-intro h2, emu-clause h2, emu-annex h2 { font-size: 1.56em; }
-emu-intro h3, emu-clause h3, emu-annex h3 { font-size: 1.25em; }
-emu-intro h4, emu-clause h4, emu-annex h4 { font-size: 1.11em; }
-emu-intro h5, emu-clause h5, emu-annex h5 { font-size: 1em; }
-emu-intro h6, emu-clause h6, emu-annex h6 { font-size: 0.9em; }
-emu-intro emu-intro h1, emu-clause emu-clause h1, emu-annex emu-annex h1 { font-size: 1.56em; }
-emu-intro emu-intro h2, emu-clause emu-clause h2, emu-annex emu-annex h2 { font-size: 1.25em; }
-emu-intro emu-intro h3, emu-clause emu-clause h3, emu-annex emu-annex h3 { font-size: 1.11em; }
-emu-intro emu-intro h4, emu-clause emu-clause h4, emu-annex emu-annex h4 { font-size: 1em; }
-emu-intro emu-intro h5, emu-clause emu-clause h5, emu-annex emu-annex h5 { font-size: 0.9em; }
-emu-intro emu-intro emu-intro h1, emu-clause emu-clause emu-clause h1, emu-annex emu-annex emu-annex h1 { font-size: 1.25em; }
-emu-intro emu-intro emu-intro h2, emu-clause emu-clause emu-clause h2, emu-annex emu-annex emu-annex h2 { font-size: 1.11em; }
-emu-intro emu-intro emu-intro h3, emu-clause emu-clause emu-clause h3, emu-annex emu-annex emu-annex h3 { font-size: 1em; }
-emu-intro emu-intro emu-intro h4, emu-clause emu-clause emu-clause h4, emu-annex emu-annex emu-annex h4 { font-size: 0.9em; }
-emu-intro emu-intro emu-intro emu-intro h1, emu-clause emu-clause emu-clause emu-clause h1, emu-annex emu-annex emu-annex emu-annex h1 { font-size: 1.11em; }
-emu-intro emu-intro emu-intro emu-intro h2, emu-clause emu-clause emu-clause emu-clause h2, emu-annex emu-annex emu-annex emu-annex h2 { font-size: 1em; }
-emu-intro emu-intro emu-intro emu-intro h3, emu-clause emu-clause emu-clause emu-clause h3, emu-annex emu-annex emu-annex emu-annex h3 { font-size: 0.9em; }
-emu-intro emu-intro emu-intro emu-intro emu-intro h1, emu-clause emu-clause emu-clause emu-clause emu-clause h1, emu-annex emu-annex emu-annex emu-annex emu-annex h1 { font-size: 1em; }
-emu-intro emu-intro emu-intro emu-intro emu-intro h2, emu-clause emu-clause emu-clause emu-clause emu-clause h2, emu-annex emu-annex emu-annex emu-annex emu-annex h2 { font-size: 0.9em; }
-emu-intro emu-intro emu-intro emu-intro emu-intro emu-intro h1, emu-clause emu-clause emu-clause emu-clause emu-clause emu-clause h1, emu-annex emu-annex emu-annex emu-annex emu-annex emu-annex h1 { font-size: 0.9em }
-
-emu-clause, emu-intro, emu-annex {
-    display: block;
+#spec-container > emu-intro:first-of-type,
+#spec-container > emu-clause:first-of-type,
+#spec-container > emu-annex:first-of-type {
+  margin-top: 0;
 }
 
 /* Figures and tables */
-figure { display: block; margin: 1em 0 3em 0; }
-figure object { display: block; margin: 0 auto; }
-figure table.real-table { margin: 0 auto; }
+figure {
+  display: block;
+  margin: 1em 0 3em 0;
+}
+figure object {
+  display: block;
+  margin: 0 auto;
+}
+figure table.real-table {
+  margin: 0 auto;
+}
 figure figcaption {
-    display: block;
-    color: #555555;
-    font-weight: bold;
-    text-align: center;
+  display: block;
+  color: #555555;
+  font-weight: bold;
+  text-align: center;
 }
 
 emu-table table {
   margin: 0 auto;
 }
 
-emu-table table, table.real-table {
-    border-collapse: collapse;
+emu-table table,
+table.real-table {
+  border-collapse: collapse;
 }
 
-emu-table td, emu-table th, table.real-table td, table.real-table th {
-    border: 1px solid black;
-    padding: 0.4em;
-    vertical-align: baseline;
+emu-table td,
+emu-table th,
+table.real-table td,
+table.real-table th {
+  border: 1px solid black;
+  padding: 0.4em;
+  vertical-align: baseline;
 }
-emu-table th, emu-table thead td, table.real-table th {
-    background-color: #eeeeee;
+emu-table th,
+emu-table thead td,
+table.real-table th {
+  background-color: #eeeeee;
+}
+
+emu-table td {
+  background: #fff;
 }
 
 /* Note: the left content edges of table.lightweight-table >tbody >tr >td
    and div.display line up. */
 table.lightweight-table {
-    border-collapse: collapse;
-    margin: 0 0 0 1.5em;
+  border-collapse: collapse;
+  margin: 0 0 0 1.5em;
 }
-table.lightweight-table td, table.lightweight-table th {
-    border: none;
-    padding: 0 0.5em;
-    vertical-align: baseline;
+table.lightweight-table td,
+table.lightweight-table th {
+  border: none;
+  padding: 0 0.5em;
+  vertical-align: baseline;
 }
 
 /* diff styles */
 ins {
-    background-color: #e0f8e0;
-    text-decoration: none;
-    border-bottom: 1px solid #396;
+  background-color: #e0f8e0;
+  text-decoration: none;
+  border-bottom: 1px solid #396;
 }
 
 del {
-    background-color: #fee;
+  background-color: #fee;
 }
 
-ins.block, del.block,
-emu-production > ins, emu-production > del,
-emu-grammar > ins, emu-grammar > del {
+ins.block,
+del.block,
+emu-production > ins,
+emu-production > del,
+emu-grammar > ins,
+emu-grammar > del {
   display: block;
 }
-emu-rhs > ins, emu-rhs > del { 
+emu-rhs > ins,
+emu-rhs > del {
   display: inline;
 }
 
@@ -1405,7 +2078,7 @@ tr.del > td {
   -khtml-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
-  user-select: none;;
+  user-select: none;
 
   cursor: pointer;
 }
@@ -1413,7 +2086,8 @@ tr.del > td {
 #menu {
   display: flex;
   flex-direction: column;
-  width: 33%; height: 100vh;
+  width: 33%;
+  height: 100vh;
   max-width: 500px;
   box-sizing: border-box;
   background-color: #ddd;
@@ -1421,13 +2095,14 @@ tr.del > td {
   transition: opacity 0.1s linear;
   padding: 0 5px;
   position: fixed;
-  left: 0; top: 0;
+  left: 0;
+  top: 0;
   border-right: 2px solid #bbb;
 
   z-index: 2;
 }
 
-#menu-spacer {
+.menu-spacer {
   flex-basis: 33%;
   max-width: 500px;
   flex-grow: 0;
@@ -1482,7 +2157,8 @@ tr.del > td {
   padding: 0;
 }
 
-#menu-toc > ol , #menu-toc > ol ol {
+#menu-toc > ol,
+#menu-toc > ol ol {
   list-style-type: none;
   margin: 0;
   padding: 0;
@@ -1512,7 +2188,7 @@ tr.del > td {
   -khtml-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
-  user-select: none;;
+  user-select: none;
 
   cursor: pointer;
 }
@@ -1543,7 +2219,7 @@ tr.del > td {
   */
 }
 
-#menu-toc li.revealed-leaf> a {
+#menu-toc li.revealed-leaf > a {
   color: #206ca7;
   /*
   background-color: #222;
@@ -1579,6 +2255,34 @@ tr.del > td {
   font-size: 0.8em;
 }
 
+.menu-pane-header emu-opt,
+.menu-pane-header emu-t,
+.menu-pane-header emu-nt {
+  margin-right: 0px;
+  display: inline;
+  color: inherit;
+}
+
+.menu-pane-header emu-rhs {
+  display: inline;
+  padding-left: 0px;
+  text-indent: 0px;
+}
+
+.menu-pane-header emu-geq {
+  margin-left: 0px;
+}
+
+a.menu-pane-header-production {
+  color: inherit;
+}
+
+.menu-pane-header-production {
+  text-transform: none;
+  letter-spacing: 1.5px;
+  padding-left: 0.5em;
+}
+
 #menu-toc {
   display: flex;
   flex-direction: column;
@@ -1597,10 +2301,10 @@ tr.del > td {
   flex-grow: 0;
   flex-shrink: 0;
   width: 100%;
-  
+
   display: flex;
   flex-direction: column;
-  
+
   max-height: 300px;
 }
 
@@ -1625,43 +2329,42 @@ tr.del > td {
 }
 
 li.menu-search-result-clause:before {
-    content: 'clause';
-    width: 40px;
-    display: inline-block;
-    text-align: right;
-    padding-right: 1ex;
-    color: #666;
-    font-size: 75%;
+  content: 'clause';
+  width: 40px;
+  display: inline-block;
+  text-align: right;
+  padding-right: 1ex;
+  color: #666;
+  font-size: 75%;
 }
 li.menu-search-result-op:before {
-    content: 'op';
-    width: 40px;
-    display: inline-block;
-    text-align: right;
-    padding-right: 1ex;
-    color: #666;
-    font-size: 75%;
+  content: 'op';
+  width: 40px;
+  display: inline-block;
+  text-align: right;
+  padding-right: 1ex;
+  color: #666;
+  font-size: 75%;
 }
 
 li.menu-search-result-prod:before {
-    content: 'prod';
-    width: 40px;
-    display: inline-block;
-    text-align: right;
-    padding-right: 1ex;
-    color: #666;
-    font-size: 75%
+  content: 'prod';
+  width: 40px;
+  display: inline-block;
+  text-align: right;
+  padding-right: 1ex;
+  color: #666;
+  font-size: 75%;
 }
 
-
 li.menu-search-result-term:before {
-    content: 'term';
-    width: 40px;
-    display: inline-block;
-    text-align: right;
-    padding-right: 1ex;
-    color: #666;
-    font-size: 75%
+  content: 'term';
+  width: 40px;
+  display: inline-block;
+  text-align: right;
+  padding-right: 1ex;
+  color: #666;
+  font-size: 75%;
 }
 
 #menu-search-results ul {
@@ -1674,7 +2377,6 @@ li.menu-search-result-term:before {
   text-overflow: ellipsis;
 }
 
-
 #menu-trace-list {
   counter-reset: item;
   margin: 0 0 0 20px;
@@ -1686,19 +2388,19 @@ li.menu-search-result-term:before {
 }
 
 #menu-trace-list li .secnum:after {
-  content: " ";
+  content: ' ';
 }
 #menu-trace-list li:before {
-    content: counter(item) " ";
-    background-color: #222;
-    counter-increment: item;
-    color: #999;
-    width: 20px;
-    height: 20px;
-    line-height: 20px;
-    display: inline-block;
-    text-align: center;
-    margin: 2px 4px 2px 0;
+  content: counter(item) ' ';
+  background-color: #222;
+  counter-increment: item;
+  color: #999;
+  width: 20px;
+  height: 20px;
+  line-height: 20px;
+  display: inline-block;
+  text-align: center;
+  margin: 2px 4px 2px 0;
 }
 
 @media (max-width: 1000px) {
@@ -1740,24 +2442,29 @@ li.menu-search-result-term:before {
   }
 
   h1 .secnum:empty {
-    margin: 0; padding: 0;
+    margin: 0;
+    padding: 0;
   }
 }
 
-
 /* Toolbox */
-.toolbox {
-	position: absolute;
-	background: #ddd;
-	border: 1px solid #aaa;
+.toolbox-container {
+  position: absolute;
   display: none;
+  padding-bottom: 7px;
+}
+
+.toolbox-container.active {
+  display: inline-block;
+}
+
+.toolbox {
+  position: relative;
+  background: #ddd;
+  border: 1px solid #aaa;
   color: #eee;
   padding: 5px;
   border-radius: 3px;
-}
-
-.toolbox.active {
-  display: inline-block;
 }
 
 .toolbox a {
@@ -1769,28 +2476,29 @@ li.menu-search-result-term:before {
   text-decoration: underline;
 }
 
-.toolbox:after, .toolbox:before {
-	top: 100%;
-	left: 15px;
-	border: solid transparent;
-	content: " ";
-	height: 0;
-	width: 0;
-	position: absolute;
-	pointer-events: none;
+.toolbox:after,
+.toolbox:before {
+  top: 100%;
+  left: 15px;
+  border: solid transparent;
+  content: ' ';
+  height: 0;
+  width: 0;
+  position: absolute;
+  pointer-events: none;
 }
 
 .toolbox:after {
-	border-color: rgba(0, 0, 0, 0);
-	border-top-color: #ddd;
-	border-width: 10px;
-	margin-left: -10px;
+  border-color: rgba(0, 0, 0, 0);
+  border-top-color: #ddd;
+  border-width: 10px;
+  margin-left: -10px;
 }
 .toolbox:before {
-	border-color: rgba(204, 204, 204, 0);
-	border-top-color: #aaa;
-	border-width: 12px;
-	margin-left: -12px;
+  border-color: rgba(204, 204, 204, 0);
+  border-top-color: #aaa;
+  border-width: 12px;
+  margin-left: -12px;
 }
 
 #references-pane-container {
@@ -1807,11 +2515,6 @@ li.menu-search-result-term:before {
 #references-pane-table-container {
   overflow-x: hidden;
   overflow-y: auto;
-}
-
-#references-pane-spacer {
-  flex-basis: 33%;
-  max-width: 500px;
 }
 
 #references-pane {
@@ -1831,6 +2534,10 @@ li.menu-search-result-term:before {
   cursor: pointer;
 }
 
+#references-pane table tbody {
+  vertical-align: baseline;
+}
+
 #references-pane table tr td:first-child {
   text-align: right;
   padding-right: 5px;
@@ -1838,39 +2545,84 @@ li.menu-search-result-term:before {
 
 @media print {
   #menu-toggle {
-    display: none; 
+    display: none;
   }
 }
-</style></head><body><div id="menu-toggle">☰</div><div id="menu-spacer"></div><div id="menu"><div id="menu-search"><input type="text" id="menu-search-box" placeholder="Search..."><div id="menu-search-results" class="inactive"></div></div><div id="menu-pins"><div class="menu-pane-header">Pins</div><ul id="menu-pins-list"></ul></div><div class="menu-pane-header">Table of Contents</div><div id="menu-toc"><ol class="toc"><li><span class="item-toggle">◢</span><a href="#pluralrules-objects" title="PluralRules Objects"><span class="secnum">1</span> PluralRules Objects</a><ol class="toc"><li><span class="item-toggle">◢</span><a href="#sec-intl-pluralrules-constructor" title="The Intl.PluralRules Constructor"><span class="secnum">1.1</span> The Intl.PluralRules Constructor</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-intl.pluralrules" title="Intl.PluralRules ( [ locales [ , options ] ] )"><span class="secnum">1.1.1</span> Intl.PluralRules ( [ <var>locales</var> [ , <var>options</var> ] ] )</a></li><li><span class="item-toggle-none"></span><a href="#sec-initializepluralrules" title="InitializePluralRules ( pluralRules, locales, options )"><span class="secnum">1.1.2</span> InitializePluralRules ( <var>pluralRules</var>, <var>locales</var>, <var>options</var> )</a></li></ol></li><li><span class="item-toggle">◢</span><a href="#sec-properties-of-intl-pluralrules-constructor" title="Properties of the Intl.PluralRules Constructor"><span class="secnum">1.2</span> Properties of the Intl.PluralRules Constructor</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-intl.pluralrules.prototype" title="Intl.PluralRules.prototype"><span class="secnum">1.2.1</span> Intl.PluralRules.prototype</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.pluralrules.supportedlocalesof" title="Intl.PluralRules.supportedLocalesOf ( locales [ , options ] )"><span class="secnum">1.2.2</span> Intl.PluralRules.supportedLocalesOf ( <var>locales</var> [ , <var>options</var> ] )</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.pluralrules-internal-slots" title="Internal slots"><span class="secnum">1.2.3</span> Internal slots</a></li></ol></li><li><span class="item-toggle">◢</span><a href="#sec-properties-of-intl-pluralrules-prototype-object" title="Properties of the Intl.PluralRules Prototype Object"><span class="secnum">1.3</span> Properties of the Intl.PluralRules Prototype Object</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-intl.pluralrules.prototype.constructor" title="Intl.PluralRules.prototype.constructor"><span class="secnum">1.3.1</span> Intl.PluralRules.prototype.constructor</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.pluralrules.prototype-tostringtag" title="Intl.PluralRules.prototype [ @@toStringTag ]"><span class="secnum">1.3.2</span> Intl.PluralRules.prototype [ @@toStringTag ]</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.pluralrules.prototype.select" title="Intl.PluralRules.prototype.select ( value )"><span class="secnum">1.3.3</span> Intl.PluralRules.prototype.select ( <var>value</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.pluralrules.prototype.selectrange" title="Intl.PluralRules.prototype.selectRange ( start, end )"><span class="secnum">1.3.4</span> Intl.PluralRules.prototype.selectRange ( <var>start</var>, <var>end</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.pluralrules.prototype.resolvedoptions" title="Intl.PluralRules.prototype.resolvedOptions ( )"><span class="secnum">1.3.5</span> Intl.PluralRules.prototype.resolvedOptions ( )</a></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-properties-of-intl-pluralrules-instances" title="Properties of Intl.PluralRules Instances"><span class="secnum">1.4</span> Properties of Intl.PluralRules Instances</a></li><li><span class="item-toggle">◢</span><a href="#sec-intl-pluralrules-abstracts" title="Abstract Operations for PluralRules Objects"><span class="secnum">1.5</span> Abstract Operations for PluralRules Objects</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-getoperands" title="
-         GetOperands (
-           s: a decimal String,
-         )
-       "><span class="secnum">1.5.1</span> 
-         GetOperands (
-           <var>s</var>: a decimal String,
-         )
-       </a></li><li><span class="item-toggle-none"></span><a href="#sec-pluralruleselect" title="
-        PluralRuleSelect (
-          locale: a String,
-          type: a String,
-          n: a finite Number,
-          operands: a Plural Rules Operands Record derived from formatting n,
-        )
-      "><span class="secnum">1.5.2</span> 
-        PluralRuleSelect (
-          <var>locale</var>: a String,
-          <var>type</var>: a String,
-          <var>n</var>: a finite Number,
-          <var>operands</var>: a Plural Rules Operands Record derived from formatting <var>n</var>,
-        )
-      </a></li><li><span class="item-toggle-none"></span><a href="#sec-resolveplural" title="ResolvePlural ( pluralRules, n )"><span class="secnum">1.5.3</span> ResolvePlural ( <var>pluralRules</var>, <var>n</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-pluralruleselectrange" title="PluralRuleSelectRange ( locale, type, xp, yp )"><span class="secnum">1.5.4</span> PluralRuleSelectRange ( <var>locale</var>, <var>type</var>, <var>xp</var>, <var>yp</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-resolvepluralrange" title="ResolvePluralRange ( pluralRules, x, y )"><span class="secnum">1.5.5</span> ResolvePluralRange ( <var>pluralRules</var>, <var>x</var>, <var>y</var> )</a></li></ol></li></ol></li></ol></div></div><div id="spec-container"><emu-clause id="pluralrules-objects">
-  <h1 class="first"><span class="secnum">1</span> PluralRules Objects</h1>
+
+[normative-optional],
+[legacy] {
+  border-left: 5px solid #ff6600;
+  padding: 0.5em;
+  display: block;
+  background: #ffeedd;
+}
+
+.clause-attributes-tag {
+  text-transform: uppercase;
+  color: #884400;
+}
+
+.clause-attributes-tag a {
+  color: #884400;
+}
+
+/* Shortcuts help dialog */
+
+#shortcuts-help {
+  position: fixed;
+  left: 5%;
+  margin: 0 auto;
+  right: 5%;
+  z-index: 10;
+  top: 10%;
+  top: calc(5vw + 5vh);
+  padding: 30px 90px;
+  max-width: 500px;
+  outline: solid 10000px rgba(255, 255, 255, 0.6);
+  border-radius: 5px;
+  border-width: 1px 1px 0 1px;
+  background-color: #ddd;
+  display: none;
+}
+
+#shortcuts-help.active {
+  display: block;
+}
+
+#shortcuts-help ul {
+  padding: 0;
+}
+
+#shortcuts-help li {
+  display: flex;
+  justify-content: space-between;
+}
+
+#shortcuts-help code {
+  padding: 3px 10px;
+  border-radius: 3px;
+  border-width: 1px 1px 0 1px;
+  border-color: #bbb;
+  background-color: #eee;
+  box-shadow: inset 0 -1px 0 #ccc;
+}
+</style></head><body><div id="shortcuts-help">
+<ul>
+  <li><span>Toggle shortcuts help</span><code>?</code></li>
+  <li><span>Toggle "can call user code" annotations</span><code>u</code></li>
+
+  <li><span>Jump to search box</span><code>/</code></li>
+</ul></div><div id="menu-toggle"><svg xmlns="http://www.w3.org/2000/svg" style="width:100%; height:100%; stroke:currentColor" viewBox="0 0 120 120">
+      <title>Menu</title>
+      <path stroke-width="10" stroke-linecap="round" d="M30,60 h60  M30,30 m0,5 h60  M30,90 m0,-5 h60"></path>
+    </svg></div><div id="menu-spacer" class="menu-spacer"></div><div id="menu"><div id="menu-search"><input type="text" id="menu-search-box" placeholder="Search..."><div id="menu-search-results" class="inactive"></div></div><div id="menu-pins"><div class="menu-pane-header">Pins</div><ul id="menu-pins-list"></ul></div><div class="menu-pane-header">Table of Contents</div><div id="menu-toc"><ol class="toc"><li><span class="item-toggle">◢</span><a href="#pluralrules-objects" title="PluralRules Objects"><span class="secnum">1</span> PluralRules Objects</a><ol class="toc"><li><span class="item-toggle">◢</span><a href="#sec-intl-pluralrules-constructor" title="The Intl.PluralRules Constructor"><span class="secnum">1.1</span> The Intl.PluralRules Constructor</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-intl.pluralrules" title="Intl.PluralRules ( [ locales [ , options ] ] )"><span class="secnum">1.1.1</span> Intl.PluralRules ( [ <var>locales</var> [ , <var>options</var> ] ] )</a></li><li><span class="item-toggle-none"></span><a href="#sec-initializepluralrules" title="InitializePluralRules ( pluralRules, locales, options )"><span class="secnum">1.1.2</span> InitializePluralRules ( <var>pluralRules</var>, <var>locales</var>, <var>options</var> )</a></li></ol></li><li><span class="item-toggle">◢</span><a href="#sec-properties-of-intl-pluralrules-constructor" title="Properties of the Intl.PluralRules Constructor"><span class="secnum">1.2</span> Properties of the Intl.PluralRules Constructor</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-intl.pluralrules.prototype" title="Intl.PluralRules.prototype"><span class="secnum">1.2.1</span> Intl.PluralRules.prototype</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.pluralrules.supportedlocalesof" title="Intl.PluralRules.supportedLocalesOf ( locales [ , options ] )"><span class="secnum">1.2.2</span> Intl.PluralRules.supportedLocalesOf ( <var>locales</var> [ , <var>options</var> ] )</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.pluralrules-internal-slots" title="Internal slots"><span class="secnum">1.2.3</span> Internal slots</a></li></ol></li><li><span class="item-toggle">◢</span><a href="#sec-properties-of-intl-pluralrules-prototype-object" title="Properties of the Intl.PluralRules Prototype Object"><span class="secnum">1.3</span> Properties of the Intl.PluralRules Prototype Object</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-intl.pluralrules.prototype.constructor" title="Intl.PluralRules.prototype.constructor"><span class="secnum">1.3.1</span> Intl.PluralRules.prototype.constructor</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.pluralrules.prototype-tostringtag" title="Intl.PluralRules.prototype [ @@toStringTag ]"><span class="secnum">1.3.2</span> Intl.PluralRules.prototype [ @@toStringTag ]</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.pluralrules.prototype.select" title="Intl.PluralRules.prototype.select ( value )"><span class="secnum">1.3.3</span> Intl.PluralRules.prototype.select ( <var>value</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.pluralrules.prototype.selectrange" title="Intl.PluralRules.prototype.selectRange ( start, end )"><span class="secnum">1.3.4</span> Intl.PluralRules.prototype.selectRange ( <var>start</var>, <var>end</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.pluralrules.prototype.resolvedoptions" title="Intl.PluralRules.prototype.resolvedOptions ( )"><span class="secnum">1.3.5</span> Intl.PluralRules.prototype.resolvedOptions ( )</a></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-properties-of-intl-pluralrules-instances" title="Properties of Intl.PluralRules Instances"><span class="secnum">1.4</span> Properties of Intl.PluralRules Instances</a></li><li><span class="item-toggle">◢</span><a href="#sec-intl-pluralrules-abstracts" title="Abstract Operations for PluralRules Objects"><span class="secnum">1.5</span> Abstract Operations for PluralRules Objects</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-getoperands" title="GetOperands ( s )"><span class="secnum">1.5.1</span> GetOperands ( <var>s</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-pluralruleselect" title="PluralRuleSelect ( locale, type, n, operands )"><span class="secnum">1.5.2</span> PluralRuleSelect ( <var>locale</var>, <var>type</var>, <var>n</var>, <var>operands</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-resolveplural" title="ResolvePlural ( pluralRules, n )"><span class="secnum">1.5.3</span> ResolvePlural ( <var>pluralRules</var>, <var>n</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-pluralruleselectrange" title="PluralRuleSelectRange ( locale, type, xp, yp )"><span class="secnum">1.5.4</span> PluralRuleSelectRange ( <var>locale</var>, <var>type</var>, <var>xp</var>, <var>yp</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-resolvepluralrange" title="ResolvePluralRange ( pluralRules, x, y )"><span class="secnum">1.5.5</span> ResolvePluralRange ( <var>pluralRules</var>, <var>x</var>, <var>y</var> )</a></li></ol></li></ol></li></ol></div></div><div id="spec-container"><emu-clause id="pluralrules-objects">
+  <h1><span class="secnum">1</span> PluralRules Objects</h1>
 
   <emu-clause id="sec-intl-pluralrules-constructor">
     <h1><span class="secnum">1.1</span> The Intl.PluralRules Constructor</h1>
 
     <p>
-      The PluralRules <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> is the <dfn>%PluralRules%</dfn> intrinsic object and a standard built-in property of the Intl object. Behaviour common to all service <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> properties of the Intl object is specified in <emu-xref href="#sec-internal-slots"></emu-xref>.
+      The PluralRules constructor is the <dfn>%PluralRules%</dfn> intrinsic object and a standard built-in property of the Intl object. Behaviour common to all service constructor properties of the Intl object is specified in <emu-xref href="#sec-internal-slots"></emu-xref>.
     </p>
 
     <emu-clause id="sec-intl.pluralrules">
@@ -1880,7 +2632,7 @@ li.menu-search-result-term:before {
         When the <code>Intl.PluralRules</code> function is called with optional arguments <var>locales</var> and <var>options</var>, the following steps are taken:
       </p>
 
-      <emu-alg><ol><li>If NewTarget is <emu-val>undefined</emu-val>, throw a <emu-val>TypeError</emu-val> exception.</li><li>Let <var>pluralRules</var> be ?&nbsp;<emu-xref aoid="OrdinaryCreateFromConstructor" id="_ref_2"><a href="https://tc39.es/ecma262/#sec-ordinarycreatefromconstructor">OrdinaryCreateFromConstructor</a></emu-xref>(NewTarget, <emu-val>"%PluralRules.prototype%"</emu-val>, « [[InitializedPluralRules]], [[Locale]], [[Type]], [[MinimumIntegerDigits]], [[MinimumFractionDigits]], [[MaximumFractionDigits]], [[MinimumSignificantDigits]], [[MaximumSignificantDigits]], [[RoundingType]] »).</li><li>Return ?&nbsp;<emu-xref aoid="InitializePluralRules" id="_ref_3"><a href="#sec-initializepluralrules">InitializePluralRules</a></emu-xref>(<var>pluralRules</var>, <var>locales</var>, <var>options</var>).</li></ol></emu-alg>
+      <emu-alg><ol><li>If NewTarget is <emu-val>undefined</emu-val>, throw a <emu-val>TypeError</emu-val> exception.</li><li>Let <var>pluralRules</var> be ?&nbsp;OrdinaryCreateFromConstructor(NewTarget, <emu-val>"%PluralRules.prototype%"</emu-val>, « [[InitializedPluralRules]], [[Locale]], [[Type]], [[MinimumIntegerDigits]], [[MinimumFractionDigits]], [[MaximumFractionDigits]], [[MinimumSignificantDigits]], [[MaximumSignificantDigits]], [[RoundingType]]<ins>, [[RoundingMode]], [[RoundingIncrement]], [[TrailingZeroDisplay]]</ins> »).</li><li>Return ?&nbsp;<emu-xref aoid="InitializePluralRules" id="_ref_2"><a href="#sec-initializepluralrules">InitializePluralRules</a></emu-xref>(<var>pluralRules</var>, <var>locales</var>, <var>options</var>).</li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-initializepluralrules" aoid="InitializePluralRules">
@@ -1890,7 +2642,7 @@ li.menu-search-result-term:before {
         The abstract operation InitializePluralRules accepts the arguments <var>pluralRules</var> (which must be an object), <var>locales</var>, and <var>options</var>. It initializes <var>pluralRules</var> as a PluralRules object. The following steps are taken:
       </p>
 
-      <emu-alg><ol><li>Let <var>requestedLocales</var> be ?&nbsp;CanonicalizeLocaleList(<var>locales</var>).</li><li>Set <var>options</var> to ?&nbsp;CoerceOptionsToObject(<var>options</var>).</li><li>Let <var>opt</var> be a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref>.</li><li>Let <var>matcher</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"localeMatcher"</emu-val>, <emu-const>string</emu-const>, « <emu-val>"lookup"</emu-val>, <emu-val>"best fit"</emu-val> », <emu-val>"best fit"</emu-val>).</li><li>Set <var>opt</var>.[[localeMatcher]] to <var>matcher</var>.</li><li>Let <var>t</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"type"</emu-val>, <emu-const>string</emu-const>, « <emu-val>"cardinal"</emu-val>, <emu-val>"ordinal"</emu-val> », <emu-val>"cardinal"</emu-val>).</li><li>Set <var>pluralRules</var>.[[Type]] to <var>t</var>.</li><li>Perform ?&nbsp;SetNumberFormatDigitOptions(<var>pluralRules</var>, <var>options</var>, <emu-val>+0</emu-val><sub>𝔽</sub>, <emu-val>3</emu-val><sub>𝔽</sub>, <emu-val>"standard"</emu-val>).</li><li>Let <var>localeData</var> be <emu-xref href="#sec-intl-pluralrules-constructor" id="_ref_4"><a href="#sec-intl-pluralrules-constructor">%PluralRules%</a></emu-xref>.[[LocaleData]].</li><li>Let <var>r</var> be ResolveLocale(<emu-xref href="#sec-intl-pluralrules-constructor" id="_ref_5"><a href="#sec-intl-pluralrules-constructor">%PluralRules%</a></emu-xref>.[[AvailableLocales]], <var>requestedLocales</var>, <var>opt</var>, <emu-xref href="#sec-intl-pluralrules-constructor" id="_ref_6"><a href="#sec-intl-pluralrules-constructor">%PluralRules%</a></emu-xref>.[[RelevantExtensionKeys]], <var>localeData</var>).</li><li>Set <var>pluralRules</var>.[[Locale]] to <var>r</var>.[[locale]].</li><li>Return <var>pluralRules</var>.</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>requestedLocales</var> be ?&nbsp;CanonicalizeLocaleList(<var>locales</var>).</li><li>Set <var>options</var> to ?&nbsp;CoerceOptionsToObject(<var>options</var>).</li><li>Let <var>opt</var> be a new Record.</li><li>Let <var>matcher</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"localeMatcher"</emu-val>, <emu-const>string</emu-const>, « <emu-val>"lookup"</emu-val>, <emu-val>"best fit"</emu-val> », <emu-val>"best fit"</emu-val>).</li><li>Set <var>opt</var>.[[localeMatcher]] to <var>matcher</var>.</li><li>Let <var>t</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"type"</emu-val>, <emu-const>string</emu-const>, « <emu-val>"cardinal"</emu-val>, <emu-val>"ordinal"</emu-val> », <emu-val>"cardinal"</emu-val>).</li><li>Set <var>pluralRules</var>.[[Type]] to <var>t</var>.</li><li>Perform ?&nbsp;SetNumberFormatDigitOptions(<var>pluralRules</var>, <var>options</var>, <emu-val>+0</emu-val><sub>𝔽</sub>, <emu-val>3</emu-val><sub>𝔽</sub>, <emu-val>"standard"</emu-val>).</li><li>Let <var>localeData</var> be <emu-xref href="#sec-intl-pluralrules-constructor" id="_ref_3"><a href="#sec-intl-pluralrules-constructor">%PluralRules%</a></emu-xref>.[[LocaleData]].</li><li>Let <var>r</var> be ResolveLocale(<emu-xref href="#sec-intl-pluralrules-constructor" id="_ref_4"><a href="#sec-intl-pluralrules-constructor">%PluralRules%</a></emu-xref>.[[AvailableLocales]], <var>requestedLocales</var>, <var>opt</var>, <emu-xref href="#sec-intl-pluralrules-constructor" id="_ref_5"><a href="#sec-intl-pluralrules-constructor">%PluralRules%</a></emu-xref>.[[RelevantExtensionKeys]], <var>localeData</var>).</li><li>Set <var>pluralRules</var>.[[Locale]] to <var>r</var>.[[locale]].</li><li>Return <var>pluralRules</var>.</li></ol></emu-alg>
     </emu-clause>
   </emu-clause>
 
@@ -1898,14 +2650,14 @@ li.menu-search-result-term:before {
     <h1><span class="secnum">1.2</span> Properties of the Intl.PluralRules Constructor</h1>
 
     <p>
-      The Intl.PluralRules <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> has the following properties:
+      The Intl.PluralRules constructor has the following properties:
     </p>
 
     <emu-clause id="sec-intl.pluralrules.prototype">
       <h1><span class="secnum">1.2.1</span> Intl.PluralRules.prototype</h1>
 
       <p>
-        The value of <code>Intl.PluralRules.prototype</code> is <emu-xref href="#sec-properties-of-intl-pluralrules-prototype-object" id="_ref_7"><a href="#sec-properties-of-intl-pluralrules-prototype-object">%PluralRules.prototype%</a></emu-xref>.
+        The value of <code>Intl.PluralRules.prototype</code> is <emu-xref href="#sec-properties-of-intl-pluralrules-prototype-object" id="_ref_6"><a href="#sec-properties-of-intl-pluralrules-prototype-object">%PluralRules.prototype%</a></emu-xref>.
       </p>
       <p>
         This property has the attributes { [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>false</emu-val> }.
@@ -1919,7 +2671,7 @@ li.menu-search-result-term:before {
         When the <code>supportedLocalesOf</code> method is called with arguments <var>locales</var> and <var>options</var>, the following steps are taken:
       </p>
 
-      <emu-alg><ol><li>Let <var>availableLocales</var> be <emu-xref href="#sec-intl-pluralrules-constructor" id="_ref_8"><a href="#sec-intl-pluralrules-constructor">%PluralRules%</a></emu-xref>.[[AvailableLocales]].</li><li>Let <var>requestedLocales</var> be ?&nbsp;CanonicalizeLocaleList(<var>locales</var>).</li><li>Return ?&nbsp;SupportedLocales(<var>availableLocales</var>, <var>requestedLocales</var>, <var>options</var>).</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>availableLocales</var> be <emu-xref href="#sec-intl-pluralrules-constructor" id="_ref_7"><a href="#sec-intl-pluralrules-constructor">%PluralRules%</a></emu-xref>.[[AvailableLocales]].</li><li>Let <var>requestedLocales</var> be ?&nbsp;CanonicalizeLocaleList(<var>locales</var>).</li><li>Return ?&nbsp;SupportedLocales(<var>availableLocales</var>, <var>requestedLocales</var>, <var>options</var>).</li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-intl.pluralrules-internal-slots">
@@ -1958,7 +2710,7 @@ li.menu-search-result-term:before {
       <h1><span class="secnum">1.3.1</span> Intl.PluralRules.prototype.constructor</h1>
 
       <p>
-        The initial value of <code>Intl.PluralRules.prototype.constructor</code> is <emu-xref href="#sec-intl-pluralrules-constructor" id="_ref_9"><a href="#sec-intl-pluralrules-constructor">%PluralRules%</a></emu-xref>.
+        The initial value of <code>Intl.PluralRules.prototype.constructor</code> is <emu-xref href="#sec-intl-pluralrules-constructor" id="_ref_8"><a href="#sec-intl-pluralrules-constructor">%PluralRules%</a></emu-xref>.
       </p>
     </emu-clause>
 
@@ -1980,7 +2732,7 @@ li.menu-search-result-term:before {
         When the <code>select</code> method is called with an argument <var>value</var>, the following steps are taken:
       </p>
 
-      <emu-alg><ol><li>Let <var>pr</var> be the <emu-val>this</emu-val> value.</li><li>Perform ?&nbsp;<emu-xref aoid="RequireInternalSlot" id="_ref_10"><a href="https://tc39.es/ecma262/#sec-requireinternalslot">RequireInternalSlot</a></emu-xref>(<var>pr</var>, [[InitializedPluralRules]]).</li><li>Let <var>n</var> be ?&nbsp;<emu-xref aoid="ToNumber" id="_ref_11"><a href="https://tc39.es/ecma262/#sec-tonumber">ToNumber</a></emu-xref>(<var>value</var>).</li><li>Return !&nbsp;<emu-xref aoid="ResolvePlural" id="_ref_12"><a href="#sec-resolveplural">ResolvePlural</a></emu-xref>(<var>pr</var>, <var>n</var>).</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>pr</var> be the <emu-val>this</emu-val> value.</li><li>Perform ?&nbsp;RequireInternalSlot(<var>pr</var>, [[InitializedPluralRules]]).</li><li>Let <var>n</var> be ?&nbsp;ToNumber(<var>value</var>).</li><li>Return !&nbsp;<emu-xref aoid="ResolvePlural" id="_ref_9"><a href="#sec-resolveplural">ResolvePlural</a></emu-xref>(<var>pr</var>, <var>n</var>).</li></ol></emu-alg>
     </emu-clause>
 
     <ins class="block">
@@ -1991,7 +2743,7 @@ li.menu-search-result-term:before {
         When the <code>selectRange</code> method is called with arguments <var>start</var> and <var>end</var>, the following steps are taken:
       </p>
 
-      <emu-alg><ol><li>Let <var>pr</var> be the <emu-val>this</emu-val> value.</li><li>Perform ?&nbsp;<emu-xref aoid="RequireInternalSlot" id="_ref_13"><a href="https://tc39.es/ecma262/#sec-requireinternalslot">RequireInternalSlot</a></emu-xref>(<var>pr</var>, [[InitializedPluralRules]]).</li><li>If <var>start</var> is <emu-val>undefined</emu-val> or <var>end</var> is <emu-val>undefined</emu-val>, throw a <emu-val>TypeError</emu-val> exception.</li><li>Let <var>x</var> be ?&nbsp;<emu-xref aoid="ToNumber" id="_ref_14"><a href="https://tc39.es/ecma262/#sec-tonumber">ToNumber</a></emu-xref>(<var>start</var>).</li><li>Let <var>y</var> be ?&nbsp;<emu-xref aoid="ToNumber" id="_ref_15"><a href="https://tc39.es/ecma262/#sec-tonumber">ToNumber</a></emu-xref>(<var>end</var>).</li><li>Return ?&nbsp;<emu-xref aoid="ResolvePluralRange" id="_ref_16"><a href="#sec-resolvepluralrange">ResolvePluralRange</a></emu-xref>(<var>pr</var>, <var>x</var>, <var>y</var>).</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>pr</var> be the <emu-val>this</emu-val> value.</li><li>Perform ?&nbsp;RequireInternalSlot(<var>pr</var>, [[InitializedPluralRules]]).</li><li>If <var>start</var> is <emu-val>undefined</emu-val> or <var>end</var> is <emu-val>undefined</emu-val>, throw a <emu-val>TypeError</emu-val> exception.</li><li>Let <var>x</var> be ?&nbsp;ToNumber(<var>start</var>).</li><li>Let <var>y</var> be ?&nbsp;ToNumber(<var>end</var>).</li><li>Return ?&nbsp;<emu-xref aoid="ResolvePluralRange" id="_ref_10"><a href="#sec-resolvepluralrange">ResolvePluralRange</a></emu-xref>(<var>pr</var>, <var>x</var>, <var>y</var>).</li></ol></emu-alg>
     </emu-clause>
     </ins>
 
@@ -2002,7 +2754,7 @@ li.menu-search-result-term:before {
         This function provides access to the locale and options computed during initialization of the object.
       </p>
 
-      <emu-alg><ol><li>Let <var>pr</var> be the <emu-val>this</emu-val> value.</li><li>Perform ?&nbsp;<emu-xref aoid="RequireInternalSlot" id="_ref_17"><a href="https://tc39.es/ecma262/#sec-requireinternalslot">RequireInternalSlot</a></emu-xref>(<var>pr</var>, [[InitializedPluralRules]]).</li><li>Let <var>options</var> be OrdinaryObjectCreate(%Object.prototype%).</li><li>For each row of <emu-xref href="#table-pluralrules-resolvedoptions-properties" id="_ref_0"><a href="#table-pluralrules-resolvedoptions-properties">Table 1</a></emu-xref>, except the header row, in table order, do<ol><li>Let <var>p</var> be the Property value of the current row.</li><li>Let <var>v</var> be the value of <var>pr</var>'s internal slot whose name is the Internal Slot value of the current row.</li><li>If <var>v</var> is not <emu-val>undefined</emu-val>, then<ol><li>Perform !&nbsp;<emu-xref aoid="CreateDataPropertyOrThrow" id="_ref_18"><a href="https://tc39.es/ecma262/#sec-createdatapropertyorthrow">CreateDataPropertyOrThrow</a></emu-xref>(<var>options</var>, <var>p</var>, <var>v</var>).</li></ol></li></ol></li><li>Let <var>pluralCategories</var> be a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> of Strings containing all possible results of <emu-xref href="#sec-pluralruleselect" id="_ref_1"><a href="#sec-pluralruleselect">PluralRuleSelect</a></emu-xref> for the selected locale <var>pr</var>.[[Locale]].</li><li>Perform !&nbsp;<emu-xref aoid="CreateDataProperty" id="_ref_19"><a href="https://tc39.es/ecma262/#sec-createdataproperty">CreateDataProperty</a></emu-xref>(<var>options</var>, <emu-val>"pluralCategories"</emu-val>, <emu-xref aoid="CreateArrayFromList" id="_ref_20"><a href="https://tc39.es/ecma262/#sec-createarrayfromlist">CreateArrayFromList</a></emu-xref>(<var>pluralCategories</var>)).</li><li><ins class="block">If <var>pr</var>.[[RoundingType]] is <emu-const>morePrecision</emu-const>, then</ins><ol><li><ins class="block">Perform !&nbsp;<emu-xref aoid="CreateDataPropertyOrThrow" id="_ref_21"><a href="https://tc39.es/ecma262/#sec-createdatapropertyorthrow">CreateDataPropertyOrThrow</a></emu-xref>(<var>options</var>, <emu-val>"roundingPriority"</emu-val>, <emu-val>"morePrecision"</emu-val>).</ins></li></ol></li><li><ins class="block">Else if <var>pr</var>.[[RoundingType]] is <emu-const>lessPrecision</emu-const>, then</ins><ol><li><ins class="block">Perform !&nbsp;<emu-xref aoid="CreateDataPropertyOrThrow" id="_ref_22"><a href="https://tc39.es/ecma262/#sec-createdatapropertyorthrow">CreateDataPropertyOrThrow</a></emu-xref>(<var>options</var>, <emu-val>"roundingPriority"</emu-val>, <emu-val>"lessPrecision"</emu-val>).</ins></li></ol></li><li><ins class="block">Else,</ins><ol><li><ins class="block">Perform !&nbsp;<emu-xref aoid="CreateDataPropertyOrThrow" id="_ref_23"><a href="https://tc39.es/ecma262/#sec-createdatapropertyorthrow">CreateDataPropertyOrThrow</a></emu-xref>(<var>options</var>, <emu-val>"roundingPriority"</emu-val>, <emu-val>"auto"</emu-val>).</ins></li></ol></li><li>Return <var>options</var>.</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>pr</var> be the <emu-val>this</emu-val> value.</li><li>Perform ?&nbsp;RequireInternalSlot(<var>pr</var>, [[InitializedPluralRules]]).</li><li>Let <var>options</var> be OrdinaryObjectCreate(%Object.prototype%).</li><li>For each row of <emu-xref href="#table-pluralrules-resolvedoptions-properties" id="_ref_0"><a href="#table-pluralrules-resolvedoptions-properties">Table 1</a></emu-xref>, except the header row, in table order, do<ol><li>Let <var>p</var> be the Property value of the current row.</li><li>Let <var>v</var> be the value of <var>pr</var>'s internal slot whose name is the Internal Slot value of the current row.</li><li>If <var>v</var> is not <emu-val>undefined</emu-val>, then<ol><li>Perform !&nbsp;CreateDataPropertyOrThrow(<var>options</var>, <var>p</var>, <var>v</var>).</li></ol></li></ol></li><li>Let <var>pluralCategories</var> be a List of Strings containing all possible results of <emu-xref href="#sec-pluralruleselect" id="_ref_1"><a href="#sec-pluralruleselect">PluralRuleSelect</a></emu-xref> for the selected locale <var>pr</var>.[[Locale]].</li><li>Perform !&nbsp;CreateDataProperty(<var>options</var>, <emu-val>"pluralCategories"</emu-val>, CreateArrayFromList(<var>pluralCategories</var>)).</li><li><ins class="block">If <var>pr</var>.[[RoundingType]] is <emu-const>morePrecision</emu-const>, then</ins><ol><li><ins class="block">Perform !&nbsp;CreateDataPropertyOrThrow(<var>options</var>, <emu-val>"roundingPriority"</emu-val>, <emu-val>"morePrecision"</emu-val>).</ins></li></ol></li><li><ins class="block">Else if <var>pr</var>.[[RoundingType]] is <emu-const>lessPrecision</emu-const>, then</ins><ol><li><ins class="block">Perform !&nbsp;CreateDataPropertyOrThrow(<var>options</var>, <emu-val>"roundingPriority"</emu-val>, <emu-val>"lessPrecision"</emu-val>).</ins></li></ol></li><li><ins class="block">Else,</ins><ol><li><ins class="block">Perform !&nbsp;CreateDataPropertyOrThrow(<var>options</var>, <emu-val>"roundingPriority"</emu-val>, <emu-val>"auto"</emu-val>).</ins></li></ol></li><li>Return <var>options</var>.</li></ol></emu-alg>
 
       <emu-table id="table-pluralrules-resolvedoptions-properties"><figure><figcaption>Table 1: Resolved Options of PluralRules Instances</figcaption>
         
@@ -2041,6 +2793,18 @@ li.menu-search-result-term:before {
             <td>[[MaximumSignificantDigits]]</td>
             <td><emu-val>"maximumSignificantDigits"</emu-val></td>
           </tr>
+          <tr>
+            <td><ins>[[RoundingMode]]</ins></td>
+            <td><ins><emu-val>"roundingMode"</emu-val></ins></td>
+          </tr>
+          <tr>
+            <td><ins>[[RoundingIncrement]]</ins></td>
+            <td><ins><emu-val>"roundingIncrement"</emu-val></ins></td>
+          </tr>
+          <tr>
+            <td><ins>[[TrailingZeroDisplay]]</ins></td>
+            <td><ins><emu-val>"trailingZeroDisplay"</emu-val></ins></td>
+          </tr>
         </tbody></table>
       </figure></emu-table>
     </emu-clause>
@@ -2050,7 +2814,7 @@ li.menu-search-result-term:before {
     <h1><span class="secnum">1.4</span> Properties of Intl.PluralRules Instances</h1>
 
     <p>
-      Intl.PluralRules instances are ordinary objects that inherit properties from <emu-xref href="#sec-properties-of-intl-pluralrules-prototype-object" id="_ref_24"><a href="#sec-properties-of-intl-pluralrules-prototype-object">%PluralRules.prototype%</a></emu-xref>.
+      Intl.PluralRules instances are ordinary objects that inherit properties from <emu-xref href="#sec-properties-of-intl-pluralrules-prototype-object" id="_ref_11"><a href="#sec-properties-of-intl-pluralrules-prototype-object">%PluralRules.prototype%</a></emu-xref>.
     </p>
 
     <p>
@@ -2058,35 +2822,31 @@ li.menu-search-result-term:before {
     </p>
 
     <p>
-      Intl.PluralRules instances also have several internal slots that are computed by the <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref>:
+      Intl.PluralRules instances also have several internal slots that are computed by the constructor:
     </p>
 
     <ul>
       <li>[[Locale]] is a String value with the language tag of the locale whose localization is used by the plural rules.</li>
       <li>[[Type]] is one of the String values <emu-val>"cardinal"</emu-val> or <emu-val>"ordinal"</emu-val>, identifying the plural rules used.</li>
-      <li>[[MinimumIntegerDigits]] is a non-negative <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref> <emu-xref href="#number-value"><a href="https://tc39.es/ecma262/#number-value">Number value</a></emu-xref> indicating the minimum <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref> digits to be used.</li>
-      <li>[[MinimumFractionDigits]] and [[MaximumFractionDigits]] are non-negative <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref> Number values indicating the minimum and maximum fraction digits to be used. Numbers will be rounded or padded with trailing zeroes if necessary.</li>
-      <li>[[MinimumSignificantDigits]] and [[MaximumSignificantDigits]] are positive <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref> Number values indicating the minimum and maximum fraction digits to be used. Either none or both of these properties are present; if they are, they override minimum and maximum <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref> and fraction digits.</li>
+      <li>[[MinimumIntegerDigits]] is a non-negative integer Number value indicating the minimum integer digits to be used.</li>
+      <li>[[MinimumFractionDigits]] and [[MaximumFractionDigits]] are non-negative integer Number values indicating the minimum and maximum fraction digits to be used. Numbers will be rounded or padded with trailing zeroes if necessary.</li>
+      <li>[[MinimumSignificantDigits]] and [[MaximumSignificantDigits]] are positive integer Number values indicating the minimum and maximum fraction digits to be used. Either none or both of these properties are present; if they are, they override minimum and maximum integer and fraction digits.</li>
       <li>[[RoundingType]] is one of the values <emu-const>fractionDigits</emu-const>, <del>or</del> <emu-const>significantDigits</emu-const>, <ins><emu-const>morePrecision</emu-const>, or <emu-const>lessPrecision</emu-const></ins>, indicating which rounding strategy to use, as discussed in <emu-xref href="#sec-properties-of-intl-numberformat-instances"></emu-xref>.</li>
+      <li><ins class="block">[[RoundingMode]] is one of the String values in the Identifier column of <emu-xref href="#table-intl-rounding-modes"></emu-xref>, specifying which rounding mode to use.</ins></li>
+      <li><ins class="block">[[RoundingIncrement]] is an integer-valued Number that evenly divides 10, 100, 1000, or 10000 into tenths, fifths, quarters, or halves. It indicates the increment at which rounding should take place relative to the calculated rounding magnitude. For example, if [[MaximumFractionDigits]] is 2 and [[RoundingIncrement]] is 5, then the number is rounded to the nearest 0.05 ("nickel rounding").</ins></li>
+      <li><ins class="block">[[TrailingZeroDisplay]] is one of the String values <emu-val>"auto"</emu-val> or <emu-val>"stripIfInteger"</emu-val>, indicating whether to strip trailing zeros if the formatted number is an integer (i.e., has no nonzero fraction digit).</ins></li>
     </ul>
   </emu-clause>
 
   <emu-clause id="sec-intl-pluralrules-abstracts">
     <h1><span class="secnum">1.5</span> Abstract Operations for PluralRules Objects</h1>
 
-    <emu-clause id="sec-getoperands" type="abstract operation">
-       <h1><span class="secnum">1.5.1</span> 
-         GetOperands (
-           <var>s</var>: a decimal String,
-         )
-       </h1>
-       <dl class="header">
-        <dt>description</dt>
-        <dd>It extracts numeric features from <var>s</var> that correspond with the operands of <a href="https://unicode.org/reports/tr35/tr35-numbers.html#Operands">Unicode Technical Standard #35 Part 3 Numbers, Section 5.1.1 Operands</a>.</dd>
-       </dl>
-       <emu-alg><ol><li>Let <var>n</var> be !&nbsp;<emu-xref aoid="ToNumber" id="_ref_25"><a href="https://tc39.es/ecma262/#sec-tonumber">ToNumber</a></emu-xref>(<var>s</var>).</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>n</var> is finite.</li><li>Let <var>dp</var> be StringIndexOf(<var>s</var>, <emu-val>"."</emu-val>, 0).</li><li>If <var>dp</var> = -1, then<ol><li>Let <var>intPart</var> be <var>n</var>.</li><li>Let <var>fracSlice</var> be <emu-val>""</emu-val>.</li></ol></li><li>Else,<ol><li>Let <var>intPart</var> be the substring of <var>s</var> from 0 to <var>dp</var>.</li><li>Let <var>fracSlice</var> be the substring of <var>s</var> from <var>dp</var> + 1.</li></ol></li><li>Let <var>i</var> be <emu-xref aoid="abs"><a href="https://tc39.es/ecma262/#eqn-abs">abs</a></emu-xref>(! <emu-xref aoid="ToNumber" id="_ref_26"><a href="https://tc39.es/ecma262/#sec-tonumber">ToNumber</a></emu-xref>(<var>intPart</var>)).</li><li>Let <var>fracDigitCount</var> be the length of <var>fracSlice</var>.</li><li>Let <var>f</var> be !&nbsp;<emu-xref aoid="ToNumber" id="_ref_27"><a href="https://tc39.es/ecma262/#sec-tonumber">ToNumber</a></emu-xref>(<var>fracSlice</var>).</li><li>Let <var>significantFracSlice</var> be the value of <var>fracSlice</var> stripped of trailing <emu-val>"0"</emu-val>.</li><li>Let <var>significantFracDigitCount</var> be the length of <var>significantFracSlice</var>.</li><li>Let <var>significantFrac</var> be !&nbsp;<emu-xref aoid="ToNumber" id="_ref_28"><a href="https://tc39.es/ecma262/#sec-tonumber">ToNumber</a></emu-xref>(<var>significantFracSlice</var>).</li><li>Return a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Number]]: <emu-xref aoid="abs"><a href="https://tc39.es/ecma262/#eqn-abs">abs</a></emu-xref>(<var>n</var>), [[IntegerDigits]]: <var>i</var>, [[FractionDigits]]: <var>f</var>, [[NumberOfFractionDigits]]: <var>fracDigitCount</var>, [[FractionDigitsWithoutTrailing]]: <var>significantFrac</var>, [[NumberOfFractionDigitsWithoutTrailing]]: <var>significantFracDigitCount</var> }.</li></ol></emu-alg>
+    <emu-clause id="sec-getoperands" type="abstract operation" aoid="GetOperands">
+       <h1><span class="secnum">1.5.1</span> GetOperands ( <var>s</var> )</h1>
+       <p>The abstract operation GetOperands takes argument <var>s</var> (a decimal String). It extracts numeric features from <var>s</var> that correspond with the operands of <a href="https://unicode.org/reports/tr35/tr35-numbers.html#Operands">Unicode Technical Standard #35 Part 3 Numbers, Section 5.1.1 Operands</a>. It performs the following steps when called:</p>
+       <emu-alg><ol><li>Let <var>n</var> be !&nbsp;ToNumber(<var>s</var>).</li><li>Assert: <var>n</var> is finite.</li><li>Let <var>dp</var> be StringIndexOf(<var>s</var>, <emu-val>"."</emu-val>, 0).</li><li>If <var>dp</var> = -1, then<ol><li>Let <var>intPart</var> be <var>n</var>.</li><li>Let <var>fracSlice</var> be <emu-val>""</emu-val>.</li></ol></li><li>Else,<ol><li>Let <var>intPart</var> be the substring of <var>s</var> from 0 to <var>dp</var>.</li><li>Let <var>fracSlice</var> be the substring of <var>s</var> from <var>dp</var> + 1.</li></ol></li><li>Let <var>i</var> be abs(! ToNumber(<var>intPart</var>)).</li><li>Let <var>fracDigitCount</var> be the length of <var>fracSlice</var>.</li><li>Let <var>f</var> be !&nbsp;ToNumber(<var>fracSlice</var>).</li><li>Let <var>significantFracSlice</var> be the value of <var>fracSlice</var> stripped of trailing <emu-val>"0"</emu-val>.</li><li>Let <var>significantFracDigitCount</var> be the length of <var>significantFracSlice</var>.</li><li>Let <var>significantFrac</var> be !&nbsp;ToNumber(<var>significantFracSlice</var>).</li><li>Return a new Record { [[Number]]: abs(<var>n</var>), [[IntegerDigits]]: <var>i</var>, [[FractionDigits]]: <var>f</var>, [[NumberOfFractionDigits]]: <var>fracDigitCount</var>, [[FractionDigitsWithoutTrailing]]: <var>significantFrac</var>, [[NumberOfFractionDigitsWithoutTrailing]]: <var>significantFracDigitCount</var> }.</li></ol></emu-alg>
 
-       <emu-table id="table-plural-operands"><figure><figcaption>Table 2: Plural Rules Operands <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> Fields</figcaption>
+       <emu-table id="table-plural-operands"><figure><figcaption>Table 2: Plural Rules Operands Record Fields</figcaption>
          
          <table class="real-table">
            <thead>
@@ -2107,13 +2867,13 @@ li.menu-search-result-term:before {
              <td>[[IntegerDigits]]</td>
              <td>Number</td>
              <td>i</td>
-             <td><emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">Integer</a></emu-xref> part of [[Number]].</td>
+             <td>Integer part of [[Number]].</td>
            </tr>
            <tr>
              <td>[[FractionDigits]]</td>
              <td>Number</td>
              <td>f</td>
-             <td>Visible fraction digits in [[Number]], <em>with</em> trailing zeroes, as an <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref> having [[NumberOfFractionDigits]] digits.</td>
+             <td>Visible fraction digits in [[Number]], <em>with</em> trailing zeroes, as an integer having [[NumberOfFractionDigits]] digits.</td>
            </tr>
            <tr>
              <td>[[NumberOfFractionDigits]]</td>
@@ -2125,7 +2885,7 @@ li.menu-search-result-term:before {
              <td>[[FractionDigitsWithoutTrailing]]</td>
              <td>Number</td>
              <td>t</td>
-             <td>Visible fraction digits in [[Number]], <em>without</em> trailing zeroes, as an <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref> having [[NumberOfFractionDigitsWithoutTrailing]] digits.</td>
+             <td>Visible fraction digits in [[Number]], <em>without</em> trailing zeroes, as an integer having [[NumberOfFractionDigitsWithoutTrailing]] digits.</td>
            </tr>
            <tr>
              <td>[[NumberOfFractionDigitsWithoutTrailing]]</td>
@@ -2137,28 +2897,18 @@ li.menu-search-result-term:before {
        </figure></emu-table>
     </emu-clause>
 
-    <emu-clause id="sec-pluralruleselect" type="implementation-defined abstract operation">
-      <h1><span class="secnum">1.5.2</span> 
-        PluralRuleSelect (
-          <var>locale</var>: a String,
-          <var>type</var>: a String,
-          <var>n</var>: a finite Number,
-          <var>operands</var>: a Plural Rules Operands Record derived from formatting <var>n</var>,
-        )
-      </h1>
-      <dl class="header">
-        <dt>description</dt>
-        <dd>It returns the String from « <emu-val>"zero"</emu-val>, <emu-val>"one"</emu-val>, <emu-val>"two"</emu-val>, <emu-val>"few"</emu-val>, <emu-val>"many"</emu-val>, <emu-val>"other"</emu-val> » that best categorizes the <var>operands</var> representation of <var>n</var> according to the rules for <var>locale</var> and <var>type</var>.</dd>
-      </dl>
+    <emu-clause id="sec-pluralruleselect" type="implementation-defined abstract operation" aoid="PluralRuleSelect">
+      <h1><span class="secnum">1.5.2</span> PluralRuleSelect ( <var>locale</var>, <var>type</var>, <var>n</var>, <var>operands</var> )</h1>
+      <p>The implementation-defined abstract operation PluralRuleSelect takes arguments <var>locale</var> (a String), <var>type</var> (a String), <var>n</var> (a finite Number), and <var>operands</var> (a Plural Rules Operands Record derived from formatting <var>n</var>). It returns the String from « <emu-val>"zero"</emu-val>, <emu-val>"one"</emu-val>, <emu-val>"two"</emu-val>, <emu-val>"few"</emu-val>, <emu-val>"many"</emu-val>, <emu-val>"other"</emu-val> » that best categorizes the <var>operands</var> representation of <var>n</var> according to the rules for <var>locale</var> and <var>type</var>.</p>
     </emu-clause>
 
     <emu-clause id="sec-resolveplural" aoid="ResolvePlural">
       <h1><span class="secnum">1.5.3</span> ResolvePlural ( <var>pluralRules</var>, <var>n</var> )</h1>
       <p>
-        When the ResolvePlural abstract operation is called with arguments <var>pluralRules</var> (which must be an object initialized as a PluralRules) and <var>n</var> (which must be a <emu-xref href="#number-value"><a href="https://tc39.es/ecma262/#number-value">Number value</a></emu-xref>), it returns a String value representing the plural form of <var>n</var> according to the effective locale and the options of <var>pluralRules</var>. The following steps are taken:
+        When the ResolvePlural abstract operation is called with arguments <var>pluralRules</var> (which must be an object initialized as a PluralRules) and <var>n</var> (which must be a Number value), it returns a String value representing the plural form of <var>n</var> according to the effective locale and the options of <var>pluralRules</var>. The following steps are taken:
       </p>
 
-      <emu-alg><ol><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <emu-xref aoid="Type" id="_ref_29"><a href="https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>pluralRules</var>) is Object.</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>pluralRules</var> has an [[InitializedPluralRules]] internal slot.</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <emu-xref aoid="Type" id="_ref_30"><a href="https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>n</var>) is Number.</li><li>If <var>n</var> is not a finite Number, then<ol><li>Return <emu-val>"other"</emu-val>.</li></ol></li><li>Let <var>locale</var> be <var>pluralRules</var>.[[Locale]].</li><li>Let <var>type</var> be <var>pluralRules</var>.[[Type]].</li><li>Let <var>res</var> be !&nbsp;FormatNumericToString(<var>pluralRules</var>, <var>n</var>).</li><li>Let <var>s</var> be <var>res</var>.[[FormattedString]].</li><li>Let <var>operands</var> be !&nbsp;GetOperands(<var>s</var>).</li><li>Return !&nbsp;PluralRuleSelect(<var>locale</var>, <var>type</var>, <var>n</var>, <var>operands</var>).</li></ol></emu-alg>
+      <emu-alg><ol><li>Assert: Type(<var>pluralRules</var>) is Object.</li><li>Assert: <var>pluralRules</var> has an [[InitializedPluralRules]] internal slot.</li><li>Assert: Type(<var>n</var>) is Number.</li><li>If <var>n</var> is not a finite Number, then<ol><li>Return <emu-val>"other"</emu-val>.</li></ol></li><li>Let <var>locale</var> be <var>pluralRules</var>.[[Locale]].</li><li>Let <var>type</var> be <var>pluralRules</var>.[[Type]].</li><li>Let <var>res</var> be !&nbsp;FormatNumericToString(<var>pluralRules</var>, <var>n</var>).</li><li>Let <var>s</var> be <var>res</var>.[[FormattedString]].</li><li>Let <var>operands</var> be !&nbsp;<emu-xref aoid="GetOperands" id="_ref_12"><a href="#sec-getoperands">GetOperands</a></emu-xref>(<var>s</var>).</li><li>Return !&nbsp;<emu-xref aoid="PluralRuleSelect" id="_ref_13"><a href="#sec-pluralruleselect">PluralRuleSelect</a></emu-xref>(<var>locale</var>, <var>type</var>, <var>n</var>, <var>operands</var>).</li></ol></emu-alg>
     </emu-clause>
 
     <ins class="block">
@@ -2173,10 +2923,10 @@ li.menu-search-result-term:before {
     <emu-clause id="sec-resolvepluralrange" aoid="ResolvePluralRange">
       <h1><span class="secnum">1.5.5</span> ResolvePluralRange ( <var>pluralRules</var>, <var>x</var>, <var>y</var> )</h1>
       <p>
-        When the ResolvePluralRange abstract operation is called with arguments <var>pluralRules</var> (which must be an object initialized as a PluralRules), <var>x</var> (which must be a <emu-xref href="#number-value"><a href="https://tc39.es/ecma262/#number-value">Number value</a></emu-xref>), and <var>y</var> (which must be a <emu-xref href="#number-value"><a href="https://tc39.es/ecma262/#number-value">Number value</a></emu-xref>), it returns a String value representing the plural form of the range starting from <var>x</var> and ending at <var>y</var> according to the effective locale and the options of <var>pluralRules</var>. The following steps are taken:
+        When the ResolvePluralRange abstract operation is called with arguments <var>pluralRules</var> (which must be an object initialized as a PluralRules), <var>x</var> (which must be a Number value), and <var>y</var> (which must be a Number value), it returns a String value representing the plural form of the range starting from <var>x</var> and ending at <var>y</var> according to the effective locale and the options of <var>pluralRules</var>. The following steps are taken:
       </p>
 
-      <emu-alg><ol><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <emu-xref aoid="Type" id="_ref_31"><a href="https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>pluralRules</var>) is Object.</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>pluralRules</var> has an [[InitializedPluralRules]] internal slot.</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <emu-xref aoid="Type" id="_ref_32"><a href="https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>x</var>) is Number.</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <emu-xref aoid="Type" id="_ref_33"><a href="https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>y</var>) is Number.</li><li>If <var>x</var> is <emu-val>NaN</emu-val> or <var>y</var> is <emu-val>NaN</emu-val>, throw a <emu-val>RangeError</emu-val> exception.</li><li>Let <var>xp</var> be !&nbsp;<emu-xref aoid="ResolvePlural" id="_ref_34"><a href="#sec-resolveplural">ResolvePlural</a></emu-xref>(<var>pluralRules</var>, <var>x</var>).</li><li>Let <var>yp</var> be !&nbsp;<emu-xref aoid="ResolvePlural" id="_ref_35"><a href="#sec-resolveplural">ResolvePlural</a></emu-xref>(<var>pluralRules</var>, <var>y</var>).</li><li>Let <var>locale</var> be <var>pluralRules</var>.[[Locale]].</li><li>Let <var>type</var> be <var>pluralRules</var>.[[Type]].</li><li>Return !&nbsp;<emu-xref aoid="PluralRuleSelectRange" id="_ref_36"><a href="#sec-pluralruleselectrange">PluralRuleSelectRange</a></emu-xref>(<var>locale</var>, <var>type</var>, <var>xp</var>, <var>yp</var>).</li></ol></emu-alg>
+      <emu-alg><ol><li>Assert: Type(<var>pluralRules</var>) is Object.</li><li>Assert: <var>pluralRules</var> has an [[InitializedPluralRules]] internal slot.</li><li>Assert: Type(<var>x</var>) is Number.</li><li>Assert: Type(<var>y</var>) is Number.</li><li>If <var>x</var> is <emu-val>NaN</emu-val> or <var>y</var> is <emu-val>NaN</emu-val>, throw a <emu-val>RangeError</emu-val> exception.</li><li>Let <var>xp</var> be !&nbsp;<emu-xref aoid="ResolvePlural" id="_ref_14"><a href="#sec-resolveplural">ResolvePlural</a></emu-xref>(<var>pluralRules</var>, <var>x</var>).</li><li>Let <var>yp</var> be !&nbsp;<emu-xref aoid="ResolvePlural" id="_ref_15"><a href="#sec-resolveplural">ResolvePlural</a></emu-xref>(<var>pluralRules</var>, <var>y</var>).</li><li>Let <var>locale</var> be <var>pluralRules</var>.[[Locale]].</li><li>Let <var>type</var> be <var>pluralRules</var>.[[Type]].</li><li>Return !&nbsp;<emu-xref aoid="PluralRuleSelectRange" id="_ref_16"><a href="#sec-pluralruleselectrange">PluralRuleSelectRange</a></emu-xref>(<var>locale</var>, <var>type</var>, <var>xp</var>, <var>yp</var>).</li></ol></emu-alg>
     </emu-clause>
     </ins>
   </emu-clause>

--- a/out/pluralrules/proposed.html
+++ b/out/pluralrules/proposed.html
@@ -1,6 +1,88 @@
 <!doctype html>
-<head><meta charset="utf-8"><script type="application/json" id="menu-search-biblio">[{"type":"term","term":"%PluralRules%","refId":"sec-intl-pluralrules-constructor","referencingIds":[],"namespace":"<no location>","location":"","key":"%PluralRules%"},{"type":"clause","id":"sec-intl.pluralrules","aoid":null,"title":"Intl.PluralRules ( [ locales [ , options ] ] )","titleHTML":"Intl.PluralRules ( [ <var>locales</var> [ , <var>options</var> ] ] )","number":"1.1.1","namespace":"<no location>","location":"","referencingIds":[],"key":"Intl.PluralRules ( [ locales [ , options ] ] )"},{"type":"op","aoid":"InitializePluralRules","refId":"sec-initializepluralrules","location":"","referencingIds":[],"key":"InitializePluralRules"},{"type":"clause","id":"sec-initializepluralrules","aoid":"InitializePluralRules","title":"InitializePluralRules ( pluralRules, locales, options )","titleHTML":"InitializePluralRules ( <var>pluralRules</var>, <var>locales</var>, <var>options</var> )","number":"1.1.2","namespace":"<no location>","location":"","referencingIds":["_ref_3"],"key":"InitializePluralRules ( pluralRules, locales, options )"},{"type":"clause","id":"sec-intl-pluralrules-constructor","aoid":null,"title":"The Intl.PluralRules Constructor","titleHTML":"The Intl.PluralRules Constructor","number":"1.1","namespace":"<no location>","location":"","referencingIds":["_ref_4","_ref_5","_ref_6","_ref_8","_ref_9"],"key":"The Intl.PluralRules Constructor"},{"type":"clause","id":"sec-intl.pluralrules.prototype","aoid":null,"title":"Intl.PluralRules.prototype","titleHTML":"Intl.PluralRules.prototype","number":"1.2.1","namespace":"<no location>","location":"","referencingIds":[],"key":"Intl.PluralRules.prototype"},{"type":"clause","id":"sec-intl.pluralrules.supportedlocalesof","aoid":null,"title":"Intl.PluralRules.supportedLocalesOf ( locales [ , options ] )","titleHTML":"Intl.PluralRules.supportedLocalesOf ( <var>locales</var> [ , <var>options</var> ] )","number":"1.2.2","namespace":"<no location>","location":"","referencingIds":[],"key":"Intl.PluralRules.supportedLocalesOf ( locales [ , options ] )"},{"type":"clause","id":"sec-intl.pluralrules-internal-slots","aoid":null,"title":"Internal slots","titleHTML":"Internal slots","number":"1.2.3","namespace":"<no location>","location":"","referencingIds":[],"key":"Internal slots"},{"type":"clause","id":"sec-properties-of-intl-pluralrules-constructor","aoid":null,"title":"Properties of the Intl.PluralRules Constructor","titleHTML":"Properties of the Intl.PluralRules Constructor","number":"1.2","namespace":"<no location>","location":"","referencingIds":[],"key":"Properties of the Intl.PluralRules Constructor"},{"type":"term","term":"%PluralRules.prototype%","refId":"sec-properties-of-intl-pluralrules-prototype-object","referencingIds":[],"namespace":"<no location>","location":"","key":"%PluralRules.prototype%"},{"type":"clause","id":"sec-intl.pluralrules.prototype.constructor","aoid":null,"title":"Intl.PluralRules.prototype.constructor","titleHTML":"Intl.PluralRules.prototype.constructor","number":"1.3.1","namespace":"<no location>","location":"","referencingIds":[],"key":"Intl.PluralRules.prototype.constructor"},{"type":"clause","id":"sec-intl.pluralrules.prototype-tostringtag","aoid":null,"title":"Intl.PluralRules.prototype [ @@toStringTag ]","titleHTML":"Intl.PluralRules.prototype [ @@toStringTag ]","number":"1.3.2","namespace":"<no location>","location":"","referencingIds":[],"key":"Intl.PluralRules.prototype [ @@toStringTag ]"},{"type":"clause","id":"sec-intl.pluralrules.prototype.select","aoid":null,"title":"Intl.PluralRules.prototype.select ( value )","titleHTML":"Intl.PluralRules.prototype.select ( <var>value</var> )","number":"1.3.3","namespace":"<no location>","location":"","referencingIds":[],"key":"Intl.PluralRules.prototype.select ( value )"},{"type":"clause","id":"sec-intl.pluralrules.prototype.selectrange","aoid":null,"title":"Intl.PluralRules.prototype.selectRange ( start, end )","titleHTML":"Intl.PluralRules.prototype.selectRange ( <var>start</var>, <var>end</var> )","number":"1.3.4","namespace":"<no location>","location":"","referencingIds":[],"key":"Intl.PluralRules.prototype.selectRange ( start, end )"},{"type":"table","id":"table-pluralrules-resolvedoptions-properties","number":1,"caption":"Table 1: Resolved Options of PluralRules Instances","referencingIds":["_ref_0"],"namespace":"<no location>","location":"","key":"Table 1: Resolved Options of PluralRules Instances"},{"type":"clause","id":"sec-intl.pluralrules.prototype.resolvedoptions","aoid":null,"title":"Intl.PluralRules.prototype.resolvedOptions ( )","titleHTML":"Intl.PluralRules.prototype.resolvedOptions ( )","number":"1.3.5","namespace":"<no location>","location":"","referencingIds":[],"key":"Intl.PluralRules.prototype.resolvedOptions ( )"},{"type":"clause","id":"sec-properties-of-intl-pluralrules-prototype-object","aoid":null,"title":"Properties of the Intl.PluralRules Prototype Object","titleHTML":"Properties of the Intl.PluralRules Prototype Object","number":"1.3","namespace":"<no location>","location":"","referencingIds":["_ref_7","_ref_24"],"key":"Properties of the Intl.PluralRules Prototype Object"},{"type":"clause","id":"sec-properties-of-intl-pluralrules-instances","aoid":null,"title":"Properties of Intl.PluralRules Instances","titleHTML":"Properties of Intl.PluralRules Instances","number":"1.4","namespace":"<no location>","location":"","referencingIds":[],"key":"Properties of Intl.PluralRules Instances"},{"type":"table","id":"table-plural-operands","number":2,"caption":"Table 2: Plural Rules Operands Record Fields","referencingIds":[],"namespace":"<no location>","location":"","key":"Table 2: Plural Rules Operands Record Fields"},{"type":"clause","id":"sec-getoperands","aoid":null,"title":"\n         GetOperands (\n           s: a decimal String,\n         )\n       ","titleHTML":"\n         GetOperands (\n           <var>s</var>: a decimal String,\n         )\n       ","number":"1.5.1","namespace":"<no location>","location":"","referencingIds":[],"key":"\n         GetOperands (\n           s: a decimal String,\n         )\n       "},{"type":"clause","id":"sec-pluralruleselect","aoid":null,"title":"\n        PluralRuleSelect (\n          locale: a String,\n          type: a String,\n          n: a finite Number,\n          operands: a Plural Rules Operands Record derived from formatting n,\n        )\n      ","titleHTML":"\n        PluralRuleSelect (\n          <var>locale</var>: a String,\n          <var>type</var>: a String,\n          <var>n</var>: a finite Number,\n          <var>operands</var>: a Plural Rules Operands Record derived from formatting <var>n</var>,\n        )\n      ","number":"1.5.2","namespace":"<no location>","location":"","referencingIds":["_ref_1"],"key":"\n        PluralRuleSelect (\n          locale: a String,\n          type: a String,\n          n: a finite Number,\n          operands: a Plural Rules Operands Record derived from formatting n,\n        )\n      "},{"type":"op","aoid":"ResolvePlural","refId":"sec-resolveplural","location":"","referencingIds":[],"key":"ResolvePlural"},{"type":"clause","id":"sec-resolveplural","aoid":"ResolvePlural","title":"ResolvePlural ( pluralRules, n )","titleHTML":"ResolvePlural ( <var>pluralRules</var>, <var>n</var> )","number":"1.5.3","namespace":"<no location>","location":"","referencingIds":["_ref_12","_ref_34","_ref_35"],"key":"ResolvePlural ( pluralRules, n )"},{"type":"op","aoid":"PluralRuleSelectRange","refId":"sec-pluralruleselectrange","location":"","referencingIds":[],"key":"PluralRuleSelectRange"},{"type":"clause","id":"sec-pluralruleselectrange","aoid":"PluralRuleSelectRange","title":"PluralRuleSelectRange ( locale, type, xp, yp )","titleHTML":"PluralRuleSelectRange ( <var>locale</var>, <var>type</var>, <var>xp</var>, <var>yp</var> )","number":"1.5.4","namespace":"<no location>","location":"","referencingIds":["_ref_36"],"key":"PluralRuleSelectRange ( locale, type, xp, yp )"},{"type":"op","aoid":"ResolvePluralRange","refId":"sec-resolvepluralrange","location":"","referencingIds":[],"key":"ResolvePluralRange"},{"type":"clause","id":"sec-resolvepluralrange","aoid":"ResolvePluralRange","title":"ResolvePluralRange ( pluralRules, x, y )","titleHTML":"ResolvePluralRange ( <var>pluralRules</var>, <var>x</var>, <var>y</var> )","number":"1.5.5","namespace":"<no location>","location":"","referencingIds":["_ref_16"],"key":"ResolvePluralRange ( pluralRules, x, y )"},{"type":"clause","id":"sec-intl-pluralrules-abstracts","aoid":null,"title":"Abstract Operations for PluralRules Objects","titleHTML":"Abstract Operations for PluralRules Objects","number":"1.5","namespace":"<no location>","location":"","referencingIds":[],"key":"Abstract Operations for PluralRules Objects"},{"type":"clause","id":"pluralrules-objects","aoid":null,"title":"PluralRules Objects","titleHTML":"PluralRules Objects","number":"1","namespace":"<no location>","location":"","referencingIds":[],"key":"PluralRules Objects"}]</script><script>"use strict";
+<head><meta charset="utf-8"><script>'use strict';
+let sdoBox = {
+  init() {
+    this.$alternativeId = null;
+    this.$outer = document.createElement('div');
+    this.$outer.classList.add('toolbox-container');
+    this.$container = document.createElement('div');
+    this.$container.classList.add('toolbox');
+    this.$displayLink = document.createElement('a');
+    this.$displayLink.setAttribute('href', '#');
+    this.$displayLink.textContent = 'Syntax-Directed Operations';
+    this.$displayLink.addEventListener('click', e => {
+      e.preventDefault();
+      e.stopPropagation();
+      referencePane.showSDOs(sdoMap[this.$alternativeId] || {}, this.$alternativeId);
+    });
+    this.$container.appendChild(this.$displayLink);
+    this.$outer.appendChild(this.$container);
+    document.body.appendChild(this.$outer);
+  },
 
+  activate(el) {
+    clearTimeout(this.deactiveTimeout);
+    Toolbox.deactivate();
+    this.$alternativeId = el.id;
+    let numSdos = Object.keys(sdoMap[this.$alternativeId] || {}).length;
+    this.$displayLink.textContent = 'Syntax-Directed Operations (' + numSdos + ')';
+    this.$outer.classList.add('active');
+    let top = el.offsetTop - this.$outer.offsetHeight;
+    let left = el.offsetLeft + 50 - 10; // 50px = padding-left(=75px) + text-indent(=-25px)
+    this.$outer.setAttribute('style', 'left: ' + left + 'px; top: ' + top + 'px');
+    if (top < document.body.scrollTop) {
+      this.$container.scrollIntoView();
+    }
+  },
+
+  deactivate() {
+    clearTimeout(this.deactiveTimeout);
+    this.$outer.classList.remove('active');
+  },
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+  if (typeof sdoMap == 'undefined') {
+    console.error('could not find sdo map');
+    return;
+  }
+  sdoBox.init();
+
+  let insideTooltip = false;
+  sdoBox.$outer.addEventListener('pointerenter', () => {
+    insideTooltip = true;
+  });
+  sdoBox.$outer.addEventListener('pointerleave', () => {
+    insideTooltip = false;
+    sdoBox.deactivate();
+  });
+
+  sdoBox.deactiveTimeout = null;
+  [].forEach.call(document.querySelectorAll('emu-grammar[type=definition] emu-rhs'), node => {
+    node.addEventListener('pointerenter', function () {
+      sdoBox.activate(this);
+    });
+
+    node.addEventListener('pointerleave', () => {
+      sdoBox.deactiveTimeout = setTimeout(() => {
+        if (!insideTooltip) {
+          sdoBox.deactivate();
+        }
+      }, 500);
+    });
+  });
+
+  document.addEventListener(
+    'keydown',
+    debounce(e => {
+      if (e.code === 'Escape') {
+        sdoBox.deactivate();
+      }
+    })
+  );
+});
+
+'use strict';
 function Search(menu) {
   this.menu = menu;
   this.$search = document.getElementById('menu-search');
@@ -11,8 +93,14 @@ function Search(menu) {
 
   document.addEventListener('keydown', this.documentKeydown.bind(this));
 
-  this.$searchBox.addEventListener('keydown', debounce(this.searchBoxKeydown.bind(this), { stopPropagation: true }));
-  this.$searchBox.addEventListener('keyup', debounce(this.searchBoxKeyup.bind(this), { stopPropagation: true }));
+  this.$searchBox.addEventListener(
+    'keydown',
+    debounce(this.searchBoxKeydown.bind(this), { stopPropagation: true })
+  );
+  this.$searchBox.addEventListener(
+    'keyup',
+    debounce(this.searchBoxKeyup.bind(this), { stopPropagation: true })
+  );
 
   // Perform an initial search if the box is not empty.
   if (this.$searchBox.value) {
@@ -21,26 +109,34 @@ function Search(menu) {
 }
 
 Search.prototype.loadBiblio = function () {
-  var $biblio = document.getElementById('menu-search-biblio');
-  if (!$biblio) {
-    this.biblio = [];
+  if (typeof biblio === 'undefined') {
+    console.error('could not find biblio');
+    this.biblio = { refToClause: {}, entries: [] };
   } else {
-    this.biblio = JSON.parse($biblio.textContent);
-    this.biblio.clauses = this.biblio.filter(function (e) { return e.type === 'clause' });
-    this.biblio.byId = this.biblio.reduce(function (map, entry) {
+    this.biblio = biblio;
+    this.biblio.clauses = this.biblio.entries.filter(e => e.type === 'clause');
+    this.biblio.byId = this.biblio.entries.reduce((map, entry) => {
       map[entry.id] = entry;
       return map;
     }, {});
+    let refParentClause = Object.create(null);
+    this.biblio.refParentClause = refParentClause;
+    let refsByClause = this.biblio.refsByClause;
+    Object.keys(refsByClause).forEach(clause => {
+      refsByClause[clause].forEach(ref => {
+        refParentClause[ref] = clause;
+      });
+    });
   }
-}
+};
 
 Search.prototype.documentKeydown = function (e) {
-  if (e.keyCode === 191) {
+  if (e.key === '/') {
     e.preventDefault();
     e.stopPropagation();
     this.triggerSearch();
   }
-}
+};
 
 Search.prototype.searchBoxKeydown = function (e) {
   e.stopPropagation();
@@ -51,7 +147,7 @@ Search.prototype.searchBoxKeydown = function (e) {
     e.preventDefault();
     this.selectResult();
   }
-}
+};
 
 Search.prototype.searchBoxKeyup = function (e) {
   if (e.keyCode === 13 || e.keyCode === 9) {
@@ -59,10 +155,9 @@ Search.prototype.searchBoxKeyup = function (e) {
   }
 
   this.search(e.target.value);
-}
+};
 
-
-Search.prototype.triggerSearch = function (e) {
+Search.prototype.triggerSearch = function () {
   if (this.menu.isVisible()) {
     this._closeAfterSearch = false;
   } else {
@@ -72,14 +167,14 @@ Search.prototype.triggerSearch = function (e) {
 
   this.$searchBox.focus();
   this.$searchBox.select();
-}
+};
 // bit 12 - Set if the result starts with searchString
 // bits 8-11: 8 - number of chunks multiplied by 2 if cases match, otherwise 1.
 // bits 1-7: 127 - length of the entry
 // General scheme: prefer case sensitive matches with fewer chunks, and otherwise
 // prefer shorter matches.
-function relevance(result, searchString) {
-  var relevance = 0;
+function relevance(result) {
+  let relevance = 0;
 
   relevance = Math.max(0, 8 - result.match.chunks) << 7;
 
@@ -88,10 +183,10 @@ function relevance(result, searchString) {
   }
 
   if (result.match.prefix) {
-    relevance += 2048
+    relevance += 2048;
   }
 
-  relevance += Math.max(0, 255 - result.entry.key.length);
+  relevance += Math.max(0, 255 - result.key.length);
 
   return relevance;
 }
@@ -110,36 +205,34 @@ Search.prototype.search = function (searchString) {
     return;
   }
 
-  var results;
+  let results;
 
-  if (/^[\d\.]*$/.test(searchString)) {
-    results = this.biblio.clauses.filter(function (clause) {
-      return clause.number.substring(0, searchString.length) === searchString;
-    }).map(function (clause) {
-      return { entry: clause };
-    });
+  if (/^[\d.]*$/.test(searchString)) {
+    results = this.biblio.clauses
+      .filter(clause => clause.number.substring(0, searchString.length) === searchString)
+      .map(clause => ({ key: getKey(clause), entry: clause }));
   } else {
     results = [];
 
-    for (var i = 0; i < this.biblio.length; i++) {
-      var entry = this.biblio[i];
-      if (!entry.key) {
+    for (let i = 0; i < this.biblio.entries.length; i++) {
+      let entry = this.biblio.entries[i];
+      let key = getKey(entry);
+      if (!key) {
         // biblio entries without a key aren't searchable
         continue;
       }
 
-      var match = fuzzysearch(searchString, entry.key);
+      let match = fuzzysearch(searchString, key);
       if (match) {
-        results.push({ entry: entry, match: match });
+        results.push({ key, entry, match });
       }
     }
 
-    results.forEach(function (result) {
+    results.forEach(result => {
       result.relevance = relevance(result, searchString);
     });
 
-    results = results.sort(function (a, b) { return b.relevance - a.relevance });
-
+    results = results.sort((a, b) => b.relevance - a.relevance);
   }
 
   if (results.length > 50) {
@@ -147,17 +240,17 @@ Search.prototype.search = function (searchString) {
   }
 
   this.displayResults(results);
-}
+};
 Search.prototype.hideSearch = function () {
   this.$search.classList.remove('active');
-}
+};
 
 Search.prototype.showSearch = function () {
   this.$search.classList.add('active');
-}
+};
 
 Search.prototype.selectResult = function () {
-  var $first = this.$searchResults.querySelector('li:first-child a');
+  let $first = this.$searchResults.querySelector('li:first-child a');
 
   if ($first) {
     document.location = $first.getAttribute('href');
@@ -171,53 +264,79 @@ Search.prototype.selectResult = function () {
   if (this._closeAfterSearch) {
     this.menu.hide();
   }
-}
+};
 
 Search.prototype.displayResults = function (results) {
   if (results.length > 0) {
     this.$searchResults.classList.remove('no-results');
 
-    var html = '<ul>';
+    let html = '<ul>';
 
-    results.forEach(function (result) {
-      var entry = result.entry;
-      var id = entry.id;
-      var cssClass = '';
-      var text = '';
+    results.forEach(result => {
+      let key = result.key;
+      let entry = result.entry;
+      let id = entry.id;
+      let cssClass = '';
+      let text = '';
 
       if (entry.type === 'clause') {
-        var number = entry.number ? entry.number + ' ' : '';
-        text = number + entry.key;
+        let number = entry.number ? entry.number + ' ' : '';
+        text = number + key;
         cssClass = 'clause';
         id = entry.id;
       } else if (entry.type === 'production') {
-        text = entry.key;
+        text = key;
         cssClass = 'prod';
         id = entry.id;
       } else if (entry.type === 'op') {
-        text = entry.key;
+        text = key;
         cssClass = 'op';
         id = entry.id || entry.refId;
       } else if (entry.type === 'term') {
-        text = entry.key;
+        text = key;
         cssClass = 'term';
         id = entry.id || entry.refId;
       }
 
       if (text) {
-        html += '<li class=menu-search-result-' + cssClass + '><a href="#' + id + '">' + text + '</a></li>';
+        // prettier-ignore
+        html += `<li class=menu-search-result-${cssClass}><a href="${makeLinkToId(id)}">${text}</a></li>`;
       }
     });
 
-    html += '</ul>'
+    html += '</ul>';
 
     this.$searchResults.innerHTML = html;
   } else {
     this.$searchResults.innerHTML = '';
     this.$searchResults.classList.add('no-results');
   }
-}
+};
 
+function getKey(item) {
+  if (item.key) {
+    return item.key;
+  }
+  switch (item.type) {
+    case 'clause':
+      return item.title || item.titleHTML;
+    case 'production':
+      return item.name;
+    case 'op':
+      return item.aoid;
+    case 'term':
+      return item.term;
+    case 'table':
+    case 'figure':
+    case 'example':
+    case 'note':
+      return item.caption;
+    case 'step':
+      return item.id;
+    default:
+      throw new Error("Can't get key for " + item.type);
+  }
+}
 
 function Menu() {
   this.$toggle = document.getElementById('menu-toggle');
@@ -229,7 +348,7 @@ function Menu() {
   this.$specContainer = document.getElementById('spec-container');
   this.search = new Search(this);
 
-  this._pinnedIds = {}; 
+  this._pinnedIds = {};
   this.loadPinEntries();
 
   // toggle menu
@@ -239,23 +358,23 @@ function Menu() {
   document.addEventListener('keydown', this.documentKeydown.bind(this));
 
   // toc expansion
-  var tocItems = this.$menu.querySelectorAll('#menu-toc li');
-  for (var i = 0; i < tocItems.length; i++) {
-    var $item = tocItems[i];
-    $item.addEventListener('click', function($item, event) {
+  let tocItems = this.$menu.querySelectorAll('#menu-toc li');
+  for (let i = 0; i < tocItems.length; i++) {
+    let $item = tocItems[i];
+    $item.addEventListener('click', event => {
       $item.classList.toggle('active');
       event.stopPropagation();
-    }.bind(null, $item));
+    });
   }
 
   // close toc on toc item selection
-  var tocLinks = this.$menu.querySelectorAll('#menu-toc li > a');
-  for (var i = 0; i < tocLinks.length; i++) {
-    var $link = tocLinks[i];
-    $link.addEventListener('click', function(event) {
+  let tocLinks = this.$menu.querySelectorAll('#menu-toc li > a');
+  for (let i = 0; i < tocLinks.length; i++) {
+    let $link = tocLinks[i];
+    $link.addEventListener('click', event => {
       this.toggle();
       event.stopPropagation();
-    }.bind(this));
+    });
   }
 
   // update active clause on scroll
@@ -263,14 +382,13 @@ function Menu() {
   this.updateActiveClause();
 
   // prevent menu scrolling from scrolling the body
-  this.$toc.addEventListener('wheel', function (e) {
-    var target = e.currentTarget;
-    var offTop = e.deltaY < 0 && target.scrollTop === 0;
+  this.$toc.addEventListener('wheel', e => {
+    let target = e.currentTarget;
+    let offTop = e.deltaY < 0 && target.scrollTop === 0;
     if (offTop) {
       e.preventDefault();
     }
-    var offBottom = e.deltaY > 0
-                    && target.offsetHeight + target.scrollTop >= target.scrollHeight;
+    let offBottom = e.deltaY > 0 && target.offsetHeight + target.scrollTop >= target.scrollHeight;
 
     if (offBottom) {
       e.preventDefault();
@@ -285,62 +403,66 @@ Menu.prototype.documentKeydown = function (e) {
   } else if (e.keyCode > 48 && e.keyCode < 58) {
     this.selectPin(e.keyCode - 49);
   }
-}
+};
 
 Menu.prototype.updateActiveClause = function () {
-  this.setActiveClause(findActiveClause(this.$specContainer))
-}
+  this.setActiveClause(findActiveClause(this.$specContainer));
+};
 
 Menu.prototype.setActiveClause = function (clause) {
   this.$activeClause = clause;
   this.revealInToc(this.$activeClause);
-}
+};
 
 Menu.prototype.revealInToc = function (path) {
-  var current = this.$toc.querySelectorAll('li.revealed');
-  for (var i = 0; i < current.length; i++) {
+  let current = this.$toc.querySelectorAll('li.revealed');
+  for (let i = 0; i < current.length; i++) {
     current[i].classList.remove('revealed');
     current[i].classList.remove('revealed-leaf');
   }
 
-  var current = this.$toc;
-  var index = 0;
-  while (index < path.length) {
-    var children = current.children;
-    for (var i = 0; i < children.length; i++) {
-      if ('#' + path[index].id === children[i].children[1].getAttribute('href') ) {
+  current = this.$toc;
+  let index = 0;
+  outer: while (index < path.length) {
+    let children = current.children;
+    for (let i = 0; i < children.length; i++) {
+      if ('#' + path[index].id === children[i].children[1].hash) {
         children[i].classList.add('revealed');
         if (index === path.length - 1) {
           children[i].classList.add('revealed-leaf');
-          var rect = children[i].getBoundingClientRect();
+          let rect = children[i].getBoundingClientRect();
           // this.$toc.getBoundingClientRect().top;
-          var tocRect = this.$toc.getBoundingClientRect();
+          let tocRect = this.$toc.getBoundingClientRect();
           if (rect.top + 10 > tocRect.bottom) {
-            this.$toc.scrollTop = this.$toc.scrollTop + (rect.top - tocRect.bottom) + (rect.bottom - rect.top);
+            this.$toc.scrollTop =
+              this.$toc.scrollTop + (rect.top - tocRect.bottom) + (rect.bottom - rect.top);
           } else if (rect.top < tocRect.top) {
             this.$toc.scrollTop = this.$toc.scrollTop - (tocRect.top - rect.top);
           }
         }
         current = children[i].querySelector('ol');
         index++;
-        break;
+        continue outer;
       }
     }
-
+    console.log('could not find location in table of contents', path);
+    break;
   }
-}
+};
 
 function findActiveClause(root, path) {
-  var clauses = new ClauseWalker(root);
-  var $clause;
-  var path = path || [];
+  let clauses = getChildClauses(root);
+  path = path || [];
 
-  while ($clause = clauses.nextNode()) {
-    var rect = $clause.getBoundingClientRect();
-    var $header = $clause.querySelector("h1");
-    var marginTop = parseInt(getComputedStyle($header)["margin-top"]);
+  for (let $clause of clauses) {
+    let rect = $clause.getBoundingClientRect();
+    let $header = $clause.querySelector('h1');
+    let marginTop = Math.max(
+      parseInt(getComputedStyle($clause)['margin-top']),
+      parseInt(getComputedStyle($header)['margin-top'])
+    );
 
-    if ((rect.top - marginTop) <= 0 && rect.bottom > 0) {
+    if (rect.top - marginTop <= 1 && rect.bottom > 0) {
       return findActiveClause($clause, path.concat($clause)) || path;
     }
   }
@@ -348,57 +470,49 @@ function findActiveClause(root, path) {
   return path;
 }
 
-function ClauseWalker(root) {
-  var previous;
-  var treeWalker = document.createTreeWalker(
-    root,
-    NodeFilter.SHOW_ELEMENT,
-    {
-      acceptNode: function (node) {
-        if (previous === node.parentNode) {
-          return NodeFilter.FILTER_REJECT;
-        } else {
-          previous = node;
-        }
-        if (node.nodeName === 'EMU-CLAUSE' || node.nodeName === 'EMU-INTRO' || node.nodeName === 'EMU-ANNEX') {
-          return NodeFilter.FILTER_ACCEPT;
-        } else {
-          return NodeFilter.FILTER_SKIP;
-        }
-      }
-    },
-    false
-    );
+function* getChildClauses(root) {
+  for (let el of root.children) {
+    switch (el.nodeName) {
+      // descend into <emu-import>
+      case 'EMU-IMPORT':
+        yield* getChildClauses(el);
+        break;
 
-  return treeWalker;
+      // accept <emu-clause>, <emu-intro>, and <emu-annex>
+      case 'EMU-CLAUSE':
+      case 'EMU-INTRO':
+      case 'EMU-ANNEX':
+        yield el;
+    }
+  }
 }
 
 Menu.prototype.toggle = function () {
   this.$menu.classList.toggle('active');
-}
+};
 
 Menu.prototype.show = function () {
   this.$menu.classList.add('active');
-}
+};
 
 Menu.prototype.hide = function () {
   this.$menu.classList.remove('active');
-}
+};
 
-Menu.prototype.isVisible = function() {
+Menu.prototype.isVisible = function () {
   return this.$menu.classList.contains('active');
-}
+};
 
 Menu.prototype.showPins = function () {
   this.$pins.classList.add('active');
-}
+};
 
 Menu.prototype.hidePins = function () {
   this.$pins.classList.remove('active');
-}
+};
 
 Menu.prototype.addPinEntry = function (id) {
-  var entry = this.search.biblio.byId[id];
+  let entry = this.search.biblio.byId[id];
   if (!entry) {
     // id was deleted after pin (or something) so remove it
     delete this._pinnedIds[id];
@@ -407,15 +521,16 @@ Menu.prototype.addPinEntry = function (id) {
   }
 
   if (entry.type === 'clause') {
-    var prefix;
+    let prefix;
     if (entry.number) {
       prefix = entry.number + ' ';
     } else {
       prefix = '';
     }
-    this.$pinList.innerHTML += '<li><a href="#' + entry.id + '">' + prefix + entry.titleHTML + '</a></li>';
+    // prettier-ignore
+    this.$pinList.innerHTML += `<li><a href="${makeLinkToId(entry.id)}">${prefix}${entry.titleHTML}</a></li>`;
   } else {
-    this.$pinList.innerHTML += '<li><a href="#' + entry.id + '">' + entry.key + '</a></li>';
+    this.$pinList.innerHTML += `<li><a href="${makeLinkToId(entry.id)}">${getKey(entry)}</a></li>`;
   }
 
   if (Object.keys(this._pinnedIds).length === 0) {
@@ -423,10 +538,10 @@ Menu.prototype.addPinEntry = function (id) {
   }
   this._pinnedIds[id] = true;
   this.persistPinEntries();
-}
+};
 
 Menu.prototype.removePinEntry = function (id) {
-  var item = this.$pinList.querySelector('a[href="#' + id + '"]').parentNode;
+  let item = this.$pinList.querySelector(`a[href="${makeLinkToId(id)}"]`).parentNode;
   this.$pinList.removeChild(item);
   delete this._pinnedIds[id];
   if (Object.keys(this._pinnedIds).length === 0) {
@@ -434,7 +549,7 @@ Menu.prototype.removePinEntry = function (id) {
   }
 
   this.persistPinEntries();
-}
+};
 
 Menu.prototype.persistPinEntries = function () {
   try {
@@ -444,7 +559,7 @@ Menu.prototype.persistPinEntries = function () {
   }
 
   localStorage.pinEntries = JSON.stringify(Object.keys(this._pinnedIds));
-}
+};
 
 Menu.prototype.loadPinEntries = function () {
   try {
@@ -453,13 +568,13 @@ Menu.prototype.loadPinEntries = function () {
     return;
   }
 
-  var pinsString = window.localStorage.pinEntries;
+  let pinsString = window.localStorage.pinEntries;
   if (!pinsString) return;
-  var pins = JSON.parse(pinsString);
-  for(var i = 0; i < pins.length; i++) {
+  let pins = JSON.parse(pinsString);
+  for (let i = 0; i < pins.length; i++) {
     this.addPinEntry(pins[i]);
   }
-}
+};
 
 Menu.prototype.togglePinEntry = function (id) {
   if (!id) {
@@ -471,62 +586,49 @@ Menu.prototype.togglePinEntry = function (id) {
   } else {
     this.addPinEntry(id);
   }
-}
+};
 
 Menu.prototype.selectPin = function (num) {
   document.location = this.$pinList.children[num].children[0].href;
-}
+};
 
-var menu;
-function init() {
-  menu = new Menu();
-  var $container = document.getElementById('spec-container');
-  $container.addEventListener('mouseover', debounce(function (e) {
-    Toolbox.activateIfMouseOver(e);
-  }));
-  document.addEventListener('keydown', debounce(function (e) {
-    if (e.code === "Escape" && Toolbox.active) {
-      Toolbox.deactivate();
-    }
-  }));
-}
+let menu;
 
 document.addEventListener('DOMContentLoaded', init);
 
 function debounce(fn, opts) {
   opts = opts || {};
-  var timeout;
-  return function(e) {
+  let timeout;
+  return function (e) {
     if (opts.stopPropagation) {
       e.stopPropagation();
     }
-    var args = arguments;
+    let args = arguments;
     if (timeout) {
       clearTimeout(timeout);
     }
-    timeout = setTimeout(function() {
+    timeout = setTimeout(() => {
       timeout = null;
       fn.apply(this, args);
-    }.bind(this), 150);
-  }
+    }, 150);
+  };
 }
 
-var CLAUSE_NODES = ['EMU-CLAUSE', 'EMU-INTRO', 'EMU-ANNEX'];
-function findLocalReferences ($elem) {
-  var name = $elem.innerHTML;
-  var references = [];
-
-  var parentClause = $elem.parentNode;
+let CLAUSE_NODES = ['EMU-CLAUSE', 'EMU-INTRO', 'EMU-ANNEX'];
+function findContainer($elem) {
+  let parentClause = $elem.parentNode;
   while (parentClause && CLAUSE_NODES.indexOf(parentClause.nodeName) === -1) {
     parentClause = parentClause.parentNode;
   }
+  return parentClause;
+}
 
-  if(!parentClause) return;
+function findLocalReferences(parentClause, name) {
+  let vars = parentClause.querySelectorAll('var');
+  let references = [];
 
-  var vars = parentClause.querySelectorAll('var');
-
-  for (var i = 0; i < vars.length; i++) {
-    var $var = vars[i];
+  for (let i = 0; i < vars.length; i++) {
+    let $var = vars[i];
 
     if ($var.innerHTML === name) {
       references.push($var);
@@ -536,21 +638,38 @@ function findLocalReferences ($elem) {
   return references;
 }
 
+let REFERENCED_CLASSES = Array.from({ length: 7 }, (x, i) => `referenced${i}`);
+function chooseHighlightIndex(parentClause) {
+  let counts = REFERENCED_CLASSES.map($class => parentClause.getElementsByClassName($class).length);
+  // Find the earliest index with the lowest count.
+  let minCount = Infinity;
+  let index = null;
+  for (let i = 0; i < counts.length; i++) {
+    if (counts[i] < minCount) {
+      minCount = counts[i];
+      index = i;
+    }
+  }
+  return index;
+}
+
 function toggleFindLocalReferences($elem) {
-  var references = findLocalReferences($elem);
+  let parentClause = findContainer($elem);
+  let references = findLocalReferences(parentClause, $elem.innerHTML);
   if ($elem.classList.contains('referenced')) {
-    references.forEach(function ($reference) {
-      $reference.classList.remove('referenced');
+    references.forEach($reference => {
+      $reference.classList.remove('referenced', ...REFERENCED_CLASSES);
     });
   } else {
-    references.forEach(function ($reference) {
-      $reference.classList.add('referenced');
+    let index = chooseHighlightIndex(parentClause);
+    references.forEach($reference => {
+      $reference.classList.add('referenced', `referenced${index}`);
     });
   }
 }
 
-function installFindLocalReferences () {
-  document.addEventListener('click', function (e) {
+function installFindLocalReferences() {
+  document.addEventListener('click', e => {
     if (e.target.nodeName === 'VAR') {
       toggleFindLocalReferences(e.target);
     }
@@ -558,9 +677,6 @@ function installFindLocalReferences () {
 }
 
 document.addEventListener('DOMContentLoaded', installFindLocalReferences);
-
-
-
 
 // The following license applies to the fuzzysearch function
 // The MIT License (MIT)
@@ -582,11 +698,11 @@ document.addEventListener('DOMContentLoaded', installFindLocalReferences);
 // COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-function fuzzysearch (searchString, haystack, caseInsensitive) {
-  var tlen = haystack.length;
-  var qlen = searchString.length;
-  var chunks = 1;
-  var finding = false;
+function fuzzysearch(searchString, haystack, caseInsensitive) {
+  let tlen = haystack.length;
+  let qlen = searchString.length;
+  let chunks = 1;
+  let finding = false;
 
   if (qlen > tlen) {
     return false;
@@ -602,10 +718,11 @@ function fuzzysearch (searchString, haystack, caseInsensitive) {
     }
   }
 
-  outer: for (var i = 0, j = 0; i < qlen; i++) {
-    var nch = searchString[i];
+  let j = 0;
+  outer: for (let i = 0; i < qlen; i++) {
+    let nch = searchString[i];
     while (j < tlen) {
-      var targetChar = haystack[j++];
+      let targetChar = haystack[j++];
       if (targetChar === nch) {
         finding = true;
         continue outer;
@@ -616,113 +733,24 @@ function fuzzysearch (searchString, haystack, caseInsensitive) {
       }
     }
 
-    if (caseInsensitive) { return false; }
+    if (caseInsensitive) {
+      return false;
+    }
 
     return fuzzysearch(searchString.toLowerCase(), haystack.toLowerCase(), true);
   }
 
-  return { caseMatch: !caseInsensitive, chunks: chunks, prefix: j <= qlen };
+  return { caseMatch: !caseInsensitive, chunks, prefix: j <= qlen };
 }
 
-var Toolbox = {
-  init: function () {
-    this.$container = document.createElement('div');
-    this.$container.classList.add('toolbox');
-    this.$permalink = document.createElement('a');
-    this.$permalink.textContent = 'Permalink';
-    this.$pinLink = document.createElement('a');
-    this.$pinLink.textContent = 'Pin';
-    this.$pinLink.setAttribute('href', '#');
-    this.$pinLink.addEventListener('click', function (e) {
-      e.preventDefault();
-      e.stopPropagation();
-      menu.togglePinEntry(this.entry.id);
-    }.bind(this));
-
-    this.$refsLink = document.createElement('a');
-    this.$refsLink.setAttribute('href', '#');
-    this.$refsLink.addEventListener('click', function (e) {
-      e.preventDefault();
-      e.stopPropagation();
-      referencePane.showReferencesFor(this.entry);
-    }.bind(this));
-    this.$container.appendChild(this.$permalink);
-    this.$container.appendChild(this.$pinLink);
-    this.$container.appendChild(this.$refsLink);
-    document.body.appendChild(this.$container);
-  },
-
-  activate: function (el, entry, target) {
-    if (el === this._activeEl) return;
-    this.active = true;
-    this.entry = entry;
-    this.$container.classList.add('active');
-    this.top = el.offsetTop - this.$container.offsetHeight - 10;
-    this.left = el.offsetLeft;
-    this.$container.setAttribute('style', 'left: ' + this.left + 'px; top: ' + this.top + 'px');
-    this.updatePermalink();
-    this.updateReferences();
-    this._activeEl = el;
-    if (this.top < document.body.scrollTop && el === target) {
-      // don't scroll unless it's a small thing (< 200px)
-      this.$container.scrollIntoView();
-    }
-  },
-
-  updatePermalink: function () {
-    this.$permalink.setAttribute('href', '#' + this.entry.id);
-  },
-
-  updateReferences: function () {
-    this.$refsLink.textContent = 'References (' + this.entry.referencingIds.length + ')';
-  },
-
-  activateIfMouseOver: function (e) {
-    var ref = this.findReferenceUnder(e.target);
-    if (ref && (!this.active || e.pageY > this._activeEl.offsetTop)) {
-      var entry = menu.search.biblio.byId[ref.id];
-      this.activate(ref.element, entry, e.target);
-    } else if (this.active && ((e.pageY < this.top) || e.pageY > (this._activeEl.offsetTop + this._activeEl.offsetHeight))) {
-      this.deactivate();
-    }
-  },
-
-  findReferenceUnder: function (el) {
-    while (el) {
-      var parent = el.parentNode;
-      if (el.nodeName === 'H1' && parent.nodeName.match(/EMU-CLAUSE|EMU-ANNEX|EMU-INTRO/) && parent.id) {
-        return { element: el, id: parent.id };
-      } else if (el.nodeName.match(/EMU-(?!CLAUSE|XREF|ANNEX|INTRO)|DFN/) &&
-                el.id && el.id[0] !== '_') {
-        if (el.nodeName === 'EMU-FIGURE' || el.nodeName === 'EMU-TABLE' || el.nodeName === 'EMU-EXAMPLE') {
-          // return the figcaption element
-          return { element: el.children[0].children[0], id: el.id };
-        } else if (el.nodeName === 'EMU-PRODUCTION') {
-          // return the LHS non-terminal element
-          return { element: el.children[0], id: el.id };
-        } else {
-          return { element: el, id: el.id };
-        }
-      }
-      el = parent;
-    }
-  },
-
-  deactivate: function () {
-    this.$container.classList.remove('active');
-    this._activeEl = null;
-    this.activeElBounds = null;
-    this.active = false;
-  }
-}
-
-var referencePane = {
-  init: function() {
+let referencePane = {
+  init() {
     this.$container = document.createElement('div');
     this.$container.setAttribute('id', 'references-pane-container');
 
-    var $spacer = document.createElement('div');
+    let $spacer = document.createElement('div');
     $spacer.setAttribute('id', 'references-pane-spacer');
+    $spacer.classList.add('menu-spacer');
 
     this.$pane = document.createElement('div');
     this.$pane.setAttribute('id', 'references-pane');
@@ -732,18 +760,19 @@ var referencePane = {
 
     this.$header = document.createElement('div');
     this.$header.classList.add('menu-pane-header');
-    this.$header.textContent = 'References to ';
+    this.$headerText = document.createElement('span');
+    this.$header.appendChild(this.$headerText);
     this.$headerRefId = document.createElement('a');
     this.$header.appendChild(this.$headerRefId);
     this.$closeButton = document.createElement('span');
     this.$closeButton.setAttribute('id', 'references-pane-close');
-    this.$closeButton.addEventListener('click', function (e) {
+    this.$closeButton.addEventListener('click', () => {
       this.deactivate();
-    }.bind(this));
+    });
     this.$header.appendChild(this.$closeButton);
 
     this.$pane.appendChild(this.$header);
-    var tableContainer = document.createElement('div');
+    let tableContainer = document.createElement('div');
     tableContainer.setAttribute('id', 'references-pane-table-container');
 
     this.$table = document.createElement('table');
@@ -757,70 +786,238 @@ var referencePane = {
     menu.$specContainer.appendChild(this.$container);
   },
 
-  activate: function () {
+  activate() {
     this.$container.classList.add('active');
   },
 
-  deactivate: function () {
+  deactivate() {
     this.$container.classList.remove('active');
+    this.state = null;
   },
 
   showReferencesFor(entry) {
     this.activate();
-    var newBody = document.createElement('tbody');
-    var previousId;
-    var previousCell;
-    var dupCount = 0;
+    this.state = { type: 'ref', id: entry.id };
+    this.$headerText.textContent = 'References to ';
+    let newBody = document.createElement('tbody');
+    let previousId;
+    let previousCell;
+    let dupCount = 0;
     this.$headerRefId.textContent = '#' + entry.id;
-    this.$headerRefId.setAttribute('href', '#' + entry.id);
-    entry.referencingIds.map(function (id) {
-      var target = document.getElementById(id);
-      var cid = findParentClauseId(target);
-      var clause = menu.search.biblio.byId[cid];
-      return { id: id, clause: clause }
-    }).sort(function (a, b) {
-      return sortByClauseNumber(a.clause, b.clause);
-    }).forEach(function (record, i) {
-      if (previousId === record.clause.id) {
-        previousCell.innerHTML += ' (<a href="#' + record.id + '">' + (dupCount + 2) + '</a>)';
-        dupCount++;
-      } else {
-        var row = newBody.insertRow();
-        var cell = row.insertCell();
-        cell.innerHTML = record.clause.number;
-        cell = row.insertCell();
-        cell.innerHTML = '<a href="#' + record.id + '">' + record.clause.titleHTML + '</a>';
-        previousCell = cell;
-        previousId = record.clause.id;
-        dupCount = 0;
-      }
-    }, this);
+    this.$headerRefId.setAttribute('href', makeLinkToId(entry.id));
+    this.$headerRefId.style.display = 'inline';
+    (entry.referencingIds || [])
+      .map(id => {
+        let cid = menu.search.biblio.refParentClause[id];
+        let clause = menu.search.biblio.byId[cid];
+        if (clause == null) {
+          throw new Error('could not find clause for id ' + cid);
+        }
+        return { id, clause };
+      })
+      .sort((a, b) => sortByClauseNumber(a.clause, b.clause))
+      .forEach(record => {
+        if (previousId === record.clause.id) {
+          previousCell.innerHTML += ` (<a href="${makeLinkToId(record.id)}">${dupCount + 2}</a>)`;
+          dupCount++;
+        } else {
+          let row = newBody.insertRow();
+          let cell = row.insertCell();
+          cell.innerHTML = record.clause.number;
+          cell = row.insertCell();
+          cell.innerHTML = `<a href="${makeLinkToId(record.id)}">${record.clause.titleHTML}</a>`;
+          previousCell = cell;
+          previousId = record.clause.id;
+          dupCount = 0;
+        }
+      }, this);
     this.$table.removeChild(this.$tableBody);
     this.$tableBody = newBody;
     this.$table.appendChild(this.$tableBody);
-  }
-}
-function findParentClauseId(node) {
-  while (node && node.nodeName !== 'EMU-CLAUSE' && node.nodeName !== 'EMU-INTRO' && node.nodeName !== 'EMU-ANNEX') {
-    node = node.parentNode;
-  }
-  if (!node) return null;
-  return node.getAttribute('id');
-}
+  },
 
-function sortByClauseNumber(c1, c2) {
-  var c1c = c1.number.split('.');
-  var c2c = c2.number.split('.');
+  showSDOs(sdos, alternativeId) {
+    let rhs = document.getElementById(alternativeId);
+    let parentName = rhs.parentNode.getAttribute('name');
+    let colons = rhs.parentNode.querySelector('emu-geq');
+    rhs = rhs.cloneNode(true);
+    rhs.querySelectorAll('emu-params,emu-constraints').forEach(e => {
+      e.remove();
+    });
+    rhs.querySelectorAll('[id]').forEach(e => {
+      e.removeAttribute('id');
+    });
+    rhs.querySelectorAll('a').forEach(e => {
+      e.parentNode.replaceChild(document.createTextNode(e.textContent), e);
+    });
 
-  for (var i = 0; i < c1c.length; i++) {
+    // prettier-ignore
+    this.$headerText.innerHTML = `Syntax-Directed Operations for<br><a href="${makeLinkToId(alternativeId)}" class="menu-pane-header-production"><emu-nt>${parentName}</emu-nt> ${colons.outerHTML} </a>`;
+    this.$headerText.querySelector('a').append(rhs);
+    this.showSDOsBody(sdos, alternativeId);
+  },
+
+  showSDOsBody(sdos, alternativeId) {
+    this.activate();
+    this.state = { type: 'sdo', id: alternativeId, html: this.$headerText.innerHTML };
+    this.$headerRefId.style.display = 'none';
+    let newBody = document.createElement('tbody');
+    Object.keys(sdos).forEach(sdoName => {
+      let pair = sdos[sdoName];
+      let clause = pair.clause;
+      let ids = pair.ids;
+      let first = ids[0];
+      let row = newBody.insertRow();
+      let cell = row.insertCell();
+      cell.innerHTML = clause;
+      cell = row.insertCell();
+      let html = '<a href="' + makeLinkToId(first) + '">' + sdoName + '</a>';
+      for (let i = 1; i < ids.length; ++i) {
+        html += ' (<a href="' + makeLinkToId(ids[i]) + '">' + (i + 1) + '</a>)';
+      }
+      cell.innerHTML = html;
+    });
+    this.$table.removeChild(this.$tableBody);
+    this.$tableBody = newBody;
+    this.$table.appendChild(this.$tableBody);
+  },
+};
+
+let Toolbox = {
+  init() {
+    this.$outer = document.createElement('div');
+    this.$outer.classList.add('toolbox-container');
+    this.$container = document.createElement('div');
+    this.$container.classList.add('toolbox');
+    this.$outer.appendChild(this.$container);
+    this.$permalink = document.createElement('a');
+    this.$permalink.textContent = 'Permalink';
+    this.$pinLink = document.createElement('a');
+    this.$pinLink.textContent = 'Pin';
+    this.$pinLink.setAttribute('href', '#');
+    this.$pinLink.addEventListener('click', e => {
+      e.preventDefault();
+      e.stopPropagation();
+      menu.togglePinEntry(this.entry.id);
+      this.$pinLink.textContent = menu._pinnedIds[this.entry.id] ? 'Unpin' : 'Pin';
+    });
+
+    this.$refsLink = document.createElement('a');
+    this.$refsLink.setAttribute('href', '#');
+    this.$refsLink.addEventListener('click', e => {
+      e.preventDefault();
+      e.stopPropagation();
+      referencePane.showReferencesFor(this.entry);
+    });
+    this.$container.appendChild(this.$permalink);
+    this.$container.appendChild(this.$pinLink);
+    this.$container.appendChild(this.$refsLink);
+    document.body.appendChild(this.$outer);
+  },
+
+  activate(el, entry, target) {
+    if (el === this._activeEl) return;
+    sdoBox.deactivate();
+    this.active = true;
+    this.entry = entry;
+    this.$pinLink.textContent = menu._pinnedIds[entry.id] ? 'Unpin' : 'Pin';
+    this.$outer.classList.add('active');
+    this.top = el.offsetTop - this.$outer.offsetHeight;
+    this.left = el.offsetLeft - 10;
+    this.$outer.setAttribute('style', 'left: ' + this.left + 'px; top: ' + this.top + 'px');
+    this.updatePermalink();
+    this.updateReferences();
+    this._activeEl = el;
+    if (this.top < document.body.scrollTop && el === target) {
+      // don't scroll unless it's a small thing (< 200px)
+      this.$outer.scrollIntoView();
+    }
+  },
+
+  updatePermalink() {
+    this.$permalink.setAttribute('href', makeLinkToId(this.entry.id));
+  },
+
+  updateReferences() {
+    this.$refsLink.textContent = `References (${(this.entry.referencingIds || []).length})`;
+  },
+
+  activateIfMouseOver(e) {
+    let ref = this.findReferenceUnder(e.target);
+    if (ref && (!this.active || e.pageY > this._activeEl.offsetTop)) {
+      let entry = menu.search.biblio.byId[ref.id];
+      this.activate(ref.element, entry, e.target);
+    } else if (
+      this.active &&
+      (e.pageY < this.top || e.pageY > this._activeEl.offsetTop + this._activeEl.offsetHeight)
+    ) {
+      this.deactivate();
+    }
+  },
+
+  findReferenceUnder(el) {
+    while (el) {
+      let parent = el.parentNode;
+      if (el.nodeName === 'EMU-RHS' || el.nodeName === 'EMU-PRODUCTION') {
+        return null;
+      }
+      if (
+        el.nodeName === 'H1' &&
+        parent.nodeName.match(/EMU-CLAUSE|EMU-ANNEX|EMU-INTRO/) &&
+        parent.id
+      ) {
+        return { element: el, id: parent.id };
+      } else if (el.nodeName === 'EMU-NT') {
+        if (
+          parent.nodeName === 'EMU-PRODUCTION' &&
+          parent.id &&
+          parent.id[0] !== '_' &&
+          parent.firstElementChild === el
+        ) {
+          // return the LHS non-terminal element
+          return { element: el, id: parent.id };
+        }
+        return null;
+      } else if (
+        el.nodeName.match(/EMU-(?!CLAUSE|XREF|ANNEX|INTRO)|DFN/) &&
+        el.id &&
+        el.id[0] !== '_'
+      ) {
+        if (
+          el.nodeName === 'EMU-FIGURE' ||
+          el.nodeName === 'EMU-TABLE' ||
+          el.nodeName === 'EMU-EXAMPLE'
+        ) {
+          // return the figcaption element
+          return { element: el.children[0].children[0], id: el.id };
+        } else {
+          return { element: el, id: el.id };
+        }
+      }
+      el = parent;
+    }
+  },
+
+  deactivate() {
+    this.$outer.classList.remove('active');
+    this._activeEl = null;
+    this.active = false;
+  },
+};
+
+function sortByClauseNumber(clause1, clause2) {
+  let c1c = clause1.number.split('.');
+  let c2c = clause2.number.split('.');
+
+  for (let i = 0; i < c1c.length; i++) {
     if (i >= c2c.length) {
       return 1;
     }
 
-    var c1 = c1c[i];
-    var c2 = c2c[i];
-    var c1cn = Number(c1);
-    var c2cn = Number(c2);
+    let c1 = c1c[i];
+    let c2 = c2c[i];
+    let c1cn = Number(c1);
+    let c2cn = Number(c2);
 
     if (Number.isNaN(c1cn) && Number.isNaN(c2cn)) {
       if (c1 > c2) {
@@ -832,7 +1029,7 @@ function sortByClauseNumber(c1, c2) {
       return -1;
     } else if (Number.isNaN(c1cn) && !Number.isNaN(c2cn)) {
       return 1;
-    } else if(c1cn > c2cn) {
+    } else if (c1cn > c2cn) {
       return 1;
     } else if (c1cn < c2cn) {
       return -1;
@@ -845,59 +1042,314 @@ function sortByClauseNumber(c1, c2) {
   return -1;
 }
 
-document.addEventListener('DOMContentLoaded', function () {
+function makeLinkToId(id) {
+  let hash = '#' + id;
+  if (typeof idToSection === 'undefined' || !idToSection[id]) {
+    return hash;
+  }
+  let targetSec = idToSection[id];
+  return (targetSec === 'index' ? './' : targetSec + '.html') + hash;
+}
+
+function doShortcut(e) {
+  if (!(e.target instanceof HTMLElement)) {
+    return;
+  }
+  let target = e.target;
+  let name = target.nodeName.toLowerCase();
+  if (name === 'textarea' || name === 'input' || name === 'select' || target.isContentEditable) {
+    return;
+  }
+  if (e.altKey || e.ctrlKey || e.metaKey) {
+    return;
+  }
+  if (e.key === 'm' && usesMultipage) {
+    let pathParts = location.pathname.split('/');
+    let hash = location.hash;
+    if (pathParts[pathParts.length - 2] === 'multipage') {
+      if (hash === '') {
+        let sectionName = pathParts[pathParts.length - 1];
+        if (sectionName.endsWith('.html')) {
+          sectionName = sectionName.slice(0, -5);
+        }
+        if (idToSection['sec-' + sectionName] !== undefined) {
+          hash = '#sec-' + sectionName;
+        }
+      }
+      location = pathParts.slice(0, -2).join('/') + '/' + hash;
+    } else {
+      location = 'multipage/' + hash;
+    }
+  } else if (e.key === 'u') {
+    document.documentElement.classList.toggle('show-ao-annotations');
+  } else if (e.key === '?') {
+    document.getElementById('shortcuts-help').classList.toggle('active');
+  }
+}
+
+function init() {
+  menu = new Menu();
+  let $container = document.getElementById('spec-container');
+  $container.addEventListener(
+    'mouseover',
+    debounce(e => {
+      Toolbox.activateIfMouseOver(e);
+    })
+  );
+  document.addEventListener(
+    'keydown',
+    debounce(e => {
+      if (e.code === 'Escape') {
+        if (Toolbox.active) {
+          Toolbox.deactivate();
+        }
+        document.getElementById('shortcuts-help').classList.remove('active');
+      }
+    })
+  );
+}
+
+document.addEventListener('keypress', doShortcut);
+
+document.addEventListener('DOMContentLoaded', () => {
   Toolbox.init();
   referencePane.init();
-})
-var CLAUSE_NODES = ['EMU-CLAUSE', 'EMU-INTRO', 'EMU-ANNEX'];
-function findLocalReferences ($elem) {
-  var name = $elem.innerHTML;
-  var references = [];
+});
 
-  var parentClause = $elem.parentNode;
-  while (parentClause && CLAUSE_NODES.indexOf(parentClause.nodeName) === -1) {
-    parentClause = parentClause.parentNode;
+// preserve state during navigation
+
+function getTocPath(li) {
+  let path = [];
+  let pointer = li;
+  while (true) {
+    let parent = pointer.parentElement;
+    if (parent == null) {
+      return null;
+    }
+    let index = [].indexOf.call(parent.children, pointer);
+    if (index == -1) {
+      return null;
+    }
+    path.unshift(index);
+    pointer = parent.parentElement;
+    if (pointer == null) {
+      return null;
+    }
+    if (pointer.id === 'menu-toc') {
+      break;
+    }
+    if (pointer.tagName !== 'LI') {
+      return null;
+    }
   }
+  return path;
+}
 
-  if(!parentClause) return;
+function activateTocPath(path) {
+  try {
+    let pointer = document.getElementById('menu-toc');
+    for (let index of path) {
+      pointer = pointer.querySelector('ol').children[index];
+    }
+    pointer.classList.add('active');
+  } catch (e) {
+    // pass
+  }
+}
 
-  var vars = parentClause.querySelectorAll('var');
+function getActiveTocPaths() {
+  return [...menu.$menu.querySelectorAll('.active')].map(getTocPath).filter(p => p != null);
+}
 
-  for (var i = 0; i < vars.length; i++) {
-    var $var = vars[i];
-
-    if ($var.innerHTML === name) {
-      references.push($var);
+function loadStateFromSessionStorage() {
+  if (!window.sessionStorage || typeof menu === 'undefined' || window.navigating) {
+    return;
+  }
+  if (sessionStorage.referencePaneState != null) {
+    let state = JSON.parse(sessionStorage.referencePaneState);
+    if (state != null) {
+      if (state.type === 'ref') {
+        let entry = menu.search.biblio.byId[state.id];
+        if (entry != null) {
+          referencePane.showReferencesFor(entry);
+        }
+      } else if (state.type === 'sdo') {
+        let sdos = sdoMap[state.id];
+        if (sdos != null) {
+          referencePane.$headerText.innerHTML = state.html;
+          referencePane.showSDOsBody(sdos, state.id);
+        }
+      }
+      delete sessionStorage.referencePaneState;
     }
   }
 
-  return references;
-}
+  if (sessionStorage.activeTocPaths != null) {
+    document
+      .getElementById('menu-toc')
+      .querySelectorAll('.active')
+      .forEach(e => {
+        e.classList.remove('active');
+      });
+    let active = JSON.parse(sessionStorage.activeTocPaths);
+    active.forEach(activateTocPath);
+    delete sessionStorage.activeTocPaths;
+  }
 
-function toggleFindLocalReferences($elem) {
-  var references = findLocalReferences($elem);
-  if ($elem.classList.contains('referenced')) {
-    references.forEach(function ($reference) {
-      $reference.classList.remove('referenced');
-    });
-  } else {
-    references.forEach(function ($reference) {
-      $reference.classList.add('referenced');
-    });
+  if (sessionStorage.searchValue != null) {
+    let value = JSON.parse(sessionStorage.searchValue);
+    menu.search.$searchBox.value = value;
+    menu.search.search(value);
+    delete sessionStorage.searchValue;
+  }
+
+  if (sessionStorage.tocScroll != null) {
+    let tocScroll = JSON.parse(sessionStorage.tocScroll);
+    menu.$toc.scrollTop = tocScroll;
+    delete sessionStorage.tocScroll;
   }
 }
 
-function installFindLocalReferences () {
-  document.addEventListener('click', function (e) {
-    if (e.target.nodeName === 'VAR') {
-      toggleFindLocalReferences(e.target);
+document.addEventListener('DOMContentLoaded', loadStateFromSessionStorage);
+
+window.addEventListener('pageshow', loadStateFromSessionStorage);
+
+window.addEventListener('beforeunload', () => {
+  if (!window.sessionStorage || typeof menu === 'undefined') {
+    return;
+  }
+  sessionStorage.referencePaneState = JSON.stringify(referencePane.state || null);
+  sessionStorage.activeTocPaths = JSON.stringify(getActiveTocPaths());
+  sessionStorage.searchValue = JSON.stringify(menu.search.$searchBox.value);
+  sessionStorage.tocScroll = JSON.stringify(menu.$toc.scrollTop);
+});
+
+'use strict';
+
+// Manually prefix algorithm step list items with hidden counter representations
+// corresponding with their markers so they get selected and copied with content.
+// We read list-style-type to avoid divergence with the style sheet, but
+// for efficiency assume that all lists at the same nesting depth use the same
+// style (except for those associated with replacement steps).
+// We also precompute some initial items for each supported style type.
+// https://w3c.github.io/csswg-drafts/css-counter-styles/
+
+const lowerLetters = Array.from({ length: 26 }, (_, i) =>
+  String.fromCharCode('a'.charCodeAt(0) + i)
+);
+// Implement the lower-alpha 'alphabetic' algorithm,
+// adjusting for indexing from 0 rather than 1.
+// https://w3c.github.io/csswg-drafts/css-counter-styles/#simple-alphabetic
+// https://w3c.github.io/csswg-drafts/css-counter-styles/#alphabetic-system
+const lowerAlphaTextForIndex = i => {
+  let S = '';
+  for (const N = lowerLetters.length; i >= 0; i--) {
+    S = lowerLetters[i % N] + S;
+    i = Math.floor(i / N);
+  }
+  return S;
+};
+
+const weightedLowerRomanSymbols = Object.entries({
+  m: 1000,
+  cm: 900,
+  d: 500,
+  cd: 400,
+  c: 100,
+  xc: 90,
+  l: 50,
+  xl: 40,
+  x: 10,
+  ix: 9,
+  v: 5,
+  iv: 4,
+  i: 1,
+});
+// Implement the lower-roman 'additive' algorithm,
+// adjusting for indexing from 0 rather than 1.
+// https://w3c.github.io/csswg-drafts/css-counter-styles/#simple-numeric
+// https://w3c.github.io/csswg-drafts/css-counter-styles/#additive-system
+const lowerRomanTextForIndex = i => {
+  let value = i + 1;
+  let S = '';
+  for (const [symbol, weight] of weightedLowerRomanSymbols) {
+    if (!value) break;
+    if (weight > value) continue;
+    const reps = Math.floor(value / weight);
+    S += symbol.repeat(reps);
+    value -= weight * reps;
+  }
+  return S;
+};
+
+// Memoize pure index-to-text functions with an exposed cache for fast retrieval.
+const makeCounter = (pureGetTextForIndex, precomputeCount = 30) => {
+  const cache = Array.from({ length: precomputeCount }, (_, i) => pureGetTextForIndex(i));
+  const getTextForIndex = i => {
+    if (i >= cache.length) cache[i] = pureGetTextForIndex(i);
+    return cache[i];
+  };
+  return { getTextForIndex, cache };
+};
+
+const counterByStyle = {
+  __proto__: null,
+  decimal: makeCounter(i => String(i + 1)),
+  'lower-alpha': makeCounter(lowerAlphaTextForIndex),
+  'upper-alpha': makeCounter(i => lowerAlphaTextForIndex(i).toUpperCase()),
+  'lower-roman': makeCounter(lowerRomanTextForIndex),
+  'upper-roman': makeCounter(i => lowerRomanTextForIndex(i).toUpperCase()),
+};
+const fallbackCounter = makeCounter(() => '?');
+const counterByDepth = [];
+
+function addStepNumberText(
+  ol,
+  depth = 0,
+  special = [...ol.classList].some(c => c.startsWith('nested-'))
+) {
+  let counter = !special && counterByDepth[depth];
+  if (!counter) {
+    const counterStyle = getComputedStyle(ol)['list-style-type'];
+    counter = counterByStyle[counterStyle];
+    if (!counter) {
+      console.warn('unsupported list-style-type', {
+        ol,
+        counterStyle,
+        id: ol.closest('[id]')?.getAttribute('id'),
+      });
+      counterByStyle[counterStyle] = fallbackCounter;
+      counter = fallbackCounter;
     }
+    if (!special) {
+      counterByDepth[depth] = counter;
+    }
+  }
+  const { cache, getTextForIndex } = counter;
+  let i = (Number(ol.getAttribute('start')) || 1) - 1;
+  for (const li of ol.children) {
+    const marker = document.createElement('span');
+    marker.textContent = `${i < cache.length ? cache[i] : getTextForIndex(i)}. `;
+    marker.setAttribute('aria-hidden', 'true');
+    li.prepend(marker);
+    for (const sublist of li.querySelectorAll(':scope > ol')) {
+      addStepNumberText(sublist, depth + 1, special);
+    }
+    i++;
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('emu-alg > ol').forEach(ol => {
+    addStepNumberText(ol);
   });
-}
+});
 
-document.addEventListener('DOMContentLoaded', installFindLocalReferences);
-</script><style>body {
+let sdoMap = JSON.parse(`{}`);
+let biblio = JSON.parse(`{"refsByClause":{"sec-intl.pluralrules.prototype.resolvedoptions":["_ref_0","_ref_1"],"sec-intl.pluralrules":["_ref_2"],"sec-initializepluralrules":["_ref_3","_ref_4","_ref_5"],"sec-intl.pluralrules.prototype":["_ref_6"],"sec-intl.pluralrules.supportedlocalesof":["_ref_7"],"sec-intl.pluralrules.prototype.constructor":["_ref_8"],"sec-intl.pluralrules.prototype.select":["_ref_9"],"sec-intl.pluralrules.prototype.selectrange":["_ref_10"],"sec-properties-of-intl-pluralrules-instances":["_ref_11"],"sec-resolveplural":["_ref_12","_ref_13"],"sec-resolvepluralrange":["_ref_14","_ref_15","_ref_16"]},"entries":[{"type":"term","term":"%PluralRules%","refId":"sec-intl-pluralrules-constructor"},{"type":"clause","id":"sec-intl.pluralrules","title":"Intl.PluralRules ( [ locales [ , options ] ] )","titleHTML":"Intl.PluralRules ( [ <var>locales</var> [ , <var>options</var> ] ] )","number":"1.1.1"},{"type":"op","aoid":"InitializePluralRules","refId":"sec-initializepluralrules"},{"type":"clause","id":"sec-initializepluralrules","title":"InitializePluralRules ( pluralRules, locales, options )","titleHTML":"InitializePluralRules ( <var>pluralRules</var>, <var>locales</var>, <var>options</var> )","number":"1.1.2","referencingIds":["_ref_2"]},{"type":"clause","id":"sec-intl-pluralrules-constructor","titleHTML":"The Intl.PluralRules Constructor","number":"1.1","referencingIds":["_ref_3","_ref_4","_ref_5","_ref_7","_ref_8"]},{"type":"clause","id":"sec-intl.pluralrules.prototype","titleHTML":"Intl.PluralRules.prototype","number":"1.2.1"},{"type":"clause","id":"sec-intl.pluralrules.supportedlocalesof","title":"Intl.PluralRules.supportedLocalesOf ( locales [ , options ] )","titleHTML":"Intl.PluralRules.supportedLocalesOf ( <var>locales</var> [ , <var>options</var> ] )","number":"1.2.2"},{"type":"clause","id":"sec-intl.pluralrules-internal-slots","titleHTML":"Internal slots","number":"1.2.3"},{"type":"clause","id":"sec-properties-of-intl-pluralrules-constructor","titleHTML":"Properties of the Intl.PluralRules Constructor","number":"1.2"},{"type":"term","term":"%PluralRules.prototype%","refId":"sec-properties-of-intl-pluralrules-prototype-object"},{"type":"clause","id":"sec-intl.pluralrules.prototype.constructor","titleHTML":"Intl.PluralRules.prototype.constructor","number":"1.3.1"},{"type":"clause","id":"sec-intl.pluralrules.prototype-tostringtag","titleHTML":"Intl.PluralRules.prototype [ @@toStringTag ]","number":"1.3.2"},{"type":"clause","id":"sec-intl.pluralrules.prototype.select","title":"Intl.PluralRules.prototype.select ( value )","titleHTML":"Intl.PluralRules.prototype.select ( <var>value</var> )","number":"1.3.3"},{"type":"clause","id":"sec-intl.pluralrules.prototype.selectrange","title":"Intl.PluralRules.prototype.selectRange ( start, end )","titleHTML":"Intl.PluralRules.prototype.selectRange ( <var>start</var>, <var>end</var> )","number":"1.3.4"},{"type":"table","id":"table-pluralrules-resolvedoptions-properties","number":1,"caption":"Table 1: Resolved Options of PluralRules Instances","referencingIds":["_ref_0"]},{"type":"clause","id":"sec-intl.pluralrules.prototype.resolvedoptions","titleHTML":"Intl.PluralRules.prototype.resolvedOptions ( )","number":"1.3.5"},{"type":"clause","id":"sec-properties-of-intl-pluralrules-prototype-object","titleHTML":"Properties of the Intl.PluralRules Prototype Object","number":"1.3","referencingIds":["_ref_6","_ref_11"]},{"type":"clause","id":"sec-properties-of-intl-pluralrules-instances","titleHTML":"Properties of Intl.PluralRules Instances","number":"1.4"},{"type":"table","id":"table-plural-operands","number":2,"caption":"Table 2: Plural Rules Operands Record Fields"},{"type":"op","aoid":"GetOperands","refId":"sec-getoperands"},{"type":"clause","id":"sec-getoperands","title":"GetOperands ( s )","titleHTML":"GetOperands ( <var>s</var> )","number":"1.5.1","referencingIds":["_ref_12"]},{"type":"op","aoid":"PluralRuleSelect","refId":"sec-pluralruleselect"},{"type":"clause","id":"sec-pluralruleselect","title":"PluralRuleSelect ( locale, type, n, operands )","titleHTML":"PluralRuleSelect ( <var>locale</var>, <var>type</var>, <var>n</var>, <var>operands</var> )","number":"1.5.2","referencingIds":["_ref_1","_ref_13"]},{"type":"op","aoid":"ResolvePlural","refId":"sec-resolveplural"},{"type":"clause","id":"sec-resolveplural","title":"ResolvePlural ( pluralRules, n )","titleHTML":"ResolvePlural ( <var>pluralRules</var>, <var>n</var> )","number":"1.5.3","referencingIds":["_ref_9","_ref_14","_ref_15"]},{"type":"op","aoid":"PluralRuleSelectRange","refId":"sec-pluralruleselectrange"},{"type":"clause","id":"sec-pluralruleselectrange","title":"PluralRuleSelectRange ( locale, type, xp, yp )","titleHTML":"PluralRuleSelectRange ( <var>locale</var>, <var>type</var>, <var>xp</var>, <var>yp</var> )","number":"1.5.4","referencingIds":["_ref_16"]},{"type":"op","aoid":"ResolvePluralRange","refId":"sec-resolvepluralrange"},{"type":"clause","id":"sec-resolvepluralrange","title":"ResolvePluralRange ( pluralRules, x, y )","titleHTML":"ResolvePluralRange ( <var>pluralRules</var>, <var>x</var>, <var>y</var> )","number":"1.5.5","referencingIds":["_ref_10"]},{"type":"clause","id":"sec-intl-pluralrules-abstracts","titleHTML":"Abstract Operations for PluralRules Objects","number":"1.5"},{"type":"clause","id":"pluralrules-objects","titleHTML":"PluralRules Objects","number":"1"}]}`);
+;let usesMultipage = false</script><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.0.1/styles/base16/solarized-light.min.css"><style>body {
   display: flex;
+  word-wrap: break-word;
   font-size: 18px;
   line-height: 1.5;
   font-family: Cambria, Palatino Linotype, Palatino, Liberation Serif, serif;
@@ -912,6 +1364,7 @@ document.addEventListener('DOMContentLoaded', installFindLocalReferences);
   flex-basis: 66%;
   box-sizing: border-box;
   overflow: hidden;
+  padding-bottom: 1em;
 }
 
 body.oldtoc {
@@ -919,8 +1372,8 @@ body.oldtoc {
 }
 
 a {
-    text-decoration: none;
-    color: #206ca7;
+  text-decoration: none;
+  color: #206ca7;
 }
 
 a:visited {
@@ -928,15 +1381,51 @@ a:visited {
 }
 
 a:hover {
-    text-decoration: underline;
-    color: #239dee;
+  text-decoration: underline;
+  color: #239dee;
 }
 
+a.e-user-code,
+span.e-user-code {
+  white-space: nowrap;
+}
+
+a.e-user-code::before,
+span.e-user-code::before {
+  display: none;
+  color: brown;
+  background-color: white;
+  border: 2pt solid brown;
+  padding: 0.3ex;
+  margin: 0 0.25em 0 0;
+  line-height: 1;
+  vertical-align: text-top;
+  text-transform: uppercase;
+  font-family: 'Comic Code', sans-serif;
+  font-weight: 900;
+  font-size: x-small;
+}
+
+a.e-user-code:hover::before,
+span.e-user-code:hover::before {
+  background-color: brown;
+  color: white;
+}
+
+html.show-ao-annotations a.e-user-code::before,
+html.show-ao-annotations span.e-user-code::before {
+  display: inline-block;
+}
+
+a.e-user-code::before,
+span.e-user-code::before {
+  content: 'UC';
+}
 
 code {
-    font-weight: bold;
-    font-family: Consolas, Monaco, monospace;
-    white-space: pre;
+  font-weight: bold;
+  font-family: Consolas, Monaco, monospace;
+  white-space: pre;
 }
 
 pre code {
@@ -950,13 +1439,13 @@ pre code.hljs {
 }
 
 ol.toc {
-    list-style: none;
-    padding-left: 0;
+  list-style: none;
+  padding-left: 0;
 }
 
 ol.toc ol.toc {
-    padding-left: 2ex;
-    list-style: none;
+  padding-left: 2ex;
+  list-style: none;
 }
 
 var {
@@ -965,8 +1454,40 @@ var {
   cursor: pointer;
 }
 
-var.referenced {
+var.referenced0 {
+  color: inherit;
   background-color: #ffff33;
+  box-shadow: 0 0 0 2px #ffff33;
+}
+var.referenced1 {
+  color: inherit;
+  background-color: #ff87a2;
+  box-shadow: 0 0 0 2px #ff87a2;
+}
+var.referenced2 {
+  color: inherit;
+  background-color: #96e885;
+  box-shadow: 0 0 0 2px #96e885;
+}
+var.referenced3 {
+  color: inherit;
+  background-color: #3eeed2;
+  box-shadow: 0 0 0 2px #3eeed2;
+}
+var.referenced4 {
+  color: inherit;
+  background-color: #eacfb6;
+  box-shadow: 0 0 0 2px #eacfb6;
+}
+var.referenced5 {
+  color: inherit;
+  background-color: #82ddff;
+  box-shadow: 0 0 0 2px #82ddff;
+}
+var.referenced6 {
+  color: inherit;
+  background-color: #ffbcf2;
+  box-shadow: 0 0 0 2px #ffbcf2;
 }
 
 emu-const {
@@ -1015,6 +1536,10 @@ emu-alg ol.nested-lots ol {
   list-style-type: lower-roman;
 }
 
+emu-alg [aria-hidden=true] {
+  font-size: 0;
+}
+
 emu-eqn {
   display: block;
   margin-left: 4em;
@@ -1030,29 +1555,32 @@ emu-eqn div:first-child {
 }
 
 emu-note {
-    margin: 1em 0;
-    color: #666;
-    border-left: 5px solid #ccc;
-    display: flex;
-    flex-direction: row;
+  margin: 1em 0;
+  display: flex;
+  flex-direction: row;
+  color: inherit;
+  border-left: 5px solid #52e052;
+  background: #e9fbe9;
+  padding: 10px 10px 10px 0;
 }
 
 emu-note > span.note {
-    flex-basis: 100px;
-    min-width: 100px;
-    flex-grow: 0;
-    flex-shrink: 1;
-    text-transform: uppercase;
-    padding-left: 5px;
+  flex-basis: 100px;
+  min-width: 100px;
+  flex-grow: 0;
+  flex-shrink: 1;
+  text-transform: uppercase;
+  padding-left: 5px;
 }
 
-emu-note[type=editor] {
+emu-note[type='editor'] {
   border-left-color: #faa;
 }
 
 emu-note > div.note-contents {
   flex-grow: 1;
   flex-shrink: 1;
+  overflow: auto;
 }
 
 emu-note > div.note-contents > p:first-of-type {
@@ -1063,9 +1591,9 @@ emu-note > div.note-contents > p:last-of-type {
   margin-bottom: 0;
 }
 
-emu-table td code {
+emu-table:not(.code) td code {
   white-space: normal;
-} 
+}
 
 emu-figure {
   display: block;
@@ -1090,99 +1618,120 @@ emu-table figure {
 }
 
 emu-production {
-    display: block;
+  display: block;
 }
 
-emu-grammar[type="example"] emu-production,
-emu-grammar[type="definition"] emu-production {
-    margin-top: 1em;
-    margin-bottom: 1em;
-    margin-left: 5ex;
+emu-grammar[type='example'] emu-production,
+emu-grammar[type='definition'] emu-production {
+  margin-top: 1em;
+  margin-bottom: 1em;
+  margin-left: 5ex;
 }
 
-emu-grammar.inline, emu-production.inline,
-emu-grammar.inline emu-production emu-rhs, emu-production.inline emu-rhs,
-emu-grammar[collapsed] emu-production emu-rhs, emu-production[collapsed] emu-rhs {
-    display: inline;
-    padding-left: 1ex;
-    margin-left: 0;
+emu-grammar.inline,
+emu-production.inline,
+emu-grammar.inline emu-production emu-rhs,
+emu-production.inline emu-rhs,
+emu-grammar[collapsed] emu-production emu-rhs {
+  display: inline;
+  padding-left: 1ex;
+  margin-left: 0;
 }
 
-emu-grammar[collapsed] emu-production, emu-production[collapsed] {
-    margin: 0;
+emu-production[collapsed] emu-rhs {
+  display: inline;
+  padding-left: 0.5ex;
+  margin-left: 0;
+}
+
+emu-grammar[collapsed] emu-production,
+emu-production[collapsed] {
+  margin: 0;
 }
 
 emu-constraints {
-    font-size: .75em;
-    margin-right: 1ex;
+  font-size: 0.75em;
+  margin-right: 0.5ex;
 }
 
 emu-gann {
-    margin-right: 1ex;
+  margin-right: 0.5ex;
 }
 
 emu-gann emu-t:last-child,
 emu-gann emu-gprose:last-child,
 emu-gann emu-nt:last-child {
-    margin-right: 0;
+  margin-right: 0;
 }
 
 emu-geq {
-    margin-left: 1ex;
-    font-weight: bold;
+  margin-left: 0.5ex;
+  font-weight: bold;
 }
 
 emu-oneof {
-    font-weight: bold;
-    margin-left: 1ex;
+  font-weight: bold;
+  margin-left: 0.5ex;
 }
 
 emu-nt {
-    display: inline-block;
-    font-style: italic;
-    white-space: nowrap;
-    text-indent: 0;
+  display: inline-block;
+  font-style: italic;
+  white-space: nowrap;
+  text-indent: 0;
 }
 
-emu-nt a, emu-nt a:visited {
+emu-nt a,
+emu-nt a:visited {
   color: #333;
 }
 
 emu-rhs emu-nt {
-    margin-right: 1ex;
+  margin-right: 0.5ex;
 }
 
 emu-t {
-    display: inline-block;
-    font-family: monospace;
-    font-weight: bold;
-    white-space: nowrap;
-    text-indent: 0;
+  display: inline-block;
+  font-family: monospace;
+  font-weight: bold;
+  white-space: nowrap;
+  text-indent: 0;
 }
 
 emu-production emu-t {
-    margin-right: 1ex;
+  margin-right: 0.5ex;
 }
 
 emu-rhs {
-    display: block;
-    padding-left: 75px;
-    text-indent: -25px;
+  display: block;
+  padding-left: 75px;
+  text-indent: -25px;
+}
+
+emu-production:not([collapsed]) emu-rhs {
+  border: 0.2ex dashed transparent;
+}
+
+emu-production:not([collapsed]) emu-rhs:hover {
+  border-color: #888;
+  background-color: #f0f0f0;
 }
 
 emu-mods {
-    font-size: .85em;
-    vertical-align: sub;
-    font-style: normal;
-    font-weight: normal;
+  font-size: 0.85em;
+  vertical-align: sub;
+  font-style: normal;
+  font-weight: normal;
 }
 
-emu-params, emu-opt {
+emu-params,
+emu-opt {
   margin-right: 1ex;
   font-family: monospace;
 }
 
-emu-params, emu-constraints {
+emu-params,
+emu-constraints {
   color: #2aa198;
 }
 
@@ -1191,12 +1740,12 @@ emu-opt {
 }
 
 emu-gprose {
-    font-size: 0.9em;
-    font-family: Helvetica, Arial, sans-serif;
+  font-size: 0.9em;
+  font-family: Helvetica, Arial, sans-serif;
 }
 
 emu-production emu-gprose {
-    margin-right: 1ex;
+  margin-right: 1ex;
 }
 
 h1.shortname {
@@ -1208,20 +1757,19 @@ h1.shortname {
 h1.version {
   color: #f60;
   font-size: 1.5em;
-  margin: 0;
 }
 
 h1.title {
-  margin-top: 0;
   color: #f60;
 }
 
-h1.first {
-  margin-top: 0;
-}
-
-h1, h2, h3, h4, h5, h6 {
-    position: relative;
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  position: relative;
 }
 
 h1 .secnum {
@@ -1233,142 +1781,267 @@ h1 span.title {
   order: 2;
 }
 
+h1 {
+  font-size: 2.67em;
+  margin-bottom: 0;
+  line-height: 1em;
+}
+h2 {
+  font-size: 2em;
+}
+h3 {
+  font-size: 1.56em;
+}
+h4 {
+  font-size: 1.25em;
+}
+h5 {
+  font-size: 1.11em;
+}
+h6 {
+  font-size: 1em;
+}
 
-h1 { font-size: 2.67em; margin-top: 2em; margin-bottom: 0; line-height: 1em;}
-h2 { font-size: 2em; }
-h3 { font-size: 1.56em; }
-h4 { font-size: 1.25em; }
-h5 { font-size: 1.11em; }
-h6 { font-size: 1em; }
+pre code.hljs {
+  background: transparent;
+}
 
-h1:hover span.utils {
+emu-clause[id],
+emu-annex[id],
+emu-intro[id] {
+  scroll-margin-top: 2ex;
+}
+
+emu-intro h1,
+emu-clause h1,
+emu-annex h1 {
+  font-size: 2em;
+}
+emu-intro h2,
+emu-clause h2,
+emu-annex h2 {
+  font-size: 1.56em;
+}
+emu-intro h3,
+emu-clause h3,
+emu-annex h3 {
+  font-size: 1.25em;
+}
+emu-intro h4,
+emu-clause h4,
+emu-annex h4 {
+  font-size: 1.11em;
+}
+emu-intro h5,
+emu-clause h5,
+emu-annex h5 {
+  font-size: 1em;
+}
+emu-intro h6,
+emu-clause h6,
+emu-annex h6 {
+  font-size: 0.9em;
+}
+emu-intro emu-intro h1,
+emu-clause emu-clause h1,
+emu-annex emu-annex h1 {
+  font-size: 1.56em;
+}
+emu-intro emu-intro h2,
+emu-clause emu-clause h2,
+emu-annex emu-annex h2 {
+  font-size: 1.25em;
+}
+emu-intro emu-intro h3,
+emu-clause emu-clause h3,
+emu-annex emu-annex h3 {
+  font-size: 1.11em;
+}
+emu-intro emu-intro h4,
+emu-clause emu-clause h4,
+emu-annex emu-annex h4 {
+  font-size: 1em;
+}
+emu-intro emu-intro h5,
+emu-clause emu-clause h5,
+emu-annex emu-annex h5 {
+  font-size: 0.9em;
+}
+emu-intro emu-intro emu-intro h1,
+emu-clause emu-clause emu-clause h1,
+emu-annex emu-annex emu-annex h1 {
+  font-size: 1.25em;
+}
+emu-intro emu-intro emu-intro h2,
+emu-clause emu-clause emu-clause h2,
+emu-annex emu-annex emu-annex h2 {
+  font-size: 1.11em;
+}
+emu-intro emu-intro emu-intro h3,
+emu-clause emu-clause emu-clause h3,
+emu-annex emu-annex emu-annex h3 {
+  font-size: 1em;
+}
+emu-intro emu-intro emu-intro h4,
+emu-clause emu-clause emu-clause h4,
+emu-annex emu-annex emu-annex h4 {
+  font-size: 0.9em;
+}
+emu-intro emu-intro emu-intro emu-intro h1,
+emu-clause emu-clause emu-clause emu-clause h1,
+emu-annex emu-annex emu-annex emu-annex h1 {
+  font-size: 1.11em;
+}
+emu-intro emu-intro emu-intro emu-intro h2,
+emu-clause emu-clause emu-clause emu-clause h2,
+emu-annex emu-annex emu-annex emu-annex h2 {
+  font-size: 1em;
+}
+emu-intro emu-intro emu-intro emu-intro h3,
+emu-clause emu-clause emu-clause emu-clause h3,
+emu-annex emu-annex emu-annex emu-annex h3 {
+  font-size: 0.9em;
+}
+emu-intro emu-intro emu-intro emu-intro emu-intro h1,
+emu-clause emu-clause emu-clause emu-clause emu-clause h1,
+emu-annex emu-annex emu-annex emu-annex emu-annex h1 {
+  font-size: 1em;
+}
+emu-intro emu-intro emu-intro emu-intro emu-intro h2,
+emu-clause emu-clause emu-clause emu-clause emu-clause h2,
+emu-annex emu-annex emu-annex emu-annex emu-annex h2 {
+  font-size: 0.9em;
+}
+emu-intro emu-intro emu-intro emu-intro emu-intro emu-intro h1,
+emu-clause emu-clause emu-clause emu-clause emu-clause emu-clause h1,
+emu-annex emu-annex emu-annex emu-annex emu-annex emu-annex h1 {
+  font-size: 0.9em;
+}
+
+emu-clause,
+emu-intro,
+emu-annex {
   display: block;
 }
 
-span.utils {
-  font-size: 18px;
-  line-height: 18px;
-  display: none;
-  position: absolute;
-  top: 100%;
-  left: 0;
-  right: 0;
-  font-weight: normal;
+/* these values are twice the font-size for the <h1> titles for clauses */
+emu-intro,
+emu-clause,
+emu-annex {
+  margin-top: 4em;
+}
+emu-intro emu-intro,
+emu-clause emu-clause,
+emu-annex emu-annex {
+  margin-top: 3.12em;
+}
+emu-intro emu-intro emu-intro,
+emu-clause emu-clause emu-clause,
+emu-annex emu-annex emu-annex {
+  margin-top: 2.5em;
+}
+emu-intro emu-intro emu-intro emu-intro,
+emu-clause emu-clause emu-clause emu-clause,
+emu-annex emu-annex emu-annex emu-annex {
+  margin-top: 2.22em;
+}
+emu-intro emu-intro emu-intro emu-intro emu-intro,
+emu-clause emu-clause emu-clause emu-clause emu-clause,
+emu-annex emu-annex emu-annex emu-annex emu-annex {
+  margin-top: 2em;
+}
+emu-intro emu-intro emu-intro emu-intro emu-intro emu-intro,
+emu-clause emu-clause emu-clause emu-clause emu-clause emu-clause,
+emu-annex emu-annex emu-annex emu-annex emu-annex emu-annex {
+  margin-top: 1.8em;
 }
 
-span.utils:before {
-    content: "⤷";
-    display: inline-block;
-    padding: 0 5px;
-}
-
-span.utils > * {
-  display: inline-block;
-  margin-right: 20px;
-}
-
-h1 span.utils span.anchor a,
-h2 span.utils span.anchor a,
-h3 span.utils span.anchor a,
-h4 span.utils span.anchor a,
-h5 span.utils span.anchor a,
-h6 span.utils span.anchor a {
-  text-decoration: none;
-  font-variant: small-caps;
-}
-
-h1 span.utils span.anchor a:hover,
-h2 span.utils span.anchor a:hover,
-h3 span.utils span.anchor a:hover,
-h4 span.utils span.anchor a:hover,
-h5 span.utils span.anchor a:hover,
-h6 span.utils span.anchor a:hover {
-  color: #333;
-}
-
-emu-intro h1, emu-clause h1, emu-annex h1 { font-size: 2em; }
-emu-intro h2, emu-clause h2, emu-annex h2 { font-size: 1.56em; }
-emu-intro h3, emu-clause h3, emu-annex h3 { font-size: 1.25em; }
-emu-intro h4, emu-clause h4, emu-annex h4 { font-size: 1.11em; }
-emu-intro h5, emu-clause h5, emu-annex h5 { font-size: 1em; }
-emu-intro h6, emu-clause h6, emu-annex h6 { font-size: 0.9em; }
-emu-intro emu-intro h1, emu-clause emu-clause h1, emu-annex emu-annex h1 { font-size: 1.56em; }
-emu-intro emu-intro h2, emu-clause emu-clause h2, emu-annex emu-annex h2 { font-size: 1.25em; }
-emu-intro emu-intro h3, emu-clause emu-clause h3, emu-annex emu-annex h3 { font-size: 1.11em; }
-emu-intro emu-intro h4, emu-clause emu-clause h4, emu-annex emu-annex h4 { font-size: 1em; }
-emu-intro emu-intro h5, emu-clause emu-clause h5, emu-annex emu-annex h5 { font-size: 0.9em; }
-emu-intro emu-intro emu-intro h1, emu-clause emu-clause emu-clause h1, emu-annex emu-annex emu-annex h1 { font-size: 1.25em; }
-emu-intro emu-intro emu-intro h2, emu-clause emu-clause emu-clause h2, emu-annex emu-annex emu-annex h2 { font-size: 1.11em; }
-emu-intro emu-intro emu-intro h3, emu-clause emu-clause emu-clause h3, emu-annex emu-annex emu-annex h3 { font-size: 1em; }
-emu-intro emu-intro emu-intro h4, emu-clause emu-clause emu-clause h4, emu-annex emu-annex emu-annex h4 { font-size: 0.9em; }
-emu-intro emu-intro emu-intro emu-intro h1, emu-clause emu-clause emu-clause emu-clause h1, emu-annex emu-annex emu-annex emu-annex h1 { font-size: 1.11em; }
-emu-intro emu-intro emu-intro emu-intro h2, emu-clause emu-clause emu-clause emu-clause h2, emu-annex emu-annex emu-annex emu-annex h2 { font-size: 1em; }
-emu-intro emu-intro emu-intro emu-intro h3, emu-clause emu-clause emu-clause emu-clause h3, emu-annex emu-annex emu-annex emu-annex h3 { font-size: 0.9em; }
-emu-intro emu-intro emu-intro emu-intro emu-intro h1, emu-clause emu-clause emu-clause emu-clause emu-clause h1, emu-annex emu-annex emu-annex emu-annex emu-annex h1 { font-size: 1em; }
-emu-intro emu-intro emu-intro emu-intro emu-intro h2, emu-clause emu-clause emu-clause emu-clause emu-clause h2, emu-annex emu-annex emu-annex emu-annex emu-annex h2 { font-size: 0.9em; }
-emu-intro emu-intro emu-intro emu-intro emu-intro emu-intro h1, emu-clause emu-clause emu-clause emu-clause emu-clause emu-clause h1, emu-annex emu-annex emu-annex emu-annex emu-annex emu-annex h1 { font-size: 0.9em }
-
-emu-clause, emu-intro, emu-annex {
-    display: block;
+#spec-container > emu-intro:first-of-type,
+#spec-container > emu-clause:first-of-type,
+#spec-container > emu-annex:first-of-type {
+  margin-top: 0;
 }
 
 /* Figures and tables */
-figure { display: block; margin: 1em 0 3em 0; }
-figure object { display: block; margin: 0 auto; }
-figure table.real-table { margin: 0 auto; }
+figure {
+  display: block;
+  margin: 1em 0 3em 0;
+}
+figure object {
+  display: block;
+  margin: 0 auto;
+}
+figure table.real-table {
+  margin: 0 auto;
+}
 figure figcaption {
-    display: block;
-    color: #555555;
-    font-weight: bold;
-    text-align: center;
+  display: block;
+  color: #555555;
+  font-weight: bold;
+  text-align: center;
 }
 
 emu-table table {
   margin: 0 auto;
 }
 
-emu-table table, table.real-table {
-    border-collapse: collapse;
+emu-table table,
+table.real-table {
+  border-collapse: collapse;
 }
 
-emu-table td, emu-table th, table.real-table td, table.real-table th {
-    border: 1px solid black;
-    padding: 0.4em;
-    vertical-align: baseline;
+emu-table td,
+emu-table th,
+table.real-table td,
+table.real-table th {
+  border: 1px solid black;
+  padding: 0.4em;
+  vertical-align: baseline;
 }
-emu-table th, emu-table thead td, table.real-table th {
-    background-color: #eeeeee;
+emu-table th,
+emu-table thead td,
+table.real-table th {
+  background-color: #eeeeee;
+}
+
+emu-table td {
+  background: #fff;
 }
 
 /* Note: the left content edges of table.lightweight-table >tbody >tr >td
    and div.display line up. */
 table.lightweight-table {
-    border-collapse: collapse;
-    margin: 0 0 0 1.5em;
+  border-collapse: collapse;
+  margin: 0 0 0 1.5em;
 }
-table.lightweight-table td, table.lightweight-table th {
-    border: none;
-    padding: 0 0.5em;
-    vertical-align: baseline;
+table.lightweight-table td,
+table.lightweight-table th {
+  border: none;
+  padding: 0 0.5em;
+  vertical-align: baseline;
 }
 
 /* diff styles */
 ins {
-    background-color: #e0f8e0;
-    text-decoration: none;
-    border-bottom: 1px solid #396;
+  background-color: #e0f8e0;
+  text-decoration: none;
+  border-bottom: 1px solid #396;
 }
 
 del {
-    background-color: #fee;
+  background-color: #fee;
 }
 
-ins.block, del.block,
-emu-production > ins, emu-production > del,
-emu-grammar > ins, emu-grammar > del {
+ins.block,
+del.block,
+emu-production > ins,
+emu-production > del,
+emu-grammar > ins,
+emu-grammar > del {
   display: block;
 }
-emu-rhs > ins, emu-rhs > del { 
+emu-rhs > ins,
+emu-rhs > del {
   display: inline;
 }
 
@@ -1405,7 +2078,7 @@ tr.del > td {
   -khtml-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
-  user-select: none;;
+  user-select: none;
 
   cursor: pointer;
 }
@@ -1413,7 +2086,8 @@ tr.del > td {
 #menu {
   display: flex;
   flex-direction: column;
-  width: 33%; height: 100vh;
+  width: 33%;
+  height: 100vh;
   max-width: 500px;
   box-sizing: border-box;
   background-color: #ddd;
@@ -1421,13 +2095,14 @@ tr.del > td {
   transition: opacity 0.1s linear;
   padding: 0 5px;
   position: fixed;
-  left: 0; top: 0;
+  left: 0;
+  top: 0;
   border-right: 2px solid #bbb;
 
   z-index: 2;
 }
 
-#menu-spacer {
+.menu-spacer {
   flex-basis: 33%;
   max-width: 500px;
   flex-grow: 0;
@@ -1482,7 +2157,8 @@ tr.del > td {
   padding: 0;
 }
 
-#menu-toc > ol , #menu-toc > ol ol {
+#menu-toc > ol,
+#menu-toc > ol ol {
   list-style-type: none;
   margin: 0;
   padding: 0;
@@ -1512,7 +2188,7 @@ tr.del > td {
   -khtml-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
-  user-select: none;;
+  user-select: none;
 
   cursor: pointer;
 }
@@ -1543,7 +2219,7 @@ tr.del > td {
   */
 }
 
-#menu-toc li.revealed-leaf> a {
+#menu-toc li.revealed-leaf > a {
   color: #206ca7;
   /*
   background-color: #222;
@@ -1579,6 +2255,34 @@ tr.del > td {
   font-size: 0.8em;
 }
 
+.menu-pane-header emu-opt,
+.menu-pane-header emu-t,
+.menu-pane-header emu-nt {
+  margin-right: 0px;
+  display: inline;
+  color: inherit;
+}
+
+.menu-pane-header emu-rhs {
+  display: inline;
+  padding-left: 0px;
+  text-indent: 0px;
+}
+
+.menu-pane-header emu-geq {
+  margin-left: 0px;
+}
+
+a.menu-pane-header-production {
+  color: inherit;
+}
+
+.menu-pane-header-production {
+  text-transform: none;
+  letter-spacing: 1.5px;
+  padding-left: 0.5em;
+}
+
 #menu-toc {
   display: flex;
   flex-direction: column;
@@ -1597,10 +2301,10 @@ tr.del > td {
   flex-grow: 0;
   flex-shrink: 0;
   width: 100%;
-  
+
   display: flex;
   flex-direction: column;
-  
+
   max-height: 300px;
 }
 
@@ -1625,43 +2329,42 @@ tr.del > td {
 }
 
 li.menu-search-result-clause:before {
-    content: 'clause';
-    width: 40px;
-    display: inline-block;
-    text-align: right;
-    padding-right: 1ex;
-    color: #666;
-    font-size: 75%;
+  content: 'clause';
+  width: 40px;
+  display: inline-block;
+  text-align: right;
+  padding-right: 1ex;
+  color: #666;
+  font-size: 75%;
 }
 li.menu-search-result-op:before {
-    content: 'op';
-    width: 40px;
-    display: inline-block;
-    text-align: right;
-    padding-right: 1ex;
-    color: #666;
-    font-size: 75%;
+  content: 'op';
+  width: 40px;
+  display: inline-block;
+  text-align: right;
+  padding-right: 1ex;
+  color: #666;
+  font-size: 75%;
 }
 
 li.menu-search-result-prod:before {
-    content: 'prod';
-    width: 40px;
-    display: inline-block;
-    text-align: right;
-    padding-right: 1ex;
-    color: #666;
-    font-size: 75%
+  content: 'prod';
+  width: 40px;
+  display: inline-block;
+  text-align: right;
+  padding-right: 1ex;
+  color: #666;
+  font-size: 75%;
 }
 
-
 li.menu-search-result-term:before {
-    content: 'term';
-    width: 40px;
-    display: inline-block;
-    text-align: right;
-    padding-right: 1ex;
-    color: #666;
-    font-size: 75%
+  content: 'term';
+  width: 40px;
+  display: inline-block;
+  text-align: right;
+  padding-right: 1ex;
+  color: #666;
+  font-size: 75%;
 }
 
 #menu-search-results ul {
@@ -1674,7 +2377,6 @@ li.menu-search-result-term:before {
   text-overflow: ellipsis;
 }
 
-
 #menu-trace-list {
   counter-reset: item;
   margin: 0 0 0 20px;
@@ -1686,19 +2388,19 @@ li.menu-search-result-term:before {
 }
 
 #menu-trace-list li .secnum:after {
-  content: " ";
+  content: ' ';
 }
 #menu-trace-list li:before {
-    content: counter(item) " ";
-    background-color: #222;
-    counter-increment: item;
-    color: #999;
-    width: 20px;
-    height: 20px;
-    line-height: 20px;
-    display: inline-block;
-    text-align: center;
-    margin: 2px 4px 2px 0;
+  content: counter(item) ' ';
+  background-color: #222;
+  counter-increment: item;
+  color: #999;
+  width: 20px;
+  height: 20px;
+  line-height: 20px;
+  display: inline-block;
+  text-align: center;
+  margin: 2px 4px 2px 0;
 }
 
 @media (max-width: 1000px) {
@@ -1740,24 +2442,29 @@ li.menu-search-result-term:before {
   }
 
   h1 .secnum:empty {
-    margin: 0; padding: 0;
+    margin: 0;
+    padding: 0;
   }
 }
 
-
 /* Toolbox */
-.toolbox {
-	position: absolute;
-	background: #ddd;
-	border: 1px solid #aaa;
+.toolbox-container {
+  position: absolute;
   display: none;
+  padding-bottom: 7px;
+}
+
+.toolbox-container.active {
+  display: inline-block;
+}
+
+.toolbox {
+  position: relative;
+  background: #ddd;
+  border: 1px solid #aaa;
   color: #eee;
   padding: 5px;
   border-radius: 3px;
-}
-
-.toolbox.active {
-  display: inline-block;
 }
 
 .toolbox a {
@@ -1769,28 +2476,29 @@ li.menu-search-result-term:before {
   text-decoration: underline;
 }
 
-.toolbox:after, .toolbox:before {
-	top: 100%;
-	left: 15px;
-	border: solid transparent;
-	content: " ";
-	height: 0;
-	width: 0;
-	position: absolute;
-	pointer-events: none;
+.toolbox:after,
+.toolbox:before {
+  top: 100%;
+  left: 15px;
+  border: solid transparent;
+  content: ' ';
+  height: 0;
+  width: 0;
+  position: absolute;
+  pointer-events: none;
 }
 
 .toolbox:after {
-	border-color: rgba(0, 0, 0, 0);
-	border-top-color: #ddd;
-	border-width: 10px;
-	margin-left: -10px;
+  border-color: rgba(0, 0, 0, 0);
+  border-top-color: #ddd;
+  border-width: 10px;
+  margin-left: -10px;
 }
 .toolbox:before {
-	border-color: rgba(204, 204, 204, 0);
-	border-top-color: #aaa;
-	border-width: 12px;
-	margin-left: -12px;
+  border-color: rgba(204, 204, 204, 0);
+  border-top-color: #aaa;
+  border-width: 12px;
+  margin-left: -12px;
 }
 
 #references-pane-container {
@@ -1807,11 +2515,6 @@ li.menu-search-result-term:before {
 #references-pane-table-container {
   overflow-x: hidden;
   overflow-y: auto;
-}
-
-#references-pane-spacer {
-  flex-basis: 33%;
-  max-width: 500px;
 }
 
 #references-pane {
@@ -1831,6 +2534,10 @@ li.menu-search-result-term:before {
   cursor: pointer;
 }
 
+#references-pane table tbody {
+  vertical-align: baseline;
+}
+
 #references-pane table tr td:first-child {
   text-align: right;
   padding-right: 5px;
@@ -1838,39 +2545,84 @@ li.menu-search-result-term:before {
 
 @media print {
   #menu-toggle {
-    display: none; 
+    display: none;
   }
 }
-</style></head><body><div id="menu-toggle">☰</div><div id="menu-spacer"></div><div id="menu"><div id="menu-search"><input type="text" id="menu-search-box" placeholder="Search..."><div id="menu-search-results" class="inactive"></div></div><div id="menu-pins"><div class="menu-pane-header">Pins</div><ul id="menu-pins-list"></ul></div><div class="menu-pane-header">Table of Contents</div><div id="menu-toc"><ol class="toc"><li><span class="item-toggle">◢</span><a href="#pluralrules-objects" title="PluralRules Objects"><span class="secnum">1</span> PluralRules Objects</a><ol class="toc"><li><span class="item-toggle">◢</span><a href="#sec-intl-pluralrules-constructor" title="The Intl.PluralRules Constructor"><span class="secnum">1.1</span> The Intl.PluralRules Constructor</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-intl.pluralrules" title="Intl.PluralRules ( [ locales [ , options ] ] )"><span class="secnum">1.1.1</span> Intl.PluralRules ( [ <var>locales</var> [ , <var>options</var> ] ] )</a></li><li><span class="item-toggle-none"></span><a href="#sec-initializepluralrules" title="InitializePluralRules ( pluralRules, locales, options )"><span class="secnum">1.1.2</span> InitializePluralRules ( <var>pluralRules</var>, <var>locales</var>, <var>options</var> )</a></li></ol></li><li><span class="item-toggle">◢</span><a href="#sec-properties-of-intl-pluralrules-constructor" title="Properties of the Intl.PluralRules Constructor"><span class="secnum">1.2</span> Properties of the Intl.PluralRules Constructor</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-intl.pluralrules.prototype" title="Intl.PluralRules.prototype"><span class="secnum">1.2.1</span> Intl.PluralRules.prototype</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.pluralrules.supportedlocalesof" title="Intl.PluralRules.supportedLocalesOf ( locales [ , options ] )"><span class="secnum">1.2.2</span> Intl.PluralRules.supportedLocalesOf ( <var>locales</var> [ , <var>options</var> ] )</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.pluralrules-internal-slots" title="Internal slots"><span class="secnum">1.2.3</span> Internal slots</a></li></ol></li><li><span class="item-toggle">◢</span><a href="#sec-properties-of-intl-pluralrules-prototype-object" title="Properties of the Intl.PluralRules Prototype Object"><span class="secnum">1.3</span> Properties of the Intl.PluralRules Prototype Object</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-intl.pluralrules.prototype.constructor" title="Intl.PluralRules.prototype.constructor"><span class="secnum">1.3.1</span> Intl.PluralRules.prototype.constructor</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.pluralrules.prototype-tostringtag" title="Intl.PluralRules.prototype [ @@toStringTag ]"><span class="secnum">1.3.2</span> Intl.PluralRules.prototype [ @@toStringTag ]</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.pluralrules.prototype.select" title="Intl.PluralRules.prototype.select ( value )"><span class="secnum">1.3.3</span> Intl.PluralRules.prototype.select ( <var>value</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.pluralrules.prototype.selectrange" title="Intl.PluralRules.prototype.selectRange ( start, end )"><span class="secnum">1.3.4</span> Intl.PluralRules.prototype.selectRange ( <var>start</var>, <var>end</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.pluralrules.prototype.resolvedoptions" title="Intl.PluralRules.prototype.resolvedOptions ( )"><span class="secnum">1.3.5</span> Intl.PluralRules.prototype.resolvedOptions ( )</a></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-properties-of-intl-pluralrules-instances" title="Properties of Intl.PluralRules Instances"><span class="secnum">1.4</span> Properties of Intl.PluralRules Instances</a></li><li><span class="item-toggle">◢</span><a href="#sec-intl-pluralrules-abstracts" title="Abstract Operations for PluralRules Objects"><span class="secnum">1.5</span> Abstract Operations for PluralRules Objects</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-getoperands" title="
-         GetOperands (
-           s: a decimal String,
-         )
-       "><span class="secnum">1.5.1</span> 
-         GetOperands (
-           <var>s</var>: a decimal String,
-         )
-       </a></li><li><span class="item-toggle-none"></span><a href="#sec-pluralruleselect" title="
-        PluralRuleSelect (
-          locale: a String,
-          type: a String,
-          n: a finite Number,
-          operands: a Plural Rules Operands Record derived from formatting n,
-        )
-      "><span class="secnum">1.5.2</span> 
-        PluralRuleSelect (
-          <var>locale</var>: a String,
-          <var>type</var>: a String,
-          <var>n</var>: a finite Number,
-          <var>operands</var>: a Plural Rules Operands Record derived from formatting <var>n</var>,
-        )
-      </a></li><li><span class="item-toggle-none"></span><a href="#sec-resolveplural" title="ResolvePlural ( pluralRules, n )"><span class="secnum">1.5.3</span> ResolvePlural ( <var>pluralRules</var>, <var>n</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-pluralruleselectrange" title="PluralRuleSelectRange ( locale, type, xp, yp )"><span class="secnum">1.5.4</span> PluralRuleSelectRange ( <var>locale</var>, <var>type</var>, <var>xp</var>, <var>yp</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-resolvepluralrange" title="ResolvePluralRange ( pluralRules, x, y )"><span class="secnum">1.5.5</span> ResolvePluralRange ( <var>pluralRules</var>, <var>x</var>, <var>y</var> )</a></li></ol></li></ol></li></ol></div></div><div id="spec-container"><emu-clause id="pluralrules-objects">
-  <h1 class="first"><span class="secnum">1</span> PluralRules Objects</h1>
+
+[normative-optional],
+[legacy] {
+  border-left: 5px solid #ff6600;
+  padding: 0.5em;
+  display: block;
+  background: #ffeedd;
+}
+
+.clause-attributes-tag {
+  text-transform: uppercase;
+  color: #884400;
+}
+
+.clause-attributes-tag a {
+  color: #884400;
+}
+
+/* Shortcuts help dialog */
+
+#shortcuts-help {
+  position: fixed;
+  left: 5%;
+  margin: 0 auto;
+  right: 5%;
+  z-index: 10;
+  top: 10%;
+  top: calc(5vw + 5vh);
+  padding: 30px 90px;
+  max-width: 500px;
+  outline: solid 10000px rgba(255, 255, 255, 0.6);
+  border-radius: 5px;
+  border-width: 1px 1px 0 1px;
+  background-color: #ddd;
+  display: none;
+}
+
+#shortcuts-help.active {
+  display: block;
+}
+
+#shortcuts-help ul {
+  padding: 0;
+}
+
+#shortcuts-help li {
+  display: flex;
+  justify-content: space-between;
+}
+
+#shortcuts-help code {
+  padding: 3px 10px;
+  border-radius: 3px;
+  border-width: 1px 1px 0 1px;
+  border-color: #bbb;
+  background-color: #eee;
+  box-shadow: inset 0 -1px 0 #ccc;
+}
+</style></head><body><div id="shortcuts-help">
+<ul>
+  <li><span>Toggle shortcuts help</span><code>?</code></li>
+  <li><span>Toggle "can call user code" annotations</span><code>u</code></li>
+
+  <li><span>Jump to search box</span><code>/</code></li>
+</ul></div><div id="menu-toggle"><svg xmlns="http://www.w3.org/2000/svg" style="width:100%; height:100%; stroke:currentColor" viewBox="0 0 120 120">
+      <title>Menu</title>
+      <path stroke-width="10" stroke-linecap="round" d="M30,60 h60  M30,30 m0,5 h60  M30,90 m0,-5 h60"></path>
+    </svg></div><div id="menu-spacer" class="menu-spacer"></div><div id="menu"><div id="menu-search"><input type="text" id="menu-search-box" placeholder="Search..."><div id="menu-search-results" class="inactive"></div></div><div id="menu-pins"><div class="menu-pane-header">Pins</div><ul id="menu-pins-list"></ul></div><div class="menu-pane-header">Table of Contents</div><div id="menu-toc"><ol class="toc"><li><span class="item-toggle">◢</span><a href="#pluralrules-objects" title="PluralRules Objects"><span class="secnum">1</span> PluralRules Objects</a><ol class="toc"><li><span class="item-toggle">◢</span><a href="#sec-intl-pluralrules-constructor" title="The Intl.PluralRules Constructor"><span class="secnum">1.1</span> The Intl.PluralRules Constructor</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-intl.pluralrules" title="Intl.PluralRules ( [ locales [ , options ] ] )"><span class="secnum">1.1.1</span> Intl.PluralRules ( [ <var>locales</var> [ , <var>options</var> ] ] )</a></li><li><span class="item-toggle-none"></span><a href="#sec-initializepluralrules" title="InitializePluralRules ( pluralRules, locales, options )"><span class="secnum">1.1.2</span> InitializePluralRules ( <var>pluralRules</var>, <var>locales</var>, <var>options</var> )</a></li></ol></li><li><span class="item-toggle">◢</span><a href="#sec-properties-of-intl-pluralrules-constructor" title="Properties of the Intl.PluralRules Constructor"><span class="secnum">1.2</span> Properties of the Intl.PluralRules Constructor</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-intl.pluralrules.prototype" title="Intl.PluralRules.prototype"><span class="secnum">1.2.1</span> Intl.PluralRules.prototype</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.pluralrules.supportedlocalesof" title="Intl.PluralRules.supportedLocalesOf ( locales [ , options ] )"><span class="secnum">1.2.2</span> Intl.PluralRules.supportedLocalesOf ( <var>locales</var> [ , <var>options</var> ] )</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.pluralrules-internal-slots" title="Internal slots"><span class="secnum">1.2.3</span> Internal slots</a></li></ol></li><li><span class="item-toggle">◢</span><a href="#sec-properties-of-intl-pluralrules-prototype-object" title="Properties of the Intl.PluralRules Prototype Object"><span class="secnum">1.3</span> Properties of the Intl.PluralRules Prototype Object</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-intl.pluralrules.prototype.constructor" title="Intl.PluralRules.prototype.constructor"><span class="secnum">1.3.1</span> Intl.PluralRules.prototype.constructor</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.pluralrules.prototype-tostringtag" title="Intl.PluralRules.prototype [ @@toStringTag ]"><span class="secnum">1.3.2</span> Intl.PluralRules.prototype [ @@toStringTag ]</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.pluralrules.prototype.select" title="Intl.PluralRules.prototype.select ( value )"><span class="secnum">1.3.3</span> Intl.PluralRules.prototype.select ( <var>value</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.pluralrules.prototype.selectrange" title="Intl.PluralRules.prototype.selectRange ( start, end )"><span class="secnum">1.3.4</span> Intl.PluralRules.prototype.selectRange ( <var>start</var>, <var>end</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.pluralrules.prototype.resolvedoptions" title="Intl.PluralRules.prototype.resolvedOptions ( )"><span class="secnum">1.3.5</span> Intl.PluralRules.prototype.resolvedOptions ( )</a></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-properties-of-intl-pluralrules-instances" title="Properties of Intl.PluralRules Instances"><span class="secnum">1.4</span> Properties of Intl.PluralRules Instances</a></li><li><span class="item-toggle">◢</span><a href="#sec-intl-pluralrules-abstracts" title="Abstract Operations for PluralRules Objects"><span class="secnum">1.5</span> Abstract Operations for PluralRules Objects</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-getoperands" title="GetOperands ( s )"><span class="secnum">1.5.1</span> GetOperands ( <var>s</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-pluralruleselect" title="PluralRuleSelect ( locale, type, n, operands )"><span class="secnum">1.5.2</span> PluralRuleSelect ( <var>locale</var>, <var>type</var>, <var>n</var>, <var>operands</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-resolveplural" title="ResolvePlural ( pluralRules, n )"><span class="secnum">1.5.3</span> ResolvePlural ( <var>pluralRules</var>, <var>n</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-pluralruleselectrange" title="PluralRuleSelectRange ( locale, type, xp, yp )"><span class="secnum">1.5.4</span> PluralRuleSelectRange ( <var>locale</var>, <var>type</var>, <var>xp</var>, <var>yp</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-resolvepluralrange" title="ResolvePluralRange ( pluralRules, x, y )"><span class="secnum">1.5.5</span> ResolvePluralRange ( <var>pluralRules</var>, <var>x</var>, <var>y</var> )</a></li></ol></li></ol></li></ol></div></div><div id="spec-container"><emu-clause id="pluralrules-objects">
+  <h1><span class="secnum">1</span> PluralRules Objects</h1>
 
   <emu-clause id="sec-intl-pluralrules-constructor">
     <h1><span class="secnum">1.1</span> The Intl.PluralRules Constructor</h1>
 
     <p>
-      The PluralRules <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> is the <dfn>%PluralRules%</dfn> intrinsic object and a standard built-in property of the Intl object. Behaviour common to all service <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> properties of the Intl object is specified in <emu-xref href="#sec-internal-slots"></emu-xref>.
+      The PluralRules constructor is the <dfn>%PluralRules%</dfn> intrinsic object and a standard built-in property of the Intl object. Behaviour common to all service constructor properties of the Intl object is specified in <emu-xref href="#sec-internal-slots"></emu-xref>.
     </p>
 
     <emu-clause id="sec-intl.pluralrules">
@@ -1880,7 +2632,7 @@ li.menu-search-result-term:before {
         When the <code>Intl.PluralRules</code> function is called with optional arguments <var>locales</var> and <var>options</var>, the following steps are taken:
       </p>
 
-      <emu-alg><ol><li>If NewTarget is <emu-val>undefined</emu-val>, throw a <emu-val>TypeError</emu-val> exception.</li><li>Let <var>pluralRules</var> be ?&nbsp;<emu-xref aoid="OrdinaryCreateFromConstructor" id="_ref_2"><a href="https://tc39.es/ecma262/#sec-ordinarycreatefromconstructor">OrdinaryCreateFromConstructor</a></emu-xref>(NewTarget, <emu-val>"%PluralRules.prototype%"</emu-val>, « [[InitializedPluralRules]], [[Locale]], [[Type]], [[MinimumIntegerDigits]], [[MinimumFractionDigits]], [[MaximumFractionDigits]], [[MinimumSignificantDigits]], [[MaximumSignificantDigits]], [[RoundingType]] »).</li><li>Return ?&nbsp;<emu-xref aoid="InitializePluralRules" id="_ref_3"><a href="#sec-initializepluralrules">InitializePluralRules</a></emu-xref>(<var>pluralRules</var>, <var>locales</var>, <var>options</var>).</li></ol></emu-alg>
+      <emu-alg><ol><li>If NewTarget is <emu-val>undefined</emu-val>, throw a <emu-val>TypeError</emu-val> exception.</li><li>Let <var>pluralRules</var> be ?&nbsp;OrdinaryCreateFromConstructor(NewTarget, <emu-val>"%PluralRules.prototype%"</emu-val>, « [[InitializedPluralRules]], [[Locale]], [[Type]], [[MinimumIntegerDigits]], [[MinimumFractionDigits]], [[MaximumFractionDigits]], [[MinimumSignificantDigits]], [[MaximumSignificantDigits]], [[RoundingType]], [[RoundingMode]], [[RoundingIncrement]], [[TrailingZeroDisplay]] »).</li><li>Return ?&nbsp;<emu-xref aoid="InitializePluralRules" id="_ref_2"><a href="#sec-initializepluralrules">InitializePluralRules</a></emu-xref>(<var>pluralRules</var>, <var>locales</var>, <var>options</var>).</li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-initializepluralrules" aoid="InitializePluralRules">
@@ -1890,7 +2642,7 @@ li.menu-search-result-term:before {
         The abstract operation InitializePluralRules accepts the arguments <var>pluralRules</var> (which must be an object), <var>locales</var>, and <var>options</var>. It initializes <var>pluralRules</var> as a PluralRules object. The following steps are taken:
       </p>
 
-      <emu-alg><ol><li>Let <var>requestedLocales</var> be ?&nbsp;CanonicalizeLocaleList(<var>locales</var>).</li><li>Set <var>options</var> to ?&nbsp;CoerceOptionsToObject(<var>options</var>).</li><li>Let <var>opt</var> be a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref>.</li><li>Let <var>matcher</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"localeMatcher"</emu-val>, <emu-const>string</emu-const>, « <emu-val>"lookup"</emu-val>, <emu-val>"best fit"</emu-val> », <emu-val>"best fit"</emu-val>).</li><li>Set <var>opt</var>.[[localeMatcher]] to <var>matcher</var>.</li><li>Let <var>t</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"type"</emu-val>, <emu-const>string</emu-const>, « <emu-val>"cardinal"</emu-val>, <emu-val>"ordinal"</emu-val> », <emu-val>"cardinal"</emu-val>).</li><li>Set <var>pluralRules</var>.[[Type]] to <var>t</var>.</li><li>Perform ?&nbsp;SetNumberFormatDigitOptions(<var>pluralRules</var>, <var>options</var>, <emu-val>+0</emu-val><sub>𝔽</sub>, <emu-val>3</emu-val><sub>𝔽</sub>, <emu-val>"standard"</emu-val>).</li><li>Let <var>localeData</var> be <emu-xref href="#sec-intl-pluralrules-constructor" id="_ref_4"><a href="#sec-intl-pluralrules-constructor">%PluralRules%</a></emu-xref>.[[LocaleData]].</li><li>Let <var>r</var> be ResolveLocale(<emu-xref href="#sec-intl-pluralrules-constructor" id="_ref_5"><a href="#sec-intl-pluralrules-constructor">%PluralRules%</a></emu-xref>.[[AvailableLocales]], <var>requestedLocales</var>, <var>opt</var>, <emu-xref href="#sec-intl-pluralrules-constructor" id="_ref_6"><a href="#sec-intl-pluralrules-constructor">%PluralRules%</a></emu-xref>.[[RelevantExtensionKeys]], <var>localeData</var>).</li><li>Set <var>pluralRules</var>.[[Locale]] to <var>r</var>.[[locale]].</li><li>Return <var>pluralRules</var>.</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>requestedLocales</var> be ?&nbsp;CanonicalizeLocaleList(<var>locales</var>).</li><li>Set <var>options</var> to ?&nbsp;CoerceOptionsToObject(<var>options</var>).</li><li>Let <var>opt</var> be a new Record.</li><li>Let <var>matcher</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"localeMatcher"</emu-val>, <emu-const>string</emu-const>, « <emu-val>"lookup"</emu-val>, <emu-val>"best fit"</emu-val> », <emu-val>"best fit"</emu-val>).</li><li>Set <var>opt</var>.[[localeMatcher]] to <var>matcher</var>.</li><li>Let <var>t</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"type"</emu-val>, <emu-const>string</emu-const>, « <emu-val>"cardinal"</emu-val>, <emu-val>"ordinal"</emu-val> », <emu-val>"cardinal"</emu-val>).</li><li>Set <var>pluralRules</var>.[[Type]] to <var>t</var>.</li><li>Perform ?&nbsp;SetNumberFormatDigitOptions(<var>pluralRules</var>, <var>options</var>, <emu-val>+0</emu-val><sub>𝔽</sub>, <emu-val>3</emu-val><sub>𝔽</sub>, <emu-val>"standard"</emu-val>).</li><li>Let <var>localeData</var> be <emu-xref href="#sec-intl-pluralrules-constructor" id="_ref_3"><a href="#sec-intl-pluralrules-constructor">%PluralRules%</a></emu-xref>.[[LocaleData]].</li><li>Let <var>r</var> be ResolveLocale(<emu-xref href="#sec-intl-pluralrules-constructor" id="_ref_4"><a href="#sec-intl-pluralrules-constructor">%PluralRules%</a></emu-xref>.[[AvailableLocales]], <var>requestedLocales</var>, <var>opt</var>, <emu-xref href="#sec-intl-pluralrules-constructor" id="_ref_5"><a href="#sec-intl-pluralrules-constructor">%PluralRules%</a></emu-xref>.[[RelevantExtensionKeys]], <var>localeData</var>).</li><li>Set <var>pluralRules</var>.[[Locale]] to <var>r</var>.[[locale]].</li><li>Return <var>pluralRules</var>.</li></ol></emu-alg>
     </emu-clause>
   </emu-clause>
 
@@ -1898,14 +2650,14 @@ li.menu-search-result-term:before {
     <h1><span class="secnum">1.2</span> Properties of the Intl.PluralRules Constructor</h1>
 
     <p>
-      The Intl.PluralRules <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> has the following properties:
+      The Intl.PluralRules constructor has the following properties:
     </p>
 
     <emu-clause id="sec-intl.pluralrules.prototype">
       <h1><span class="secnum">1.2.1</span> Intl.PluralRules.prototype</h1>
 
       <p>
-        The value of <code>Intl.PluralRules.prototype</code> is <emu-xref href="#sec-properties-of-intl-pluralrules-prototype-object" id="_ref_7"><a href="#sec-properties-of-intl-pluralrules-prototype-object">%PluralRules.prototype%</a></emu-xref>.
+        The value of <code>Intl.PluralRules.prototype</code> is <emu-xref href="#sec-properties-of-intl-pluralrules-prototype-object" id="_ref_6"><a href="#sec-properties-of-intl-pluralrules-prototype-object">%PluralRules.prototype%</a></emu-xref>.
       </p>
       <p>
         This property has the attributes { [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>false</emu-val> }.
@@ -1919,7 +2671,7 @@ li.menu-search-result-term:before {
         When the <code>supportedLocalesOf</code> method is called with arguments <var>locales</var> and <var>options</var>, the following steps are taken:
       </p>
 
-      <emu-alg><ol><li>Let <var>availableLocales</var> be <emu-xref href="#sec-intl-pluralrules-constructor" id="_ref_8"><a href="#sec-intl-pluralrules-constructor">%PluralRules%</a></emu-xref>.[[AvailableLocales]].</li><li>Let <var>requestedLocales</var> be ?&nbsp;CanonicalizeLocaleList(<var>locales</var>).</li><li>Return ?&nbsp;SupportedLocales(<var>availableLocales</var>, <var>requestedLocales</var>, <var>options</var>).</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>availableLocales</var> be <emu-xref href="#sec-intl-pluralrules-constructor" id="_ref_7"><a href="#sec-intl-pluralrules-constructor">%PluralRules%</a></emu-xref>.[[AvailableLocales]].</li><li>Let <var>requestedLocales</var> be ?&nbsp;CanonicalizeLocaleList(<var>locales</var>).</li><li>Return ?&nbsp;SupportedLocales(<var>availableLocales</var>, <var>requestedLocales</var>, <var>options</var>).</li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-intl.pluralrules-internal-slots">
@@ -1958,7 +2710,7 @@ li.menu-search-result-term:before {
       <h1><span class="secnum">1.3.1</span> Intl.PluralRules.prototype.constructor</h1>
 
       <p>
-        The initial value of <code>Intl.PluralRules.prototype.constructor</code> is <emu-xref href="#sec-intl-pluralrules-constructor" id="_ref_9"><a href="#sec-intl-pluralrules-constructor">%PluralRules%</a></emu-xref>.
+        The initial value of <code>Intl.PluralRules.prototype.constructor</code> is <emu-xref href="#sec-intl-pluralrules-constructor" id="_ref_8"><a href="#sec-intl-pluralrules-constructor">%PluralRules%</a></emu-xref>.
       </p>
     </emu-clause>
 
@@ -1980,7 +2732,7 @@ li.menu-search-result-term:before {
         When the <code>select</code> method is called with an argument <var>value</var>, the following steps are taken:
       </p>
 
-      <emu-alg><ol><li>Let <var>pr</var> be the <emu-val>this</emu-val> value.</li><li>Perform ?&nbsp;<emu-xref aoid="RequireInternalSlot" id="_ref_10"><a href="https://tc39.es/ecma262/#sec-requireinternalslot">RequireInternalSlot</a></emu-xref>(<var>pr</var>, [[InitializedPluralRules]]).</li><li>Let <var>n</var> be ?&nbsp;<emu-xref aoid="ToNumber" id="_ref_11"><a href="https://tc39.es/ecma262/#sec-tonumber">ToNumber</a></emu-xref>(<var>value</var>).</li><li>Return !&nbsp;<emu-xref aoid="ResolvePlural" id="_ref_12"><a href="#sec-resolveplural">ResolvePlural</a></emu-xref>(<var>pr</var>, <var>n</var>).</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>pr</var> be the <emu-val>this</emu-val> value.</li><li>Perform ?&nbsp;RequireInternalSlot(<var>pr</var>, [[InitializedPluralRules]]).</li><li>Let <var>n</var> be ?&nbsp;ToNumber(<var>value</var>).</li><li>Return !&nbsp;<emu-xref aoid="ResolvePlural" id="_ref_9"><a href="#sec-resolveplural">ResolvePlural</a></emu-xref>(<var>pr</var>, <var>n</var>).</li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-intl.pluralrules.prototype.selectrange">
@@ -1990,7 +2742,7 @@ li.menu-search-result-term:before {
         When the <code>selectRange</code> method is called with arguments <var>start</var> and <var>end</var>, the following steps are taken:
       </p>
 
-      <emu-alg><ol><li>Let <var>pr</var> be the <emu-val>this</emu-val> value.</li><li>Perform ?&nbsp;<emu-xref aoid="RequireInternalSlot" id="_ref_13"><a href="https://tc39.es/ecma262/#sec-requireinternalslot">RequireInternalSlot</a></emu-xref>(<var>pr</var>, [[InitializedPluralRules]]).</li><li>If <var>start</var> is <emu-val>undefined</emu-val> or <var>end</var> is <emu-val>undefined</emu-val>, throw a <emu-val>TypeError</emu-val> exception.</li><li>Let <var>x</var> be ?&nbsp;<emu-xref aoid="ToNumber" id="_ref_14"><a href="https://tc39.es/ecma262/#sec-tonumber">ToNumber</a></emu-xref>(<var>start</var>).</li><li>Let <var>y</var> be ?&nbsp;<emu-xref aoid="ToNumber" id="_ref_15"><a href="https://tc39.es/ecma262/#sec-tonumber">ToNumber</a></emu-xref>(<var>end</var>).</li><li>Return ?&nbsp;<emu-xref aoid="ResolvePluralRange" id="_ref_16"><a href="#sec-resolvepluralrange">ResolvePluralRange</a></emu-xref>(<var>pr</var>, <var>x</var>, <var>y</var>).</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>pr</var> be the <emu-val>this</emu-val> value.</li><li>Perform ?&nbsp;RequireInternalSlot(<var>pr</var>, [[InitializedPluralRules]]).</li><li>If <var>start</var> is <emu-val>undefined</emu-val> or <var>end</var> is <emu-val>undefined</emu-val>, throw a <emu-val>TypeError</emu-val> exception.</li><li>Let <var>x</var> be ?&nbsp;ToNumber(<var>start</var>).</li><li>Let <var>y</var> be ?&nbsp;ToNumber(<var>end</var>).</li><li>Return ?&nbsp;<emu-xref aoid="ResolvePluralRange" id="_ref_10"><a href="#sec-resolvepluralrange">ResolvePluralRange</a></emu-xref>(<var>pr</var>, <var>x</var>, <var>y</var>).</li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-intl.pluralrules.prototype.resolvedoptions">
@@ -2000,7 +2752,7 @@ li.menu-search-result-term:before {
         This function provides access to the locale and options computed during initialization of the object.
       </p>
 
-      <emu-alg><ol><li>Let <var>pr</var> be the <emu-val>this</emu-val> value.</li><li>Perform ?&nbsp;<emu-xref aoid="RequireInternalSlot" id="_ref_17"><a href="https://tc39.es/ecma262/#sec-requireinternalslot">RequireInternalSlot</a></emu-xref>(<var>pr</var>, [[InitializedPluralRules]]).</li><li>Let <var>options</var> be OrdinaryObjectCreate(%Object.prototype%).</li><li>For each row of <emu-xref href="#table-pluralrules-resolvedoptions-properties" id="_ref_0"><a href="#table-pluralrules-resolvedoptions-properties">Table 1</a></emu-xref>, except the header row, in table order, do<ol><li>Let <var>p</var> be the Property value of the current row.</li><li>Let <var>v</var> be the value of <var>pr</var>'s internal slot whose name is the Internal Slot value of the current row.</li><li>If <var>v</var> is not <emu-val>undefined</emu-val>, then<ol><li>Perform !&nbsp;<emu-xref aoid="CreateDataPropertyOrThrow" id="_ref_18"><a href="https://tc39.es/ecma262/#sec-createdatapropertyorthrow">CreateDataPropertyOrThrow</a></emu-xref>(<var>options</var>, <var>p</var>, <var>v</var>).</li></ol></li></ol></li><li>Let <var>pluralCategories</var> be a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> of Strings containing all possible results of <emu-xref href="#sec-pluralruleselect" id="_ref_1"><a href="#sec-pluralruleselect">PluralRuleSelect</a></emu-xref> for the selected locale <var>pr</var>.[[Locale]].</li><li>Perform !&nbsp;<emu-xref aoid="CreateDataProperty" id="_ref_19"><a href="https://tc39.es/ecma262/#sec-createdataproperty">CreateDataProperty</a></emu-xref>(<var>options</var>, <emu-val>"pluralCategories"</emu-val>, <emu-xref aoid="CreateArrayFromList" id="_ref_20"><a href="https://tc39.es/ecma262/#sec-createarrayfromlist">CreateArrayFromList</a></emu-xref>(<var>pluralCategories</var>)).</li><li>If <var>pr</var>.[[RoundingType]] is <emu-const>morePrecision</emu-const>, then<ol><li>Perform !&nbsp;<emu-xref aoid="CreateDataPropertyOrThrow" id="_ref_21"><a href="https://tc39.es/ecma262/#sec-createdatapropertyorthrow">CreateDataPropertyOrThrow</a></emu-xref>(<var>options</var>, <emu-val>"roundingPriority"</emu-val>, <emu-val>"morePrecision"</emu-val>).</li></ol></li><li>Else if <var>pr</var>.[[RoundingType]] is <emu-const>lessPrecision</emu-const>, then<ol><li>Perform !&nbsp;<emu-xref aoid="CreateDataPropertyOrThrow" id="_ref_22"><a href="https://tc39.es/ecma262/#sec-createdatapropertyorthrow">CreateDataPropertyOrThrow</a></emu-xref>(<var>options</var>, <emu-val>"roundingPriority"</emu-val>, <emu-val>"lessPrecision"</emu-val>).</li></ol></li><li>Else,<ol><li>Perform !&nbsp;<emu-xref aoid="CreateDataPropertyOrThrow" id="_ref_23"><a href="https://tc39.es/ecma262/#sec-createdatapropertyorthrow">CreateDataPropertyOrThrow</a></emu-xref>(<var>options</var>, <emu-val>"roundingPriority"</emu-val>, <emu-val>"auto"</emu-val>).</li></ol></li><li>Return <var>options</var>.</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>pr</var> be the <emu-val>this</emu-val> value.</li><li>Perform ?&nbsp;RequireInternalSlot(<var>pr</var>, [[InitializedPluralRules]]).</li><li>Let <var>options</var> be OrdinaryObjectCreate(%Object.prototype%).</li><li>For each row of <emu-xref href="#table-pluralrules-resolvedoptions-properties" id="_ref_0"><a href="#table-pluralrules-resolvedoptions-properties">Table 1</a></emu-xref>, except the header row, in table order, do<ol><li>Let <var>p</var> be the Property value of the current row.</li><li>Let <var>v</var> be the value of <var>pr</var>'s internal slot whose name is the Internal Slot value of the current row.</li><li>If <var>v</var> is not <emu-val>undefined</emu-val>, then<ol><li>Perform !&nbsp;CreateDataPropertyOrThrow(<var>options</var>, <var>p</var>, <var>v</var>).</li></ol></li></ol></li><li>Let <var>pluralCategories</var> be a List of Strings containing all possible results of <emu-xref href="#sec-pluralruleselect" id="_ref_1"><a href="#sec-pluralruleselect">PluralRuleSelect</a></emu-xref> for the selected locale <var>pr</var>.[[Locale]].</li><li>Perform !&nbsp;CreateDataProperty(<var>options</var>, <emu-val>"pluralCategories"</emu-val>, CreateArrayFromList(<var>pluralCategories</var>)).</li><li>If <var>pr</var>.[[RoundingType]] is <emu-const>morePrecision</emu-const>, then<ol><li>Perform !&nbsp;CreateDataPropertyOrThrow(<var>options</var>, <emu-val>"roundingPriority"</emu-val>, <emu-val>"morePrecision"</emu-val>).</li></ol></li><li>Else if <var>pr</var>.[[RoundingType]] is <emu-const>lessPrecision</emu-const>, then<ol><li>Perform !&nbsp;CreateDataPropertyOrThrow(<var>options</var>, <emu-val>"roundingPriority"</emu-val>, <emu-val>"lessPrecision"</emu-val>).</li></ol></li><li>Else,<ol><li>Perform !&nbsp;CreateDataPropertyOrThrow(<var>options</var>, <emu-val>"roundingPriority"</emu-val>, <emu-val>"auto"</emu-val>).</li></ol></li><li>Return <var>options</var>.</li></ol></emu-alg>
 
       <emu-table id="table-pluralrules-resolvedoptions-properties"><figure><figcaption>Table 1: Resolved Options of PluralRules Instances</figcaption>
         
@@ -2039,6 +2791,18 @@ li.menu-search-result-term:before {
             <td>[[MaximumSignificantDigits]]</td>
             <td><emu-val>"maximumSignificantDigits"</emu-val></td>
           </tr>
+          <tr>
+            <td>[[RoundingMode]]</td>
+            <td><emu-val>"roundingMode"</emu-val></td>
+          </tr>
+          <tr>
+            <td>[[RoundingIncrement]]</td>
+            <td><emu-val>"roundingIncrement"</emu-val></td>
+          </tr>
+          <tr>
+            <td>[[TrailingZeroDisplay]]</td>
+            <td><emu-val>"trailingZeroDisplay"</emu-val></td>
+          </tr>
         </tbody></table>
       </figure></emu-table>
     </emu-clause>
@@ -2048,7 +2812,7 @@ li.menu-search-result-term:before {
     <h1><span class="secnum">1.4</span> Properties of Intl.PluralRules Instances</h1>
 
     <p>
-      Intl.PluralRules instances are ordinary objects that inherit properties from <emu-xref href="#sec-properties-of-intl-pluralrules-prototype-object" id="_ref_24"><a href="#sec-properties-of-intl-pluralrules-prototype-object">%PluralRules.prototype%</a></emu-xref>.
+      Intl.PluralRules instances are ordinary objects that inherit properties from <emu-xref href="#sec-properties-of-intl-pluralrules-prototype-object" id="_ref_11"><a href="#sec-properties-of-intl-pluralrules-prototype-object">%PluralRules.prototype%</a></emu-xref>.
     </p>
 
     <p>
@@ -2056,35 +2820,31 @@ li.menu-search-result-term:before {
     </p>
 
     <p>
-      Intl.PluralRules instances also have several internal slots that are computed by the <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref>:
+      Intl.PluralRules instances also have several internal slots that are computed by the constructor:
     </p>
 
     <ul>
       <li>[[Locale]] is a String value with the language tag of the locale whose localization is used by the plural rules.</li>
       <li>[[Type]] is one of the String values <emu-val>"cardinal"</emu-val> or <emu-val>"ordinal"</emu-val>, identifying the plural rules used.</li>
-      <li>[[MinimumIntegerDigits]] is a non-negative <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref> <emu-xref href="#number-value"><a href="https://tc39.es/ecma262/#number-value">Number value</a></emu-xref> indicating the minimum <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref> digits to be used.</li>
-      <li>[[MinimumFractionDigits]] and [[MaximumFractionDigits]] are non-negative <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref> Number values indicating the minimum and maximum fraction digits to be used. Numbers will be rounded or padded with trailing zeroes if necessary.</li>
-      <li>[[MinimumSignificantDigits]] and [[MaximumSignificantDigits]] are positive <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref> Number values indicating the minimum and maximum fraction digits to be used. Either none or both of these properties are present; if they are, they override minimum and maximum <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref> and fraction digits.</li>
+      <li>[[MinimumIntegerDigits]] is a non-negative integer Number value indicating the minimum integer digits to be used.</li>
+      <li>[[MinimumFractionDigits]] and [[MaximumFractionDigits]] are non-negative integer Number values indicating the minimum and maximum fraction digits to be used. Numbers will be rounded or padded with trailing zeroes if necessary.</li>
+      <li>[[MinimumSignificantDigits]] and [[MaximumSignificantDigits]] are positive integer Number values indicating the minimum and maximum fraction digits to be used. Either none or both of these properties are present; if they are, they override minimum and maximum integer and fraction digits.</li>
       <li>[[RoundingType]] is one of the values <emu-const>fractionDigits</emu-const>, <emu-const>significantDigits</emu-const>, <emu-const>morePrecision</emu-const>, or <emu-const>lessPrecision</emu-const>, indicating which rounding strategy to use, as discussed in <emu-xref href="#sec-properties-of-intl-numberformat-instances"></emu-xref>.</li>
+      <li>[[RoundingMode]] is one of the String values in the Identifier column of <emu-xref href="#table-intl-rounding-modes"></emu-xref>, specifying which rounding mode to use.</li>
+      <li>[[RoundingIncrement]] is an integer-valued Number that evenly divides 10, 100, 1000, or 10000 into tenths, fifths, quarters, or halves. It indicates the increment at which rounding should take place relative to the calculated rounding magnitude. For example, if [[MaximumFractionDigits]] is 2 and [[RoundingIncrement]] is 5, then the number is rounded to the nearest 0.05 ("nickel rounding").</li>
+      <li>[[TrailingZeroDisplay]] is one of the String values <emu-val>"auto"</emu-val> or <emu-val>"stripIfInteger"</emu-val>, indicating whether to strip trailing zeros if the formatted number is an integer (i.e., has no nonzero fraction digit).</li>
     </ul>
   </emu-clause>
 
   <emu-clause id="sec-intl-pluralrules-abstracts">
     <h1><span class="secnum">1.5</span> Abstract Operations for PluralRules Objects</h1>
 
-    <emu-clause id="sec-getoperands" type="abstract operation">
-       <h1><span class="secnum">1.5.1</span> 
-         GetOperands (
-           <var>s</var>: a decimal String,
-         )
-       </h1>
-       <dl class="header">
-        <dt>description</dt>
-        <dd>It extracts numeric features from <var>s</var> that correspond with the operands of <a href="https://unicode.org/reports/tr35/tr35-numbers.html#Operands">Unicode Technical Standard #35 Part 3 Numbers, Section 5.1.1 Operands</a>.</dd>
-       </dl>
-       <emu-alg><ol><li>Let <var>n</var> be !&nbsp;<emu-xref aoid="ToNumber" id="_ref_25"><a href="https://tc39.es/ecma262/#sec-tonumber">ToNumber</a></emu-xref>(<var>s</var>).</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>n</var> is finite.</li><li>Let <var>dp</var> be StringIndexOf(<var>s</var>, <emu-val>"."</emu-val>, 0).</li><li>If <var>dp</var> = -1, then<ol><li>Let <var>intPart</var> be <var>n</var>.</li><li>Let <var>fracSlice</var> be <emu-val>""</emu-val>.</li></ol></li><li>Else,<ol><li>Let <var>intPart</var> be the substring of <var>s</var> from 0 to <var>dp</var>.</li><li>Let <var>fracSlice</var> be the substring of <var>s</var> from <var>dp</var> + 1.</li></ol></li><li>Let <var>i</var> be <emu-xref aoid="abs"><a href="https://tc39.es/ecma262/#eqn-abs">abs</a></emu-xref>(! <emu-xref aoid="ToNumber" id="_ref_26"><a href="https://tc39.es/ecma262/#sec-tonumber">ToNumber</a></emu-xref>(<var>intPart</var>)).</li><li>Let <var>fracDigitCount</var> be the length of <var>fracSlice</var>.</li><li>Let <var>f</var> be !&nbsp;<emu-xref aoid="ToNumber" id="_ref_27"><a href="https://tc39.es/ecma262/#sec-tonumber">ToNumber</a></emu-xref>(<var>fracSlice</var>).</li><li>Let <var>significantFracSlice</var> be the value of <var>fracSlice</var> stripped of trailing <emu-val>"0"</emu-val>.</li><li>Let <var>significantFracDigitCount</var> be the length of <var>significantFracSlice</var>.</li><li>Let <var>significantFrac</var> be !&nbsp;<emu-xref aoid="ToNumber" id="_ref_28"><a href="https://tc39.es/ecma262/#sec-tonumber">ToNumber</a></emu-xref>(<var>significantFracSlice</var>).</li><li>Return a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Number]]: <emu-xref aoid="abs"><a href="https://tc39.es/ecma262/#eqn-abs">abs</a></emu-xref>(<var>n</var>), [[IntegerDigits]]: <var>i</var>, [[FractionDigits]]: <var>f</var>, [[NumberOfFractionDigits]]: <var>fracDigitCount</var>, [[FractionDigitsWithoutTrailing]]: <var>significantFrac</var>, [[NumberOfFractionDigitsWithoutTrailing]]: <var>significantFracDigitCount</var> }.</li></ol></emu-alg>
+    <emu-clause id="sec-getoperands" type="abstract operation" aoid="GetOperands">
+       <h1><span class="secnum">1.5.1</span> GetOperands ( <var>s</var> )</h1>
+       <p>The abstract operation GetOperands takes argument <var>s</var> (a decimal String). It extracts numeric features from <var>s</var> that correspond with the operands of <a href="https://unicode.org/reports/tr35/tr35-numbers.html#Operands">Unicode Technical Standard #35 Part 3 Numbers, Section 5.1.1 Operands</a>. It performs the following steps when called:</p>
+       <emu-alg><ol><li>Let <var>n</var> be !&nbsp;ToNumber(<var>s</var>).</li><li>Assert: <var>n</var> is finite.</li><li>Let <var>dp</var> be StringIndexOf(<var>s</var>, <emu-val>"."</emu-val>, 0).</li><li>If <var>dp</var> = -1, then<ol><li>Let <var>intPart</var> be <var>n</var>.</li><li>Let <var>fracSlice</var> be <emu-val>""</emu-val>.</li></ol></li><li>Else,<ol><li>Let <var>intPart</var> be the substring of <var>s</var> from 0 to <var>dp</var>.</li><li>Let <var>fracSlice</var> be the substring of <var>s</var> from <var>dp</var> + 1.</li></ol></li><li>Let <var>i</var> be abs(! ToNumber(<var>intPart</var>)).</li><li>Let <var>fracDigitCount</var> be the length of <var>fracSlice</var>.</li><li>Let <var>f</var> be !&nbsp;ToNumber(<var>fracSlice</var>).</li><li>Let <var>significantFracSlice</var> be the value of <var>fracSlice</var> stripped of trailing <emu-val>"0"</emu-val>.</li><li>Let <var>significantFracDigitCount</var> be the length of <var>significantFracSlice</var>.</li><li>Let <var>significantFrac</var> be !&nbsp;ToNumber(<var>significantFracSlice</var>).</li><li>Return a new Record { [[Number]]: abs(<var>n</var>), [[IntegerDigits]]: <var>i</var>, [[FractionDigits]]: <var>f</var>, [[NumberOfFractionDigits]]: <var>fracDigitCount</var>, [[FractionDigitsWithoutTrailing]]: <var>significantFrac</var>, [[NumberOfFractionDigitsWithoutTrailing]]: <var>significantFracDigitCount</var> }.</li></ol></emu-alg>
 
-       <emu-table id="table-plural-operands"><figure><figcaption>Table 2: Plural Rules Operands <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> Fields</figcaption>
+       <emu-table id="table-plural-operands"><figure><figcaption>Table 2: Plural Rules Operands Record Fields</figcaption>
          
          <table class="real-table">
            <thead>
@@ -2105,13 +2865,13 @@ li.menu-search-result-term:before {
              <td>[[IntegerDigits]]</td>
              <td>Number</td>
              <td>i</td>
-             <td><emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">Integer</a></emu-xref> part of [[Number]].</td>
+             <td>Integer part of [[Number]].</td>
            </tr>
            <tr>
              <td>[[FractionDigits]]</td>
              <td>Number</td>
              <td>f</td>
-             <td>Visible fraction digits in [[Number]], <em>with</em> trailing zeroes, as an <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref> having [[NumberOfFractionDigits]] digits.</td>
+             <td>Visible fraction digits in [[Number]], <em>with</em> trailing zeroes, as an integer having [[NumberOfFractionDigits]] digits.</td>
            </tr>
            <tr>
              <td>[[NumberOfFractionDigits]]</td>
@@ -2123,7 +2883,7 @@ li.menu-search-result-term:before {
              <td>[[FractionDigitsWithoutTrailing]]</td>
              <td>Number</td>
              <td>t</td>
-             <td>Visible fraction digits in [[Number]], <em>without</em> trailing zeroes, as an <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref> having [[NumberOfFractionDigitsWithoutTrailing]] digits.</td>
+             <td>Visible fraction digits in [[Number]], <em>without</em> trailing zeroes, as an integer having [[NumberOfFractionDigitsWithoutTrailing]] digits.</td>
            </tr>
            <tr>
              <td>[[NumberOfFractionDigitsWithoutTrailing]]</td>
@@ -2135,28 +2895,18 @@ li.menu-search-result-term:before {
        </figure></emu-table>
     </emu-clause>
 
-    <emu-clause id="sec-pluralruleselect" type="implementation-defined abstract operation">
-      <h1><span class="secnum">1.5.2</span> 
-        PluralRuleSelect (
-          <var>locale</var>: a String,
-          <var>type</var>: a String,
-          <var>n</var>: a finite Number,
-          <var>operands</var>: a Plural Rules Operands Record derived from formatting <var>n</var>,
-        )
-      </h1>
-      <dl class="header">
-        <dt>description</dt>
-        <dd>It returns the String from « <emu-val>"zero"</emu-val>, <emu-val>"one"</emu-val>, <emu-val>"two"</emu-val>, <emu-val>"few"</emu-val>, <emu-val>"many"</emu-val>, <emu-val>"other"</emu-val> » that best categorizes the <var>operands</var> representation of <var>n</var> according to the rules for <var>locale</var> and <var>type</var>.</dd>
-      </dl>
+    <emu-clause id="sec-pluralruleselect" type="implementation-defined abstract operation" aoid="PluralRuleSelect">
+      <h1><span class="secnum">1.5.2</span> PluralRuleSelect ( <var>locale</var>, <var>type</var>, <var>n</var>, <var>operands</var> )</h1>
+      <p>The implementation-defined abstract operation PluralRuleSelect takes arguments <var>locale</var> (a String), <var>type</var> (a String), <var>n</var> (a finite Number), and <var>operands</var> (a Plural Rules Operands Record derived from formatting <var>n</var>). It returns the String from « <emu-val>"zero"</emu-val>, <emu-val>"one"</emu-val>, <emu-val>"two"</emu-val>, <emu-val>"few"</emu-val>, <emu-val>"many"</emu-val>, <emu-val>"other"</emu-val> » that best categorizes the <var>operands</var> representation of <var>n</var> according to the rules for <var>locale</var> and <var>type</var>.</p>
     </emu-clause>
 
     <emu-clause id="sec-resolveplural" aoid="ResolvePlural">
       <h1><span class="secnum">1.5.3</span> ResolvePlural ( <var>pluralRules</var>, <var>n</var> )</h1>
       <p>
-        When the ResolvePlural abstract operation is called with arguments <var>pluralRules</var> (which must be an object initialized as a PluralRules) and <var>n</var> (which must be a <emu-xref href="#number-value"><a href="https://tc39.es/ecma262/#number-value">Number value</a></emu-xref>), it returns a String value representing the plural form of <var>n</var> according to the effective locale and the options of <var>pluralRules</var>. The following steps are taken:
+        When the ResolvePlural abstract operation is called with arguments <var>pluralRules</var> (which must be an object initialized as a PluralRules) and <var>n</var> (which must be a Number value), it returns a String value representing the plural form of <var>n</var> according to the effective locale and the options of <var>pluralRules</var>. The following steps are taken:
       </p>
 
-      <emu-alg><ol><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <emu-xref aoid="Type" id="_ref_29"><a href="https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>pluralRules</var>) is Object.</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>pluralRules</var> has an [[InitializedPluralRules]] internal slot.</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <emu-xref aoid="Type" id="_ref_30"><a href="https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>n</var>) is Number.</li><li>If <var>n</var> is not a finite Number, then<ol><li>Return <emu-val>"other"</emu-val>.</li></ol></li><li>Let <var>locale</var> be <var>pluralRules</var>.[[Locale]].</li><li>Let <var>type</var> be <var>pluralRules</var>.[[Type]].</li><li>Let <var>res</var> be !&nbsp;FormatNumericToString(<var>pluralRules</var>, <var>n</var>).</li><li>Let <var>s</var> be <var>res</var>.[[FormattedString]].</li><li>Let <var>operands</var> be !&nbsp;GetOperands(<var>s</var>).</li><li>Return !&nbsp;PluralRuleSelect(<var>locale</var>, <var>type</var>, <var>n</var>, <var>operands</var>).</li></ol></emu-alg>
+      <emu-alg><ol><li>Assert: Type(<var>pluralRules</var>) is Object.</li><li>Assert: <var>pluralRules</var> has an [[InitializedPluralRules]] internal slot.</li><li>Assert: Type(<var>n</var>) is Number.</li><li>If <var>n</var> is not a finite Number, then<ol><li>Return <emu-val>"other"</emu-val>.</li></ol></li><li>Let <var>locale</var> be <var>pluralRules</var>.[[Locale]].</li><li>Let <var>type</var> be <var>pluralRules</var>.[[Type]].</li><li>Let <var>res</var> be !&nbsp;FormatNumericToString(<var>pluralRules</var>, <var>n</var>).</li><li>Let <var>s</var> be <var>res</var>.[[FormattedString]].</li><li>Let <var>operands</var> be !&nbsp;<emu-xref aoid="GetOperands" id="_ref_12"><a href="#sec-getoperands">GetOperands</a></emu-xref>(<var>s</var>).</li><li>Return !&nbsp;<emu-xref aoid="PluralRuleSelect" id="_ref_13"><a href="#sec-pluralruleselect">PluralRuleSelect</a></emu-xref>(<var>locale</var>, <var>type</var>, <var>n</var>, <var>operands</var>).</li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-pluralruleselectrange" aoid="PluralRuleSelectRange">
@@ -2170,10 +2920,10 @@ li.menu-search-result-term:before {
     <emu-clause id="sec-resolvepluralrange" aoid="ResolvePluralRange">
       <h1><span class="secnum">1.5.5</span> ResolvePluralRange ( <var>pluralRules</var>, <var>x</var>, <var>y</var> )</h1>
       <p>
-        When the ResolvePluralRange abstract operation is called with arguments <var>pluralRules</var> (which must be an object initialized as a PluralRules), <var>x</var> (which must be a <emu-xref href="#number-value"><a href="https://tc39.es/ecma262/#number-value">Number value</a></emu-xref>), and <var>y</var> (which must be a <emu-xref href="#number-value"><a href="https://tc39.es/ecma262/#number-value">Number value</a></emu-xref>), it returns a String value representing the plural form of the range starting from <var>x</var> and ending at <var>y</var> according to the effective locale and the options of <var>pluralRules</var>. The following steps are taken:
+        When the ResolvePluralRange abstract operation is called with arguments <var>pluralRules</var> (which must be an object initialized as a PluralRules), <var>x</var> (which must be a Number value), and <var>y</var> (which must be a Number value), it returns a String value representing the plural form of the range starting from <var>x</var> and ending at <var>y</var> according to the effective locale and the options of <var>pluralRules</var>. The following steps are taken:
       </p>
 
-      <emu-alg><ol><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <emu-xref aoid="Type" id="_ref_31"><a href="https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>pluralRules</var>) is Object.</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>pluralRules</var> has an [[InitializedPluralRules]] internal slot.</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <emu-xref aoid="Type" id="_ref_32"><a href="https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>x</var>) is Number.</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <emu-xref aoid="Type" id="_ref_33"><a href="https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>y</var>) is Number.</li><li>If <var>x</var> is <emu-val>NaN</emu-val> or <var>y</var> is <emu-val>NaN</emu-val>, throw a <emu-val>RangeError</emu-val> exception.</li><li>Let <var>xp</var> be !&nbsp;<emu-xref aoid="ResolvePlural" id="_ref_34"><a href="#sec-resolveplural">ResolvePlural</a></emu-xref>(<var>pluralRules</var>, <var>x</var>).</li><li>Let <var>yp</var> be !&nbsp;<emu-xref aoid="ResolvePlural" id="_ref_35"><a href="#sec-resolveplural">ResolvePlural</a></emu-xref>(<var>pluralRules</var>, <var>y</var>).</li><li>Let <var>locale</var> be <var>pluralRules</var>.[[Locale]].</li><li>Let <var>type</var> be <var>pluralRules</var>.[[Type]].</li><li>Return !&nbsp;<emu-xref aoid="PluralRuleSelectRange" id="_ref_36"><a href="#sec-pluralruleselectrange">PluralRuleSelectRange</a></emu-xref>(<var>locale</var>, <var>type</var>, <var>xp</var>, <var>yp</var>).</li></ol></emu-alg>
+      <emu-alg><ol><li>Assert: Type(<var>pluralRules</var>) is Object.</li><li>Assert: <var>pluralRules</var> has an [[InitializedPluralRules]] internal slot.</li><li>Assert: Type(<var>x</var>) is Number.</li><li>Assert: Type(<var>y</var>) is Number.</li><li>If <var>x</var> is <emu-val>NaN</emu-val> or <var>y</var> is <emu-val>NaN</emu-val>, throw a <emu-val>RangeError</emu-val> exception.</li><li>Let <var>xp</var> be !&nbsp;<emu-xref aoid="ResolvePlural" id="_ref_14"><a href="#sec-resolveplural">ResolvePlural</a></emu-xref>(<var>pluralRules</var>, <var>x</var>).</li><li>Let <var>yp</var> be !&nbsp;<emu-xref aoid="ResolvePlural" id="_ref_15"><a href="#sec-resolveplural">ResolvePlural</a></emu-xref>(<var>pluralRules</var>, <var>y</var>).</li><li>Let <var>locale</var> be <var>pluralRules</var>.[[Locale]].</li><li>Let <var>type</var> be <var>pluralRules</var>.[[Type]].</li><li>Return !&nbsp;<emu-xref aoid="PluralRuleSelectRange" id="_ref_16"><a href="#sec-pluralruleselectrange">PluralRuleSelectRange</a></emu-xref>(<var>locale</var>, <var>type</var>, <var>xp</var>, <var>yp</var>).</li></ol></emu-alg>
     </emu-clause>
   </emu-clause>
 </emu-clause>

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "ecmarkup": "^3.11.5",
-    "marked": "^1.1.0"
+    "ecmarkup": "^16.0.0",
+    "marked": "^1.1.0",
+    "mkdirp": "^2.1.3"
   }
 }


### PR DESCRIPTION
This also updates `ecmarkup` because otherwise some spec text does not render correctly, like so:
![Screenshot from 2023-01-30 10-10-52](https://user-images.githubusercontent.com/5600524/215533088-23f8b713-e33a-433a-929d-589e16247cd2.png)

With the updated package, we instead get:
![Screenshot from 2023-01-30 10-20-08](https://user-images.githubusercontent.com/5600524/215533199-6dd3e0b5-8088-4112-995f-76493020e8f7.png)

